### PR TITLE
Add N3FJP logged QSO overlay and ingest API

### DIFF
--- a/server.js
+++ b/server.js
@@ -68,6 +68,53 @@ const HOST = process.env.HOST || '0.0.0.0';
 // CONFIGURATION FROM ENVIRONMENT
 // ============================================
 
+function maidenheadToLatLon(grid) {
+  if (!grid) return null;
+  const g = String(grid).trim();
+  if (g.length < 4) return null;
+
+  const A = 'A'.charCodeAt(0);
+  const a = 'a'.charCodeAt(0);
+
+  const c0 = g.charCodeAt(0);
+  const c1 = g.charCodeAt(1);
+  const c2 = g.charCodeAt(2);
+  const c3 = g.charCodeAt(3);
+
+  // Field (A-R)
+  const lonField = (c0 >= a ? c0 - a : c0 - A);
+  const latField = (c1 >= a ? c1 - a : c1 - A);
+
+  // Square (0-9)
+  const lonSquare = parseInt(g[2], 10);
+  const latSquare = parseInt(g[3], 10);
+  if (!Number.isFinite(lonSquare) || !Number.isFinite(latSquare)) return null;
+
+  // Start at SW corner of the 4-char square
+  let lon = -180 + lonField * 20 + lonSquare * 2;
+  let lat =  -90 + latField * 10 + latSquare * 1;
+
+  // Subsquare (a-x), optional
+  if (g.length >= 6) {
+    const s0 = g.charCodeAt(4);
+    const s1 = g.charCodeAt(5);
+    const lonSub = (s0 >= a ? s0 - a : s0 - A);
+    const latSub = (s1 >= a ? s1 - a : s1 - A);
+    // each subsquare: 5' lon = 1/12 deg, 2.5' lat = 1/24 deg
+    lon += lonSub * (1/12);
+    lat += latSub * (1/24);
+    // center of subsquare
+    lon += (1/12) / 2;
+    lat += (1/24) / 2;
+  } else {
+    // center of 4-char square: 1 deg lon, 0.5 deg lat
+    lon += 1.0;
+    lat += 0.5;
+  }
+
+  return { lat, lon };
+}
+
 // Convert Maidenhead grid locator to lat/lon
 function gridToLatLon(grid) {
   if (!grid || grid.length < 4) return null;
@@ -5798,6 +5845,107 @@ function handleWSJTXMessage(msg, state) {
     }
   }
 }
+
+// ---- N3FJP Logged QSO relay (in-memory) ----
+const N3FJP_QSO_RETENTION_MINUTES = parseInt(process.env.N3FJP_QSO_RETENTION_MINUTES || "15", 10);
+let n3fjpQsos = [];
+
+function pruneN3fjpQsos() {
+  const cutoff = Date.now() - (N3FJP_QSO_RETENTION_MINUTES * 60 * 1000);
+  n3fjpQsos = n3fjpQsos.filter(q => {
+    const t = Date.parse(q.ts_utc || q.ts || "");
+    return !Number.isNaN(t) && t >= cutoff;
+  });
+}
+
+// Simple in-memory cache so we don't hammer callsign lookup on every QSO
+const n3fjpCallCache = new Map(); // key=callsign, val={ts, result}
+const N3FJP_CALL_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+async function lookupCallLatLon(callsign) {
+  const call = (callsign || "").toUpperCase().trim();
+  if (!call) return null;
+
+  const cached = n3fjpCallCache.get(call);
+  if (cached && (Date.now() - cached.ts) < N3FJP_CALL_CACHE_TTL_MS) {
+    return cached.result;
+  }
+
+  try {
+    // Reuse your existing endpoint (keeps all HamQTH/grid logic in one place)
+    const resp = await fetch(`http://localhost:${PORT}/api/callsign/${encodeURIComponent(call)}`);
+    if (!resp.ok) return null;
+
+    const data = await resp.json();
+    if (typeof data.lat === "number" && typeof data.lon === "number") {
+      n3fjpCallCache.set(call, { ts: Date.now(), result: data });
+      return data;
+    }
+  } catch (e) {
+    // swallow: mapping should never crash the server
+  }
+  return null;
+}
+
+// POST one QSO from a bridge (your Python script)
+app.post("/api/n3fjp/qso", async (req, res) => {
+  const qso = req.body || {};
+  if (!qso.dx_call) return res.status(400).json({ ok: false, error: "dx_call required" });
+
+  if (!qso.ts_utc) qso.ts_utc = new Date().toISOString();
+  if (!qso.source) qso.source = "n3fjp_to_timemapper_udp";
+
+  // Always ACK immediately so the bridge never times out
+  res.json({ ok: true });
+
+  // Do enrichment + storage after ACK
+  setImmediate(async () => {
+    try {
+      //
+      // Enrich DX location: GRID → (preferred) → HamQTH fallback
+      //
+      let locSource = "";
+
+      // 1) Prefer exact operating grid (N3FJP “Grid Rec” field)
+      if (qso.dx_grid) {
+        const loc = maidenheadToLatLon(qso.dx_grid);
+        if (loc) {
+          qso.lat = loc.lat;
+          qso.lon = loc.lon;
+          qso.loc_source = "grid";
+          locSource = "grid";
+        }
+      }
+
+      // 2) If no grid provided, fall back to HamQTH/home QTH lookup
+      if (!locSource) {
+        const dx = await lookupCallLatLon(qso.dx_call);
+        if (dx) {
+          qso.lat = dx.lat;
+          qso.lon = dx.lon;
+          qso.dx_country = dx.country || "";
+          qso.dx_cqZone = dx.cqZone || "";
+          qso.dx_ituZone = dx.ituZone || "";
+          qso.loc_source = "hamqth";
+        }
+      }
+
+      n3fjpQsos.unshift(qso);
+      pruneN3fjpQsos();
+
+      // cap memory
+      if (n3fjpQsos.length > 200) n3fjpQsos.length = 200;
+    } catch (e) {
+      console.error("[/api/n3fjp/qso] post-ack processing failed:", e);
+    }
+  });
+});
+
+// GET recent QSOs (pruned to retention window)
+app.get("/api/n3fjp/qsos", (req, res) => {
+  pruneN3fjpQsos();
+  res.json({ ok: true, retention_minutes: N3FJP_QSO_RETENTION_MINUTES, qsos: n3fjpQsos });
+});
 
 // Start UDP listener
 let wsjtxSocket = null;

--- a/src/plugins/layerRegistry.js
+++ b/src/plugins/layerRegistry.js
@@ -1,6 +1,8 @@
 /**
  * Layer Plugin Registry
  */
+
+import * as N3FJPLoggedQSOsPlugin from './layers/useN3FJPLoggedQSOs.js';
 import * as WXRadarPlugin from './layers/useWXRadar.js';
 import * as EarthquakesPlugin from './layers/useEarthquakes.js';
 import * as AuroraPlugin from './layers/useAurora.js';
@@ -19,9 +21,11 @@ const layerPlugins = [
   LightningPlugin,
   RBNPlugin,
   ContestQsosPlugin,
+  N3FJPLoggedQSOsPlugin,
 ];
 
 export function getAllLayers() {
+  console.log("Loaded layer plugins:", layerPlugins.map(p => p?.metadata?.id));
   return layerPlugins
     .filter(plugin => plugin.metadata && plugin.useLayer)
     .map(plugin => ({

--- a/src/plugins/layers/useN3FJPLoggedQSOs.js
+++ b/src/plugins/layers/useN3FJPLoggedQSOs.js
@@ -1,0 +1,283 @@
+import { useEffect, useState, useRef } from 'react';
+
+export const metadata = {
+  id: 'n3fjp_logged_qsos',
+  name: 'Logged QSOs (N3FJP)',
+  description: 'Shows recently logged QSOs sent from the N3FJP bridge.',
+  icon: '🗺️',
+  category: 'overlay',
+  defaultEnabled: false,
+  defaultOpacity: 0.9,
+  version: '0.2.0'
+};
+
+const POLL_MS = 2000;
+
+  // --- User settings (persisted) ---
+const STORAGE_MINUTES_KEY = 'n3fjp_display_minutes';
+const STORAGE_COLOR_KEY = 'n3fjp_line_color';
+
+export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
+  const [layersRef, setLayersRef] = useState([]);
+  const [qsos, setQsos] = useState([]);
+  const [retentionMinutes, setRetentionMinutes] = useState(15);
+
+  const lastOpenDxCallRef = useRef(null);
+  const suppressReopenRef = useRef(false);
+
+  const [displayMinutes, setDisplayMinutes] = useState(() => {
+    const v = parseInt(localStorage.getItem(STORAGE_MINUTES_KEY) || '15', 10);
+    return Number.isFinite(v) ? v : 15;
+  });
+
+  const [lineColor, setLineColor] = useState(() => {
+    return localStorage.getItem(STORAGE_COLOR_KEY) || '#3388ff'; // Leaflet default blue-ish
+  });
+
+  // Poll the server for QSOs
+  useEffect(() => {
+    if (!enabled) return;
+
+    let alive = true;
+
+    const fetchQsos = async () => {
+      try {
+        const resp = await fetch('/api/n3fjp/qsos');
+        if (!resp.ok) return;
+        const data = await resp.json();
+
+        if (!alive) return;
+        setRetentionMinutes(Number(data?.retention_minutes || 15));
+        setQsos(Array.isArray(data?.qsos) ? data.qsos : []);
+      } catch {
+        // silent
+      }
+    };
+
+    fetchQsos();
+    const interval = setInterval(fetchQsos, POLL_MS);
+
+    return () => {
+      alive = false;
+      clearInterval(interval);
+    };
+  }, [enabled]);
+
+  // Add a small on-map control for display window + line color
+  useEffect(() => {
+    if (!enabled || !map || typeof L === 'undefined') return;
+
+    const control = L.control({ position: 'topright' });
+
+    control.onAdd = () => {
+      const div = L.DomUtil.create('div', 'n3fjp-layer-control');
+      div.style.background = 'rgba(0,0,0,0.65)';
+      div.style.color = 'white';
+      div.style.padding = '8px 10px';
+      div.style.borderRadius = '8px';
+      div.style.fontFamily = 'JetBrains Mono, monospace';
+      div.style.fontSize = '12px';
+      div.style.minWidth = '190px';
+
+      // Stop map dragging/zooming when interacting with the control
+      L.DomEvent.disableClickPropagation(div);
+      L.DomEvent.disableScrollPropagation(div);
+
+      div.innerHTML = `
+        <div style="font-weight:bold; margin-bottom:6px;">N3FJP QSOs</div>
+
+        <div style="display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:6px;">
+          <span>Show last</span>
+          <select id="n3fjp_minutes" style="flex:1; margin-left:8px; padding:2px 4px;">
+            <option value="5">5 min</option>
+            <option value="10">10 min</option>
+            <option value="15">15 min</option>
+            <option value="30">30 min</option>
+            <option value="60">60 min</option>
+            <option value="120">120 min</option>
+          </select>
+        </div>
+
+        <div style="display:flex; align-items:center; justify-content:space-between; gap:10px;">
+          <span>Line color</span>
+          <input id="n3fjp_color" type="color" style="width:52px; height:24px; padding:0; border:0; background:transparent;" />
+        </div>
+      `;
+
+      // Initialize controls
+      const sel = div.querySelector('#n3fjp_minutes');
+      const col = div.querySelector('#n3fjp_color');
+
+      if (sel) sel.value = String(displayMinutes);
+      if (col) col.value = String(lineColor);
+
+      // Wire events
+      if (sel) {
+        sel.addEventListener('change', (e) => {
+          const v = parseInt(e.target.value, 10);
+          if (Number.isFinite(v)) {
+            localStorage.setItem(STORAGE_MINUTES_KEY, String(v));
+            setDisplayMinutes(v);
+          }
+        });
+      }
+
+      if (col) {
+        col.addEventListener('change', (e) => {
+          const v = e.target.value || '#3388ff';
+          localStorage.setItem(STORAGE_COLOR_KEY, v);
+          setLineColor(v);
+        });
+      }
+
+      return div;
+    };
+
+    control.addTo(map);
+
+    return () => {
+      try { control.remove(); } catch {}
+    };
+  }, [enabled, map, displayMinutes, lineColor]);
+
+  // Draw markers/lines whenever qsos changes
+  useEffect(() => {
+    if (!map || typeof L === 'undefined') return;
+
+	// --- Preserve open popup across redraws ---
+	// Use our own ref as the source of truth (map._popup can be fickle during redraws)
+	const openDxCall = (!suppressReopenRef.current && lastOpenDxCallRef.current)
+	  ? lastOpenDxCallRef.current
+	  : null;
+	
+	// Remove old layers
+	layersRef.forEach(layer => {
+	  try { map.removeLayer(layer); } catch {}
+	});
+	setLayersRef([]);
+
+	if (!enabled || !qsos.length) return;
+
+    // ---- CLIENT-SIDE FILTER: Show only QSOs newer than X minutes ----
+    const cutoff = Date.now() - (displayMinutes * 60 * 1000);
+    const recent = qsos.filter(q => {
+      const t = Date.parse(q.ts_utc || q.ts || '');
+      return !Number.isNaN(t) && t >= cutoff;
+    });
+
+    // If nothing recent, we're done
+    if (!recent.length) return;
+
+    // Read station position from OpenHamClock config (if present)
+    let station = null;
+    try {
+      const raw = localStorage.getItem('openhamclock_config');
+      if (raw) {
+        const cfg = JSON.parse(raw);
+        const lat = cfg?.location?.lat;
+        const lon = cfg?.location?.lon;
+        if (typeof lat === 'number' && typeof lon === 'number') station = { lat, lon };
+      }
+    } catch {}
+
+    const newLayers = [];
+
+    // Optional: show station marker
+    if (station) {
+      const stMarker = L.circleMarker([station.lat, station.lon], {
+        radius: 5,
+        opacity,
+        fillOpacity: Math.min(1, opacity * 0.8),
+      }).addTo(map);
+      stMarker.bindPopup('<b>Station</b>');
+      newLayers.push(stMarker);
+    }
+
+    // Plot each QSO using qso.lat/qso.lon
+    recent.forEach(q => {
+      const lat = q.lat;
+      const lon = q.lon;
+      if (typeof lat !== 'number' || typeof lon !== 'number') return;
+
+      const dxCall = (q.dx_call || '').trim() || '(unknown)';
+      const mode = q.mode || '';
+      // Convert integer kHz (e.g. 14230) to MHz string (e.g. 14.230)
+      let freqMhz = '';
+      if (typeof q.freq_khz === 'number' && Number.isFinite(q.freq_khz) && q.freq_khz > 0) {
+        freqMhz = (q.freq_khz / 1000).toFixed(3);
+      }
+      const ts = q.ts_utc || '';
+
+      const dxMarker = L.circleMarker([lat, lon], {
+        radius: 6,
+        opacity,
+        fillOpacity: Math.min(1, opacity * 0.8),
+      }).addTo(map);
+
+      // Tag marker so we can re-open its popup after a redraw
+      dxMarker.__dxCall = dxCall;
+       // User intent: keep THIS call's popup open across redraws
+		dxMarker.on("click", () => {
+		  lastOpenDxCallRef.current = dxCall;
+		  suppressReopenRef.current = false;
+		});
+
+    dxMarker.on("popupclose", () => {
+	  // If the marker was removed from the map (our redraw does this every POLL_MS),
+	  // Leaflet will close the popup. That's NOT a user close.
+	  if (!map || !map.hasLayer(dxMarker)) return;
+
+	  // This is a real user close (clicked X or clicked map/another marker)
+	  if (lastOpenDxCallRef.current === dxCall) {
+		suppressReopenRef.current = true;
+		lastOpenDxCallRef.current = null;
+	  }
+	});
+
+      dxMarker.bindPopup(
+        `<div style="font-family: JetBrains Mono, monospace;">
+          <b>${dxCall}</b><br/>
+          ${mode ? `Mode: ${mode}<br/>` : ''}
+          ${freqMhz ? `Freq: ${freqMhz} MHz<br/>` : ''} 
+          ${ts ? `Time: ${ts}<br/>` : ''}
+          ${q.dx_country ? `Country: ${q.dx_country}<br/>` : ''}
+          ${q.loc_source ? `Loc: ${q.loc_source}<br/>` : ''}
+          ${q.dx_grid ? `Grid: ${q.dx_grid}<br/>` : ''}
+          <span style="opacity:0.7;">Retention: ${retentionMinutes} min</span>
+        </div>`
+      );
+
+      newLayers.push(dxMarker);
+
+      // If this was the popup that was open before redraw, re-open it now
+      if (!suppressReopenRef.current && openDxCall && dxCall === openDxCall) {
+        setTimeout(() => {
+          try { dxMarker.openPopup(); } catch {}
+        }, 0);
+      }
+
+      // Draw line from station -> DX if we have station coords
+      if (station) {
+        const line = L.polyline(
+          [[station.lat, station.lon], [lat, lon]],
+          { opacity, color: lineColor }
+        ).addTo(map);
+        newLayers.push(line);
+      }
+    });
+
+    setLayersRef(newLayers);
+	
+    // Cleanup
+    return () => {
+      newLayers.forEach(layer => {
+        try { map.removeLayer(layer); } catch {}
+      });
+    };
+  }, [enabled, qsos, map, opacity, retentionMinutes, displayMinutes, lineColor]);
+
+  return {
+    qsoCount: qsos.length,
+    retentionMinutes
+  };
+}


### PR DESCRIPTION
This PR adds support for displaying recently logged QSOs from N3FJP in OpenHamClock.

Features:
- New map overlay: "Logged QSOs (N3FJP)"
- HTTP ingest endpoint for external bridges
- Popup details (call, mode, frequency, grid, country)
- Optional station-to-DX path lines
- Client-side retention filtering

This is powered by an external Python bridge (documented separately) that connects to
the N3FJP TCP API and forwards QSOs to OpenHamClock via HTTP.

Tested on Windows with N3FJP Logger and OpenHamClock running on the same LAN.