### PR TITLE
Remove version from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   openhamclock:
     build: .


### PR DESCRIPTION
Removed version specification from docker-compose file. The version syntax is deprecated -- source: https://github.com/compose-spec/compose-spec/blob/main/04-version-and-name.md