### PR TITLE
Add DockerHub CI/CD pipeline and documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,40 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Build Docker image
-      run: docker build -t openhamclock:test .
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    
+    - name: Login to DockerHub
+      uses: docker/login-action@v3
+      with:
+        username: accius
+        password: ${{ secrets.DH_TOKEN }}
+    
+    - name: Extract metadata for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: accius/openhamclock
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=ref,event=branch
+          type=sha
+    
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
     
     - name: Test Docker container
       run: |
-        docker run -d -p 3000:3000 --name ohc-test openhamclock:test
+        docker pull accius/openhamclock:latest
+        docker run -d -p 3000:3000 --name ohc-test accius/openhamclock:latest
         sleep 10
         curl -f http://localhost:3000/api/health || exit 1
         docker stop ohc-test

--- a/README.md
+++ b/README.md
@@ -706,10 +706,30 @@ The Pi setup script installs Node.js 20, clones the repository, builds the front
 
 ### Docker
 
-**Docker Compose (recommended):**
+**Pulling from DockerHub (recommended):**
+
+```bash
+docker pull accius/openhamclock:latest
+```
+
+**Run with Docker Compose:**
 
 ```bash
 docker-compose up -d
+```
+
+**Run with Docker CLI:**
+
+```bash
+docker run -d \
+  --name openhamclock \
+  -p 3000:3000 \
+  -p 2237:2237/udp \
+  -e CALLSIGN=K0CJH \
+  -e LOCATOR=EN10 \
+  -e HOST=0.0.0.0 \
+  -e TZ=America/New_York \
+  accius/openhamclock:latest
 ```
 
 **Manual Docker build:**
@@ -719,18 +739,43 @@ docker build -t openhamclock .
 docker run -d -p 3000:3000 -p 2237:2237/udp --name openhamclock openhamclock
 ```
 
+**Docker Configuration:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| **Ports** | `3000`, `2237/udp` | Port 3000 for web UI, port 2237/udp for WSJT-X (optional) |
+| **Healthcheck** | `/api/health` | Automatic health check every 30 seconds |
+
+**Required Environment Variables:**
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `CALLSIGN` | Your amateur radio callsign | `K0CJH` |
+| `LOCATOR` | Maidenhead grid square (4 or 6 chars) | `EN10` |
+| `HOST` | Bind address (`0.0.0.0` for external access) | `0.0.0.0` |
+
+**Optional Environment Variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PORT` | HTTP server port | `3000` |
+| `NODE_ENV` | Runtime environment | `production` |
+| `TZ` | IANA timezone (e.g., `America/New_York`) | *(browser)* |
+| `WSJTX_RELAY_KEY` | Secret key for WSJT-X relay (cloud deployments) | *(none)* |
+| `LOG_LEVEL` | `debug`, `info`, `warn`, `error` | `warn` |
+| `THEME` | `dark`, `light`, `legacy`, `retro` | `dark` |
+| `LAYOUT` | `modern`, `classic` | `modern` |
+| `UNITS` | `imperial` or `metric` | `imperial` |
+| `OPENWEATHER_API_KEY` | Optional OpenWeatherMap API key | *(none)* |
+| `ITURHFPROP_URL` | Optional ITURHFProp microservice URL | *(none)* |
+| `SHOW_POTA` | Show POTA markers on map | `true` |
+| `SHOW_SATELLITES` | Show satellite tracks | `true` |
+| `SHOW_DX_PATHS` | Show DX signal paths | `true` |
+| `WSJTX_ENABLED` | Enable WSJT-X UDP listener | `true` |
+| `WSJTX_UDP_PORT` | WSJT-X UDP port | `2237` |
+| `SPOT_RETENTION_MINUTES` | DX spot retention (5-30) | `30` |
+
 The Dockerfile uses a multi-stage build: Stage 1 compiles the React frontend with Vite, Stage 2 creates a minimal production image with only the server and built assets. The UDP port mapping (`-p 2237:2237/udp`) is only needed if you use WSJT-X integration.
-
-**Environment variables:** Pass your configuration via Docker environment variables:
-
-```bash
-docker run -d \
-  -p 3000:3000 \
-  -e CALLSIGN=K0CJH \
-  -e LOCATOR=EN10 \
-  -e HOST=0.0.0.0 \
-  openhamclock
-```
 
 ### Railway (Cloud)
 


### PR DESCRIPTION
## Summary

This PR adds automated DockerHub build and push functionality to the GitHub Actions CI pipeline, along with comprehensive Docker documentation.

## Changes

### CI/CD Pipeline (`.github/workflows/ci.yml`)
- Added DockerHub login using `DH_TOKEN` secret
- Configured multi-tag push strategy (semver, branch, sha tags)
- Added GitHub Actions cache for faster builds
- Tests the deployed Docker image after push

### Documentation Updates

#### `README.md` - Docker Section
- Added instructions for pulling from DockerHub
- Complete port mapping and health check information
- Comprehensive tables for required and optional environment variables
- Updated Docker run examples

---
### Sample DockerHub info:
----
# OpenHamClock Docker Image

**A real-time amateur radio dashboard for the modern operator.**

OpenHamClock brings DX cluster spots, space weather, propagation predictions, POTA activations, PSKReporter, satellite tracking, WSJT-X integration, and more into a single browser-based interface.

[📖 Full Documentation](https://github.com/accius/openhamclock#readme)

## Quick Start

```bash
docker pull accius/openhamclock:latest

docker run -d \
  --name openhamclock \
  -p 3000:3000 \
  -p 2237:2237/udp \
  -e CALLSIGN=YOUR_CALLSIGN \
  -e LOCATOR=YOUR_GRID \
  -e HOST=0.0.0.0 \
  accius/openhamclock:latest
```

Access at http://localhost:3000

## Configuration

### Required Environment Variables

| Variable | Description | Example |
|----------|-------------|---------|
| `CALLSIGN` | Your amateur radio callsign | `K0CJH` |
| `LOCATOR` | Maidenhead grid square (4 or 6 chars) | `EN10` |
| `HOST` | Bind address (`0.0.0.0` for external access) | `0.0.0.0` |

### Optional Environment Variables

| Variable | Description | Default |
|----------|-------------|---------|
| `PORT` | HTTP server port | `3000` |
| `NODE_ENV` | Runtime environment | `production` |
| `TZ` | IANA timezone (e.g., `America/New_York`) | *(browser)* |
| `WSJTX_RELAY_KEY` | Secret key for WSJT-X relay (cloud deployments) | *(none)* |
| `LOG_LEVEL` | `debug`, `info`, `warn`, `error` | `warn` |
| `THEME` | `dark`, `light`, `legacy`, `retro` | `dark` |
| `LAYOUT` | `modern`, `classic` | `modern` |
| `UNITS` | `imperial` or `metric` | `imperial` |
| `OPENWEATHER_API_KEY` | Optional OpenWeatherMap API key | *(none)* |
| `ITURHFPROP_URL` | Optional ITURHFProp microservice URL | *(none)* |
| `SHOW_POTA` | Show POTA markers on map | `true` |
| `SHOW_SATELLITES` | Show satellite tracks | `true` |
| `SHOW_DX_PATHS` | Show DX signal paths | `true` |
| `WSJTX_ENABLED` | Enable WSJT-X UDP listener | `true` |
| `WSJTX_UDP_PORT` | WSJT-X UDP port | `2237` |
| `SPOT_RETENTION_MINUTES` | DX spot retention (5-30) | `30` |

### Ports

| Port | Protocol | Description |
|------|----------|-------------|
| `3000` | TCP | Web UI and API |
| `2237` | UDP | WSJT-X integration (optional) |

### Health Check

The container includes a built-in health check that queries `/api/health` every 30 seconds.

## Docker Compose Example

```yaml
services:
  openhamclock:
    image: accius/openhamclock:latest
    container_name: openhamclock
    ports:
      - "3000:3000"
      - "2237:2237/udp"
    environment:
      - CALLSIGN=K0CJH
      - LOCATOR=EN10
      - HOST=0.0.0.0
      - TZ=America/New_York
      - WSJTX_RELAY_KEY=your-secret-key-here
    restart: unless-stopped
```

## Features

- **DX Cluster**: Live DX spots from worldwide cluster network
- **Space Weather**: Real-time SFI, K-index, SSN, and X-ray flux
- **Propagation Predictions**: Per-band reliability predictions
- **POTA**: Parks on the Air activator tracking
- **PSKReporter**: Real-time digital mode reception reports
- **Satellites**: Amateur radio satellite tracking with orbital paths
- **WSJT-X Integration**: Live FT8/FT4/JT65 decodes on the map
- **Weather**: Station and DX location weather data
- **Contests**: Upcoming and active contest calendar

## Image Tags

- `latest` - Latest stable release
- `x.y.z` - Specific version tags (e.g., `3.14.16`)
- `x.y` - Minor version tags (e.g., `3.14`)
- `sha-<commit>` - Specific commit builds

## Support

- 📧 Contact: Chris, K0CJH — [chris@cjhlighting.com](mailto:chris@cjhlighting.com)
- 🌐 Live Site: [openhamclock.com](https://openhamclock.com)
- 💖 Support: [buymeacoffee.com/k0cjh](https://buymeacoffee.com/k0cjh)
- 📝 Source Code: [github.com/accius/openhamclock](https://github.com/accius/openhamclock)

## License

MIT License


---



## Configuration Required

Before merging, add the following to the repository secrets:
- `DH_TOKEN`: DockerHub access token (not password)

The DockerHub account and repo are hardcoded, pse review to ensure they are as expected.

Closes #190