### PR TITLE
psk map pins show DX call, pskreporter adjustable for time window

### DIFF
--- a/src/components/PSKReporterPanel.jsx
+++ b/src/components/PSKReporterPanel.jsx
@@ -43,17 +43,21 @@ const PSKReporterPanel = ({
   });
   const [wsjtxTab, setWsjtxTab] = useState('decodes');
   const [wsjtxFilter, setWsjtxFilter] = useState('all'); // 'all' | 'cq' | band name
+  const [pskMinutes, setPskMinutes] = useState(() => {
+    try { const s = localStorage.getItem('openhamclock_pskMinutes'); return s ? parseInt(s) : 30; } catch { return 30; }
+  });
   
-  // Persist panel mode and active tab
+  // Persist panel mode, active tab, and minutes
   const setPanelModePersist = (v) => { setPanelMode(v); try { localStorage.setItem('openhamclock_pskPanelMode', v); } catch {} };
   const setActiveTabPersist = (v) => { setActiveTab(v); try { localStorage.setItem('openhamclock_pskActiveTab', v); } catch {} };
+  const setPskMinutesPersist = (v) => { setPskMinutes(v); try { localStorage.setItem('openhamclock_pskMinutes', v); } catch {} };
   
   // PSKReporter hook
   const { 
     txReports, txCount, rxReports, rxCount, 
     loading, error, connected, source, refresh 
   } = usePSKReporter(callsign, { 
-    minutes: 30,
+    minutes: pskMinutes,
     enabled: callsign && callsign !== 'N0CALL'
   });
 
@@ -207,6 +211,27 @@ const PSKReporterPanel = ({
               {statusDot && (
                 <span style={{ color: statusDot.color, fontSize: '10px', lineHeight: 1 }}>{statusDot.char}</span>
               )}
+
+              {/* Time window selector */}
+              <select
+                value={pskMinutes}
+                onChange={(e) => setPskMinutesPersist(parseInt(e.target.value))}
+                style={{
+                  background: 'var(--bg-tertiary)',
+                  color: 'var(--text-primary)',
+                  border: '1px solid var(--border-color)',
+                  borderRadius: '3px',
+                  fontSize: '10px',
+                  padding: '1px 2px',
+                  cursor: 'pointer',
+                }}
+                title="Time window for spots"
+              >
+                <option value={15}>15m</option>
+                <option value={30}>30m</option>
+                <option value={60}>60m</option>
+              </select>
+
               <button onClick={onOpenFilters} style={iconBtn(pskFilterCount > 0, '#ffaa00')} title={t('pskReporterPanel.psk.filterTooltip')}>
                 <IconSearch size={11} style={{ verticalAlign: 'middle' }} />{pskFilterCount > 0 ? pskFilterCount : ''}
               </button>

--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -699,7 +699,8 @@ export const WorldMap = ({
         let spotLon = parseFloat(spot.lon);
         
         if (!isNaN(spotLat) && !isNaN(spotLon)) {
-          const displayCall = spot.receiver || spot.sender;
+          const isRX = spot.receiver?.toUpperCase() === callsign?.toUpperCase();
+          const displayCall = isRX ? spot.sender : spot.receiver;
           const freqMHz = spot.freqMHz || (spot.freq ? (spot.freq / 1000000).toFixed(3) : '?');
           const bandColor = getBandColor(parseFloat(freqMHz));
           
@@ -737,7 +738,7 @@ export const WorldMap = ({
               opacity: 0.9,
               fillOpacity: 0.8
             }).bindPopup(`
-              <b>${displayCall}</b><br>
+              <b>${isRX ? `From ${spot.sender}` : `From ${callsign?.toUpperCase()} by ${spot.receiver}`}</b><br>
               ${spot.mode} @ ${freqMHz} MHz<br>
               ${spot.snr !== null ? `SNR: ${spot.snr > 0 ? '+' : ''}${spot.snr} dB` : ''}
             `).addTo(map);

--- a/src/hooks/usePSKReporter.js
+++ b/src/hooks/usePSKReporter.js
@@ -103,6 +103,12 @@ export const usePSKReporter = (callsign, options = {}) => {
     return spots.filter(s => s.timestamp > cutoff).slice(0, maxSpots);
   }, [maxSpots]);
 
+  // Handle minutes changing: re-clean existing spots immediately
+  useEffect(() => {
+    setTxReports(prev => cleanOldSpots(prev, minutes));
+    setRxReports(prev => cleanOldSpots(prev, minutes));
+  }, [minutes, cleanOldSpots]);
+
   // Fetch historical spots via HTTP API on initial connect
   const fetchHistorical = useCallback(async (upperCallsign) => {
     if (!mountedRef.current) return;


### PR DESCRIPTION
Disclaimer: this is vibe-coded, though it's been our experience that the multi-model orchestrated way IntelliJ IDEA does this often gives us results that our decades-of-experience Developers carefully review and approve.

**I will not be offended** if this PR is rejected. But do please consider the feature changes anyway (done **_your_** way), and here's why:

I don't actually operate much. So a HamClock replacement that's geared toward DX Hunters is not what I needed.

Rather, I leave WSJT-x Band Hopping 160, 80, 40, 30, 20, 17, 15, 12, 10, & 6 meters 24x7. So whenever I glanced at HamClock, the spots tally over the past hour showed me what bands were hot FOR ME in the past hour. 15 minutes is not enough time for this much band hopping.

Then, on the actual map, because I'm 99% RX, having all those pins show MY callsign is not useful info to me. So I've changed it so that when I click a spot on the map, it shows THEIR callsign.

If I RX them, the pop-up will say "From (DXCallsign)".

If they RX me, the pop-up will say "From (MyCallsign) by (DXCallsign)".

These tell me what I'm interested to know.

All that said, **THANK YOU** for all you've done.