### PR TITLE
Github Action to create docker images on github Container Registry

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -53,7 +53,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           cache-from: type=gha,scope=${{ github.workflow }}
           cache-to: type=gha,scope=${{ github.workflow }},mode=max
           provenance: true


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the building and publishing of Docker images for the repository. The workflow is triggered on pushes to the `main` branch and handles the full process from checking out the code to building, tagging, and publishing the Docker image, as well as generating provenance attestations.

**CI/CD automation:**

* Added a new workflow file `.github/workflows/docker-image.yml` that builds and publishes Docker images to GitHub Container Registry on pushes to the `main` branch. This includes steps for setting up QEMU and Buildx, logging into the registry, extracting metadata for tags and labels, building and pushing the image with caching enabled, and generating artifact attestations for provenance.