### PR TITLE
feat: display local time and UTC offset in DX target panel

### DIFF
--- a/src/DockableApp.jsx
+++ b/src/DockableApp.jsx
@@ -340,6 +340,18 @@ export const DockableApp = ({
       </div>
       <div style={{ fontFamily: 'JetBrains Mono', fontSize: '14px' }}>
         <div style={{ color: 'var(--accent-amber)', fontSize: '22px', fontWeight: '700' }}>{dxGrid}</div>
+        {(() => {
+          const utcOffsetH = Math.round(dxLocation.lon / 15);
+          const dxDate = new Date(currentTime.getTime() + utcOffsetH * 3600000);
+          const hh = String(dxDate.getUTCHours()).padStart(2, '0');
+          const mm = String(dxDate.getUTCMinutes()).padStart(2, '0');
+          const sign = utcOffsetH >= 0 ? '+' : '';
+          return (
+            <div style={{ color: 'var(--accent-cyan)', fontSize: '13px', marginTop: '2px' }}>
+              {hh}:{mm} <span style={{ color: 'var(--text-muted)', fontSize: '11px' }}>(UTC{sign}{utcOffsetH})</span>
+            </div>
+          );
+        })()}
         <div style={{ color: 'var(--text-secondary)', fontSize: '13px', marginTop: '4px' }}>{dxLocation.lat.toFixed(4)}°, {dxLocation.lon.toFixed(4)}°</div>
         <div style={{ marginTop: '8px', fontSize: '13px' }}>
           <span style={{ color: 'var(--text-secondary)' }}>☀ </span>

--- a/src/layouts/ModernLayout.jsx
+++ b/src/layouts/ModernLayout.jsx
@@ -183,6 +183,18 @@ export default function ModernLayout(props) {
               <div style={{ fontFamily: 'JetBrains Mono', fontSize: '14px', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
                 <div style={{ flex: 1 }}>
                   <div style={{ color: 'var(--accent-amber)', fontSize: '22px', fontWeight: '700', letterSpacing: '1px' }}>{dxGrid}</div>
+                  {(() => {
+                    const utcOffsetH = Math.round(dxLocation.lon / 15);
+                    const dxDate = new Date(currentTime.getTime() + utcOffsetH * 3600000);
+                    const hh = String(dxDate.getUTCHours()).padStart(2, '0');
+                    const mm = String(dxDate.getUTCMinutes()).padStart(2, '0');
+                    const sign = utcOffsetH >= 0 ? '+' : '';
+                    return (
+                      <div style={{ color: 'var(--accent-cyan)', fontSize: '13px', marginTop: '2px', fontFamily: 'JetBrains Mono' }}>
+                        {hh}:{mm} <span style={{ color: 'var(--text-muted)', fontSize: '11px' }}>(UTC{sign}{utcOffsetH})</span>
+                      </div>
+                    );
+                  })()}
                   <div style={{ color: 'var(--text-secondary)', fontSize: '13px', marginTop: '4px' }}>{dxLocation.lat.toFixed(4)}°, {dxLocation.lon.toFixed(4)}°</div>
                   <div style={{ marginTop: '8px', fontSize: '13px' }}>
                     <span style={{ color: 'var(--text-secondary)' }}>☀ </span>


### PR DESCRIPTION
Show approximate local time at the DX target location directly below the grid square locator in the Dockable and Modern layouts. Time is derived from longitude (UTC offset = round(lon / 15)) and updates live with currentTime.

## What does this PR do?

<!-- A brief description of the change. What problem does it solve or what feature does it add? -->

## Type of change

- [ ] Bug fix
- [ x] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1.  Within UI DX cluster target now also integrated local time and UTC offset. See screenshot.
2. 
3. 

## Checklist

- [ x] App loads without console errors
- [ x] Tested in **Dark**, **Light**, and **Retro** themes
- [ x] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ x] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ x] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<img width="275" height="244" alt="Bildschirmfoto 2026-02-17 um 20 53 42" src="https://github.com/user-attachments/assets/36501c35-379a-428a-8558-c7e9b45fb4de" />
