### PR TITLE
fix: correct moon phase SVG sweep direction so new moon appears dark

### DIFF
--- a/src/components/SolarPanel.jsx
+++ b/src/components/SolarPanel.jsx
@@ -332,19 +332,17 @@ export const SolarPanel = ({ solarIndices, forcedMode }) => {
       }
       
       const absTermX = Math.abs(terminatorX);
-      
+
       if (phase < 0.5) {
-        // Waxing — right side lit
-        // Outer arc: top to bottom along right limb (sweep=1, clockwise)
-        // Terminator: bottom to top (elliptical arc)
-        const sweepTerminator = phase < 0.25 ? 1 : 0; // concave before quarter, convex after
-        return `M${CX},${CY - R} A${R},${R} 0 0,1 ${CX},${CY + R} A${absTermX},${R} 0 0,${sweepTerminator} ${CX},${CY - R}`;
+        // Waxing — right side lit, terminator concave (sweep=0)
+        // At phase≈0: absTermX≈0, ellipse collapses to a line → nearly no lit area (dark)
+        // At phase=0.25: absTermX=R, concave arc gives exactly right half lit
+        return `M${CX},${CY - R} A${R},${R} 0 0,1 ${CX},${CY + R} A${absTermX},${R} 0 0,0 ${CX},${CY - R}`;
       } else {
-        // Waning — left side lit
-        // Outer arc: top to bottom along left limb (sweep=0, counter-clockwise)
-        // Terminator: bottom to top
-        const sweepTerminator = phase > 0.75 ? 1 : 0;
-        return `M${CX},${CY - R} A${R},${R} 0 0,0 ${CX},${CY + R} A${absTermX},${R} 0 0,${sweepTerminator} ${CX},${CY - R}`;
+        // Waning — left side lit, terminator convex (sweep=1)
+        // At phase=0.75: absTermX=R, convex arc gives exactly left half lit
+        // At phase≈1: absTermX≈0, collapses to line → nearly no lit area (dark)
+        return `M${CX},${CY - R} A${R},${R} 0 0,0 ${CX},${CY + R} A${absTermX},${R} 0 0,1 ${CX},${CY - R}`;
       }
     };
     


### PR DESCRIPTION
## What does this PR do?

The terminator ellipse arc sweep was dynamically switched based on phase < 0.25 thresholds, causing new moon (phase≈0) to render as a fully lit disc instead of dark. Fixed by using a consistent sweep direction: concave (sweep=0) for all waxing phases, convex (sweep=1) for all waning phases. At phase≈0 the ellipse x-radius collapses to zero, correctly producing a dark (unlit) new moon.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1.  Check old moon phase implementation against fixed one  
2. 
3. 

## Checklist

- [x] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [x] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<!-- Before/after screenshots or a quick screen recording help reviewers a lot -->
