### PR TITLE
Add the callsign toggle button to the SOTA Panel and widen the column for the site reference

### DIFF
--- a/src/DockableApp.jsx
+++ b/src/DockableApp.jsx
@@ -147,6 +147,7 @@ export const DockableApp = ({
   const toggleWWFFEff = useInternalMapLayers ? internalMap.toggleWWFF : toggleWWFF;
   const toggleWWFFLabelsEff = useInternalMapLayers ? internalMap.toggleWWFFLabels : toggleWWFFLabels;
   const toggleSOTAEff = useInternalMapLayers ? internalMap.toggleSOTA : toggleSOTA;
+  const toggleSOTALabelsEff = useInternalMapLayers ? internalMap.toggleSOTALabels : toggleSOTALabels;
   const toggleSatellitesEff = useInternalMapLayers ? internalMap.toggleSatellites : toggleSatellites;
   const togglePSKReporterEff = useInternalMapLayers ? internalMap.togglePSKReporter : togglePSKReporter;
   const toggleWSJTXEff = useInternalMapLayers ? internalMap.toggleWSJTX : toggleWSJTX;
@@ -429,6 +430,7 @@ export const DockableApp = ({
         showWWFFLabels={mapLayersEff.showWWFFLabels}
 
         showSOTA={mapLayersEff.showSOTA}
+        showSOTALabels={mapLayersEff.showSOTALabels}
 
         showSatellites={mapLayersEff.showSatellites}
         onToggleSatellites={toggleSatellitesEff}
@@ -607,7 +609,20 @@ export const DockableApp = ({
         break;
 
       case 'sota':
-        content = <SOTAPanel data={sotaSpots.data} loading={sotaSpots.loading} lastUpdated={sotaSpots.lastUpdated} lastChecked={sotaSpots.lastChecked} showOnMap={mapLayersEff.showSOTA} onToggleMap={toggleSOTAEff} />;
+        content = (
+          <SOTAPanel
+            data={sotaSpots.data}
+            loading={sotaSpots.loading}
+            lastUpdated={sotaSpots.lastUpdated}
+            lastChecked={sotaSpots.lastChecked}
+            showOnMap={mapLayersEff.showSOTA}
+            onToggleMap={toggleSOTAEff}
+
+            showLabelsOnMap={mapLayersEff.showSOTALabels}
+            onToggleLabelsOnMap={toggleSOTALabelsEff}
+            onSpotClick={handleSpotClick}
+            />
+        );
         break;
 
       case 'contests':

--- a/src/components/SOTAPanel.jsx
+++ b/src/components/SOTAPanel.jsx
@@ -5,11 +5,25 @@
 import React from 'react';
 import CallsignLink from './CallsignLink.jsx';
 
-export const SOTAPanel = ({ data, loading, lastUpdated, lastChecked, showOnMap, onToggleMap, onSpotClick }) => {
+export const SOTAPanel = ({ data,
+  loading,
+  lastUpdated,
+  lastChecked,
+  showOnMap,
+  onToggleMap,
+  showLabelsOnMap,
+  onToggleLabelsOnMap = true,
+  onSpotClick
+}) => {
   const staleMinutes = lastUpdated ? Math.floor((Date.now() - lastUpdated) / 60000) : null;
   const isStale = staleMinutes !== null && staleMinutes >= 5;
   const checkedTime = lastChecked ? new Date(lastChecked).toISOString().substr(11, 5) + 'z' : '';
 
+  if (typeof onToggleLabelsOnMap === 'function') {
+    console.log('[SOTA] onToggleLabelsOnMap is a function');
+  } else {
+    console.log('[SOTA] onToggleLabelsOnMap is not a function');
+  }
   return (
     <div className="panel" style={{ padding: '8px', height: '100%', display: 'flex', flexDirection: 'column' }}>
       <div className="panel-header" style={{
@@ -23,22 +37,43 @@ export const SOTAPanel = ({ data, loading, lastUpdated, lastChecked, showOnMap, 
           ⛰ SOTA ACTIVATORS {data?.length > 0 ? `(${data.length})` : ''}
           {checkedTime && <span style={{ color: isStale ? (staleMinutes >= 10 ? '#ff4444' : '#ffaa00') : '#666', marginLeft: '6px', fontSize: '9px' }}>{isStale ? `⚠ ${staleMinutes}m stale` : `✓${checkedTime}`}</span>}
         </span>
-        <button
-          onClick={onToggleMap}
-          title={showOnMap ? 'Hide SOTA activators on map' : 'Show SOTA activators on map'}
-          style={{
-            background: showOnMap ? 'rgba(255, 150, 50, 0.3)' : 'rgba(100, 100, 100, 0.3)',
-            border: `1px solid ${showOnMap ? '#ff9632' : '#666'}`,
-            color: showOnMap ? '#ff9632' : '#888',
-            padding: '1px 6px',
-            borderRadius: '3px',
-            fontSize: '9px',
-            fontFamily: 'JetBrains Mono',
-            cursor: 'pointer'
-          }}
-        >
-          ⊞ Map {showOnMap ? 'ON' : 'OFF'}
-        </button>
+        <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+          <button
+            onClick={onToggleMap}
+            title={showOnMap ? 'Hide SOTA activators on map' : 'Show SOTA activators on map'}
+            style={{
+              background: showOnMap ? 'rgba(255, 150, 50, 0.3)' : 'rgba(100, 100, 100, 0.3)',
+              border: `1px solid ${showOnMap ? '#ff9632' : '#666'}`,
+              color: showOnMap ? '#ff9632' : '#888',
+              padding: '1px 6px',
+              borderRadius: '3px',
+              fontSize: '9px',
+              fontFamily: 'JetBrains Mono',
+              cursor: 'pointer'
+            }}
+          >
+            ⊞ Map {showOnMap ? 'ON' : 'OFF'}
+          </button>
+
+          {typeof onToggleLabelsOnMap === 'function' && (
+            <button
+              onClick={onToggleLabelsOnMap}
+              title={showLabelsOnMap ? 'Hide SOTA callsigns on map' : 'Show SOTA callsigns on map'}
+              style={{
+                background: showLabelsOnMap ? 'rgba(255, 170, 0, 0.22)' : 'rgba(100, 100, 100, 0.3)',
+                border: `1px solid ${showLabelsOnMap ? '#ffaa00' : '#666'}`,
+                color: showLabelsOnMap ? '#ffaa00' : '#888',
+                padding: '1px 6px',
+                borderRadius: '3px',
+                fontSize: '9px',
+                fontFamily: 'JetBrains Mono',
+                cursor: 'pointer'
+              }}
+            >
+              ⊞ Calls {showLabelsOnMap ? 'ON' : 'OFF'}
+            </button>
+          )}
+        </div>
       </div>
 
       <div style={{ flex: 1, overflowY: 'auto' }}>
@@ -54,7 +89,7 @@ export const SOTAPanel = ({ data, loading, lastUpdated, lastChecked, showOnMap, 
                 onClick={() => onSpotClick?.(spot)}
                 style={{
                   display: 'grid',
-                  gridTemplateColumns: '62px 50px 58px 1fr',
+                  gridTemplateColumns: '62px 62px 58px 1fr',
                   gap: '4px',
                   padding: '3px 0',
                   borderBottom: i < data.length - 1 ? '1px solid var(--border-color)' : 'none',

--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -64,6 +64,7 @@ export const WorldMap = ({
   showWWFF,
   showWWFFLabels = true,
   showSOTA,
+  showSOTALabels = true,
   showPSKReporter,
   showWSJTX,
   onSpotClick,
@@ -1206,7 +1207,7 @@ export const WorldMap = ({
           });
 
           // Only show callsign label when labels are enabled — replicate
-          if (showDXLabels) {
+          if (showSOTALabels) {
             const labelIcon = L.divIcon({
               className: "",
               html: `<span style="display:inline-block;background:#ff9632;color:#000;padding:2px 5px;border-radius:3px;font-size:11px;font-family:'JetBrains Mono',monospace;font-weight:700;white-space:nowrap;border:1px solid rgba(0,0,0,0.5);box-shadow:0 1px 2px rgba(0,0,0,0.3);line-height:1.1;">${spot.call}</span>`,
@@ -1224,7 +1225,7 @@ export const WorldMap = ({
         }
       });
     }
-  }, [sotaSpots, showSOTA, showDXLabels]);
+  }, [sotaSpots, showSOTA, showSOTALabels]);
 
   // Plugin layer system - properly load saved states
   useEffect(() => {

--- a/src/hooks/app/useMapLayers.js
+++ b/src/hooks/app/useMapLayers.js
@@ -10,6 +10,7 @@ export default function useMapLayers() {
     showWWFF: true,
     showWWFFLabels:true,
     showSOTA: true,
+    showSOTALabels: true,
     showSatellites: false,
     showPSKReporter: true,
     showWSJTX: true,
@@ -55,6 +56,7 @@ export default function useMapLayers() {
   const toggleWWFF = useCallback(() => setMapLayers(prev => ({ ...prev, showWWFF: !prev.showWWFF })), []);
   const toggleWWFFLabels = useCallback(() => setMapLayers(prev => ({ ...prev, showWWFFLabels: !prev.showWWFFLabels })), []);
   const toggleSOTA = useCallback(() => setMapLayers(prev => ({ ...prev, showSOTA: !prev.showSOTA })), []);
+  const toggleSOTALabels = useCallback(() => setMapLayers(prev => ({ ...prev, showSOTALabels: !prev.showSOTALabels })), []);
   const toggleSatellites = useCallback(() => setMapLayers(prev => ({ ...prev, showSatellites: !prev.showSatellites })), []);
   const togglePSKReporter = useCallback(() => setMapLayers(prev => ({ ...prev, showPSKReporter: !prev.showPSKReporter })), []);
   const toggleWSJTX = useCallback(() => setMapLayers(prev => ({ ...prev, showWSJTX: !prev.showWSJTX })), []);
@@ -71,6 +73,7 @@ export default function useMapLayers() {
     toggleWWFF,
     toggleWWFFLabels,
     toggleSOTA,
+    toggleSOTALabels,
     toggleSatellites,
     togglePSKReporter,
     toggleWSJTX,


### PR DESCRIPTION
- Widen the column for the site reference.

## What does this PR do?

Adds the toggle callsign" button to the SOTAPanel. This button toggles whether or not callsigns are displayed on the World Map, similar to how it is done for POTA and WWFF. As with POTA and WWFF, the button is only visible in the Dockable Layout

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1. Bringup the view in the Dockable layout and select the SOTA panel
2. Note that "Calls" button is present.
3. Clicking the Calls button should toggle the display of callsigns for SOTA summits on the World map.

## Checklist

- [X] App loads without console errors
- [X] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

Before:
<img width="412" height="73" alt="image" src="https://github.com/user-attachments/assets/84486d7d-bab3-4771-91eb-4800a36920ce" />

After:
<img width="325" height="96" alt="image" src="https://github.com/user-attachments/assets/7a9e4c6f-4e3e-4979-86eb-1e7dab90ea46" />
