### PR TITLE
Removed dup prettier from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "npx vite",
     "electron": "electron .",
     "electron-builder": "electron-builder",
-    "build": "npx vite build",    
+    "build": "npx vite build",
     "preview": "npx vite preview",
     "prestart": "npm run build",
     "server": "node server.js",
@@ -52,8 +52,7 @@
     "react-dom": "^18.2.0",
     "vite": "^5.0.10",
     "vitest": "^2.1.8",
-    "@vitest/coverage-v8": "^2.1.8",
-    "prettier": "3.8.1"
+    "@vitest/coverage-v8": "^2.1.8"
   },
   "lint-staged": {
     "*.{js,jsx,mjs,json,css,md}": "prettier --write"


### PR DESCRIPTION
I obviously added prettier a second time to package.json or accepted combination while merging. Removed dup prettier entry.