### PR TITLE
Use loopback IP address so docker compose healthcheck passes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ EXPOSE 2237/udp
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/api/health || exit 1
 
 # Start server with explicit heap limit and GC access for periodic compaction
 CMD ["node", "--max-old-space-size=2048", "--expose-gc", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       # - WSJTX_RELAY_KEY=your-secret-relay-key-here
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## What does this PR do?

Change the healthchecks in `Dockerfile` and `docker-compose.yaml` to use `127.0.0.1` instead of `localhost`

## Why?

On `node:20-alpine`, it seems like the default `wget` is unable to resolve `localhost`. This behavior is consistent across Mac and Linux docker hosts. 

```
➜  docker compose up
➜  docker exec -ti openhamclock /bin/sh
/app # wget --no-verbose --tries=1 --spider http://localhost:3000/api/health
Connecting to localhost:3000 ([::1]:3000)
wget: can't connect to remote host: Connection refused
/app #
/app #
/app # wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/api/health
Connecting to 127.0.0.1:3000 (127.0.0.1:3000)
remote file exists
/app #
/app #
/app # wget
BusyBox v1.37.0 (2025-12-16 14:19:28 UTC) multi-call binary.
(blah blah blah)
```

This is fixable in two ways:
- `apk add --no-cache wget` to install GNU Wget instead of BusyBox Wget
- Just use the loopback IP address, `127.0.0.1` instead of `localhost`

I chose to use the IP address because that skips name resolution entirely. However, the former works just fine.

```
/app # apk add --no-cache wget
(1/4) Installing libunistring (1.4.1-r0)
(2/4) Installing libidn2 (2.3.8-r0)
(3/4) Installing pcre2 (10.47-r0)
(4/4) Installing wget (1.25.0-r2)
Executing busybox-1.37.0-r30.trigger
OK: 14.4 MiB in 22 packages
/app # wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || echo "fail"
failed: Connection refused.
2026-02-18 23:36:08 URL: http://localhost:3000/api/health 200 OK
/app # echo $?
0
/app # wget --help
GNU Wget 1.25.0, a non-interactive network retriever.
(blah blah blah)
```

N.b. I'm not sure why wget prints `failed: Connection refused.` after we upgrade. That's another reason to favor the IP address.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to reproduce

1. check out `main`
2. `docker image rm openhamclock-openhamclock:latest`
3. run `docker compose up -d`
4. wait about 10 seconds
5. run `docker ps`
6. observe `STATUS`: `Up 10 seconds (health: starting)`
7. wait about 1 minute
8. run `docker ps`
9. observe `STATUS`: `Up 2 minutes (unhealthy)`
10. `docker compose down`

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1. check out this branch
2. `docker image rm openhamclock-openhamclock:latest`
3. run `docker compose up -d` 
4. wait about 10 seconds 
5. run `docker ps`
6. Observe `STATUS`: `Up 11 seconds (healthy)`

## Checklist

- [x] App loads without console errors
- [x] Tested in **Dark**, **Light**, and **Retro** themes
- [x] Responsive at different screen sizes (desktop + mobile)
- [x] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [x] If adding an API route: includes caching and error handling
- [x] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [x] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [x] No `.bak`, `.old`, `console.log` debug lines, or test scripts included
