### PR TITLE
[BUG] POTAPanel should display spot.ref rather than spot.locationDesc #394

### DIFF
--- a/src/components/POTAPanel.jsx
+++ b/src/components/POTAPanel.jsx
@@ -86,7 +86,7 @@ export const POTAPanel = ({
                 key={`${spot.call}-${spot.ref}-${i}`}
                 style={{
                   display: 'grid',
-                  gridTemplateColumns: '62px 50px 58px 1fr',
+                  gridTemplateColumns: '62px 62px 58px 1fr',
                   gap: '4px',
                   padding: '3px 0',
                   borderBottom: i < data.length - 1 ? '1px solid var(--border-color)' : 'none',
@@ -100,7 +100,7 @@ export const POTAPanel = ({
                   <CallsignLink call={spot.call} color="#44cc44" fontWeight="600" />
                 </span>
                 <span style={{ color: 'var(--text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  {spot.locationDesc || spot.ref}
+                  {`${spot.ref} - ${spot.name}`}
                 </span>
                 <span style={{ color: 'var(--accent-cyan)', textAlign: 'right' }}>
                   {(() => {


### PR DESCRIPTION

## What does this PR do?

I've made the panel display "ref - name" and widened the column to 62 px. The full string won't fit, but now mousing over the reference now shows the reference and the name.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Bring up the POTA panel
2. Note that the second column now contains the park reference
3. Mouse over the reference to view the reference and name

## Checklist

- [X] App loads without console errors
- [X] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

Before:
<img width="408" height="151" alt="image" src="https://github.com/user-attachments/assets/9b642fd9-a96d-49d7-b214-6d2667a33ef4" />

After:
<img width="331" height="144" alt="image" src="https://github.com/user-attachments/assets/a4793102-0b34-4cd3-a6d1-5fb39136b569" />
