### PR TITLE
Display the park name along with the reference in the WWFF Panel

### DIFF
--- a/src/components/WWFFPanel.jsx
+++ b/src/components/WWFFPanel.jsx
@@ -96,7 +96,7 @@ export const WWFFPanel = ({
                   <CallsignLink call={spot.call} color="#44cc44" fontWeight="600" />
                 </span>
                 <span style={{ color: 'var(--text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  {spot.ref}
+                  {`${spot.ref} - ${spot.name}`}
                 </span>
                 <span style={{ color: 'var(--accent-cyan)', textAlign: 'right' }}>
                   {(() => {


### PR DESCRIPTION
Similar to PR#524, have the second column of the panel (reference) also contain the name and show it with mouse over

## What does this PR do?

<!-- A brief description of the change. What problem does it solve or what feature does it add? -->

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Go to the WWFF Panel
2. Mouse over a park reference and verify that the name is displayed 

## Checklist

- [X] App loads without console errors
- [X] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

Before:
<img width="415" height="134" alt="image" src="https://github.com/user-attachments/assets/d992c225-37d8-4198-b43d-99dc1842413e" />

After
<img width="328" height="142" alt="image" src="https://github.com/user-attachments/assets/f8d08df7-7e0b-49ed-96c9-69050bc9856f" />


