### PR TITLE
Feature/publish image on release

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -58,6 +58,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha,scope=${{ github.workflow }}
           cache-to: type=gha,scope=${{ github.workflow }},mode=max


### PR DESCRIPTION
## What does this PR do?

A github release will trigger a docker build and publish. If the release is tagged with a [semver](https://semver.org/) (e.g. `1.2.3`, with or without a `v` prefix, although I recently learned the `v` is not compliant with semver), the docker image will be tagged with  `:1.2.3`, `:1.2`, `:1` as well as the other tags. The github action modifies the release description to add a link to the ghcr.io registry.

If the release is not tagged with a valid semver, build-and-push will fail.

Example release: https://github.com/agocs/openhamclock/releases/tag/v0.0.3

Example registry: https://github.com/agocs/openhamclock/pkgs/container/openhamclock

The multi-arch build takes about 5.5 minutes, compared to about 3 minutes for just `linux/amd64`. https://github.com/agocs/openhamclock/actions/runs/22252354659/job/64378046872

I played with the idea of only doing the multi-arch build on a release, and otherwise doing just `linux/amd64` for normal on-merge builds. Let me know if that's desirable.

I don't know much about Railway, but you might consider tying Railway deploys to releases.

Once a release has been made and a build has been tagged, we can modify docker-compose.yaml to use that instead of building from source.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin
