### PR TITLE
skip workflows on forks to reduce notification noise

### DIFF
--- a/.github/workflows/build-rig-listener.yml
+++ b/.github/workflows/build-rig-listener.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'accius/openhamclock'
     strategy:
       matrix:
         include:
@@ -68,8 +69,8 @@ jobs:
 
   # Attach all binaries to the GitHub release
   attach-to-release:
+    if: github.repository == 'accius/openhamclock' && github.event_name == 'release'
     needs: build
-    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   format:
+    if: github.repository == 'accius/openhamclock'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +25,7 @@ jobs:
         run: npm run format:check
 
   test:
+    if: github.repository == 'accius/openhamclock'
     runs-on: ubuntu-latest
     needs: format
 
@@ -69,10 +71,9 @@ jobs:
           exit 1
 
   docker:
+    if: github.repository == 'accius/openhamclock' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: test
-    # Only run docker build on push to main, not PRs
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -6,16 +6,18 @@ on:
 
 jobs:
   close-issue:
+    if: github.repository == 'accius/openhamclock'
     runs-on: ubuntu-latest
     # Only trigger on '/close' comments on issues (not PRs)
-    if: |
-      github.event.comment.body == '/close' &&
-      github.event.issue.pull_request == null
-    permissions:
-      issues: write
+    # Note: Using both conditions in the same if block
     steps:
-      - name: Close issue
+      - name: Check comment body
+        if: |
+          github.event.comment.body == '/close' &&
+          github.event.issue.pull_request == null
         uses: actions/github-script@v7
+        permissions:
+          issues: write
         with:
           script: |
             const { actor } = context;

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   build-and-push:
+    if: github.repository == 'accius/openhamclock'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/rig-listener-build.yml
+++ b/.github/workflows/rig-listener-build.yml
@@ -23,6 +23,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'accius/openhamclock'
     strategy:
       matrix:
         include:
@@ -67,9 +68,9 @@ jobs:
           retention-days: 30
 
   release:
+    if: github.repository == 'accius/openhamclock' && startsWith(github.ref, 'refs/tags/rig-listener-v')
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/rig-listener-v')
     name: Create Release
 
     steps:

--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -6,16 +6,17 @@ on:
 
 jobs:
   self-assign:
+    if: github.repository == 'accius/openhamclock'
     runs-on: ubuntu-latest
     # Only trigger on '/assign' comments on issues (not PRs)
-    if: |
-      github.event.comment.body == '/assign' &&
-      github.event.issue.pull_request == null
-    permissions:
-      issues: write
     steps:
       - name: Assign commenter to issue
+        if: |
+          github.event.comment.body == '/assign' &&
+          github.event.issue.pull_request == null
         uses: actions/github-script@v7
+        permissions:
+          issues: write
         with:
           script: |
             const { actor } = context;


### PR DESCRIPTION
## What does this PR do?

I have adjusted the GitHub workflows; they should no longer run in forks.