### PR TITLE
fix: Allow multiple, optional  env files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 services:
   openhamclock:
-    env_file: .env
+    env_file:
+      - path: stack.env
+        required: false
+      - path: .env
+        required: false
     build: .
     container_name: openhamclock
     ports:


### PR DESCRIPTION
## What does this PR do?
Resolve #587 by adding support for 2 optional environment files. This allows users to deploy if no .env file exists while simultaneously supports setting of environment variables via the Portainer UI to be injected into the container.


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->
FOR LOCAL TESTING
1. Freshly clone git repository
2. Remove existing openhamclock images `docker image rm ...`
3. Run container using `docker compose up`
FOR PORTAINER TESTING
5. Add new stack in Portainer of type Repository
6. Add this repo as the source
7. Deploy stack
