### PR TITLE
Fix SSN display inconsistencies when value is 0 (Solar Panel vs Header) #586

### DIFF
--- a/src/components/APRSPanel.jsx
+++ b/src/components/APRSPanel.jsx
@@ -3,9 +3,8 @@
  * Displays real-time APRS station positions with watchlist group management.
  * Supports tagging callsigns into named groups for EmComm and public service tracking.
  */
-import React, { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import CallsignLink from './CallsignLink.jsx';
-import { getBandColor } from '../utils/bandColors.js';
 
 const APRSPanel = ({ aprsData, showOnMap, onToggleMap, onSpotClick, onHoverSpot }) => {
   const {
@@ -14,7 +13,6 @@ const APRSPanel = ({ aprsData, showOnMap, onToggleMap, onSpotClick, onHoverSpot 
     connected,
     aprsEnabled,
     loading,
-    lastUpdate,
     watchlist = { groups: {}, activeGroup: 'all' },
     allWatchlistCalls = new Set(),
     addGroup,

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -3,7 +3,6 @@
  * Top bar with callsign, clocks, weather, and controls.
  * Responsive: wraps gracefully on tablet, collapses to essentials on mobile.
  */
-import React from 'react';
 import { IconGear, IconExpand, IconShrink } from './Icons.jsx';
 import DonateButton from './DonateButton.jsx';
 import { QRZToggle } from './CallsignLink.jsx';
@@ -212,7 +211,7 @@ export const Header = ({
           <div>
             <span style={{ color: 'var(--text-muted)' }}>SSN </span>
             <span style={{ color: 'var(--accent-cyan)', fontWeight: '700' }}>
-              {solarIndices?.data?.ssn?.current || spaceWeather?.data?.sunspotNumber || '--'}
+              {solarIndices?.data?.ssn?.current ?? spaceWeather?.data?.sunspotNumber ?? '--'}
             </span>
           </div>
           {!isTablet && bandConditions?.extras?.aIndex && (

--- a/src/components/SolarPanel.jsx
+++ b/src/components/SolarPanel.jsx
@@ -2,7 +2,7 @@
  * SolarPanel Component
  * Cycles between: Solar Image → Solar Indices → X-Ray Flux Chart → Lunar Phase
  */
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { getMoonPhase } from '../utils/geo.js';
 
 const MODES = ['image', 'indices', 'xray', 'lunar'];
@@ -377,7 +377,7 @@ export const SolarPanel = ({ solarIndices, forcedMode }) => {
     else if (phase >= 0.8125 && phase < 0.9375) phaseName = 'Waning Crescent';
 
     // Find next full moon & new moon by scanning forward
-    const findNextPhase = (targetPhase, label) => {
+    const findNextPhase = (targetPhase) => {
       const d = new Date(now);
       for (let i = 1; i <= 35; i++) {
         d.setDate(d.getDate() + 1);
@@ -876,12 +876,12 @@ export const SolarPanel = ({ solarIndices, forcedMode }) => {
                   <div
                     style={{ fontSize: '22px', fontWeight: '700', color: '#aa88ff', fontFamily: 'Orbitron, monospace' }}
                   >
-                    {solarIndices.data.ssn?.current || '--'}
+                    {solarIndices.data.ssn?.current ?? '--'}
                   </div>
                   <div style={{ fontSize: '8px', color: 'var(--text-muted)', lineHeight: 1.2 }}>
                     {(() => {
                       const v = solarIndices.data.ssn?.current;
-                      if (!v) return '';
+                      if (v == null) return '';
                       if (v >= 150) return 'Very High';
                       if (v >= 100) return 'High';
                       if (v >= 50) return 'Moderate';

--- a/src/components/SpaceWeatherPanel.jsx
+++ b/src/components/SpaceWeatherPanel.jsx
@@ -2,7 +2,6 @@
  * SpaceWeatherPanel Component
  * Displays solar flux, K-index, and sunspot number
  */
-import React from 'react';
 
 export const SpaceWeatherPanel = ({ data, loading }) => {
   const getKIndexColor = (kIndex) => {
@@ -65,7 +64,7 @@ export const SpaceWeatherPanel = ({ data, loading }) => {
                 fontFamily: 'Orbitron, monospace',
               }}
             >
-              {data?.sunspotNumber || '--'}
+              {data?.sunspotNumber ?? '--'}
             </div>
           </div>
         </div>

--- a/src/layouts/ClassicLayout.jsx
+++ b/src/layouts/ClassicLayout.jsx
@@ -30,11 +30,7 @@ export default function ClassicLayout(props) {
     handleToggleDxLock,
     deGrid,
     dxGrid,
-    deSunTimes,
-    dxSunTimes,
     tempUnit,
-    setTempUnit,
-    showDxWeather,
     localWeather,
     spaceWeather,
     solarIndices,
@@ -44,7 +40,6 @@ export default function ClassicLayout(props) {
     sotaSpots,
     wwbotaSpots,
     mySpots,
-    satellites,
     filteredSatellites,
     mapLayers,
     dxFilters,
@@ -60,12 +55,6 @@ export default function ClassicLayout(props) {
   const mapLegendBands = ['160', '80', '40', '30', '20', '17', '15', '12', '10', '8', '6', '4'];
 
   const { tuneTo } = useRig();
-
-  // Handler for POTA/WWFF/SOTA spot clicks
-  const handleParkSpotClick = (spot) => {
-    // tuneTo() in RigContext handles spot objects and all frequency conversions
-    tuneTo(spot);
-  };
 
   return config.layout === 'classic' ? (
     <div
@@ -174,7 +163,7 @@ export default function ClassicLayout(props) {
                   fontFamily: 'Orbitron, monospace',
                 }}
               >
-                {solarIndices?.data?.ssn?.current || '--'}
+                {solarIndices?.data?.ssn?.current ?? '--'}
               </div>
             </div>
             <div
@@ -658,7 +647,7 @@ export default function ClassicLayout(props) {
           <span>
             <span style={{ color: 'var(--text-muted)' }}>{t('app.solar.ssnShort')} </span>
             <span style={{ color: 'var(--accent-cyan)', fontWeight: '700' }}>
-              {solarIndices?.data?.ssn?.current || '--'}
+              {solarIndices?.data?.ssn?.current ?? '--'}
             </span>
           </span>
           {bandConditions?.extras?.aIndex && (
@@ -1220,7 +1209,7 @@ export default function ClassicLayout(props) {
           <span>
             <span style={{ color: 'var(--text-muted)' }}>{t('app.solar.ssnShort')} </span>
             <span style={{ color: 'var(--accent-cyan)', fontWeight: '700' }}>
-              {solarIndices?.data?.ssn?.current || '--'}
+              {solarIndices?.data?.ssn?.current ?? '--'}
             </span>
           </span>
           {bandConditions?.extras?.aIndex && (


### PR DESCRIPTION
## Summary
This PR fixes an SSN display bug where valid `0` values were treated as “missing”, causing incorrect or inconsistent numbers across the UI. Fixes #586.

### What was wrong
The app used `||` fallbacks and truthy checks in several SSN render paths.  
Because `0` is falsy in JavaScript:

- `SSN = 0` was rendered as `--` in the Solar panel.
- In the header, `SSN = 0` fell through to a fallback field (`spaceWeather.data.sunspotNumber`), which can come from a different source/timescale (monthly NOAA dataset), so users could see a different number (e.g. `113`) at the same time.

### Root cause
Mixed data sources + falsy logic:
- `solarIndices.data.ssn.current` can legitimately be `0` (current/day-level source).
- Fallback fields can represent different cadence/semantics (e.g. monthly NOAA).
- `||` and `if (!v)` incorrectly treated `0` as absent.

### What changed
- Replaced SSN `||` display fallbacks with nullish coalescing `??` so `0` is preserved.
- Replaced `if (!v)` with `if (v == null)` where SSN labels are derived.
- Applied the same fix to all relevant SSN displays for consistency.

### Updated files
- `src/components/SolarPanel.jsx`
- `src/components/Header.jsx`
- `src/layouts/ClassicLayout.jsx`
- `src/components/SpaceWeatherPanel.jsx`

### Result
- SSN now correctly displays `0` instead of `--`.
- Header and Solar Panel no longer diverge due to falsy fallback behavior.
- SSN values are now consistent across components for the same underlying data.