### PR TITLE
Reinstate the SOTA spot duplication checking

### DIFF
--- a/src/hooks/useSOTASpots.js
+++ b/src/hooks/useSOTASpots.js
@@ -40,6 +40,8 @@ export const useSOTASpots = () => {
             setLastUpdated(Date.now());
           }
 
+          let entry = []; // To weed out duplicate entries. We only want the most recent (first) spot matching "callsign summit"
+
           // Map SOTA API response to our standard spot format
           const mapped = (Array.isArray(spots) ? spots : [])
             .filter((s) => {
@@ -53,6 +55,12 @@ export const useSOTASpots = () => {
                 const ageMs = Date.now() - new Date(ts).getTime();
                 if (ageMs > 60 * 60 * 1000) return false;
               }
+
+              // Check to see if we already have already seen a spot for key.
+              const key = `${s.activatorCallsign} ${s.associationCode}/${s.summitCode}`;
+              if (entry.includes(key)) return false;
+              else entry.push(key);
+
               return true;
             })
             .map((s) => {


### PR DESCRIPTION
## What does this PR do?

Reinstates the SOTA spot duplication code that disappeared.
## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

Watch the SOTA Panel, and verify that we do not see duplicate spots, where duplicate is defined as "Same operator, same band".
