### PR TITLE
[feature/standardize-panels-for-display] added class name panel to components

### DIFF
--- a/src/DockableApp.jsx
+++ b/src/DockableApp.jsx
@@ -400,7 +400,7 @@ export const DockableApp = ({
 
   // Render DE Location panel content
   const renderDELocation = (nodeId) => (
-    <div style={{ padding: '14px', height: '100%', overflowY: 'auto' }}>
+    <div className="panel" style={{ padding: '14px', height: '100%', overflowY: 'auto' }}>
       <div style={{ fontSize: '14px', color: 'var(--accent-cyan)', fontWeight: '700', marginBottom: '10px' }}>
         📍 DE - YOUR LOCATION
       </div>
@@ -430,7 +430,7 @@ export const DockableApp = ({
     const distanceKm = calculateDistance(config.location.lat, config.location.lon, dxLocation.lat, dxLocation.lon);
 
     return (
-      <div style={{ padding: '14px', height: '100%', overflowY: 'auto' }}>
+      <div className="panel" style={{ padding: '14px', height: '100%', overflowY: 'auto' }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '10px' }}>
           <div style={{ fontSize: '14px', color: 'var(--accent-green)', fontWeight: '700' }}>🎯 DX - TARGET</div>
           {handleToggleDxLock && (

--- a/src/components/APRSPanel.jsx
+++ b/src/components/APRSPanel.jsx
@@ -57,7 +57,10 @@ const APRSPanel = ({ aprsData, showOnMap, onToggleMap, onSpotClick, onHoverSpot 
 
   if (!aprsEnabled) {
     return (
-      <div style={{ padding: '20px', color: 'var(--text-muted)', fontSize: '13px', textAlign: 'center' }}>
+      <div
+        className="panel"
+        style={{ padding: '20px', color: 'var(--text-muted)', fontSize: '13px', textAlign: 'center' }}
+      >
         <div style={{ fontSize: '24px', marginBottom: '10px' }}>📍</div>
         <div style={{ fontWeight: '600', color: 'var(--text-primary)', marginBottom: '8px' }}>APRS Not Enabled</div>
         <div>

--- a/src/components/AnalogClockPanel.jsx
+++ b/src/components/AnalogClockPanel.jsx
@@ -119,6 +119,7 @@ export const AnalogClockPanel = ({ currentTime, sunTimes }) => {
 
   return (
     <div
+      className="panel"
       ref={containerRef}
       style={{
         height: '100%',

--- a/src/components/SolarPanel.jsx
+++ b/src/components/SolarPanel.jsx
@@ -594,6 +594,7 @@ export const SolarPanel = ({ solarIndices, forcedMode }) => {
 
   return (
     <div
+      className="panel"
       style={{
         height: '100%',
         display: 'flex',


### PR DESCRIPTION
Added class name "panel" to Analog Clock, APRS panel, Solar panel, and DE / DX location components in the dockable app so that they will get the panel background colors from themes.

## What does this PR do?

<!-- A brief description of the change. What problem does it solve or what feature does it add? -->

## Type of change

- [X] Bug fix
- [X] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Observe the background color of the following panels:  Analog Clock, APRS panel, Solar panel, and DE / DX location
2. Confirm that they match the panel background color for the selected theme.

## Checklist

- [X] App loads without console errors
- [X] Tested in **Dark**, **Light**, and **Retro** themes
- [X] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [X] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)


<img width="1043" height="818" alt="Screenshot 2026-02-25 114253" src="https://github.com/user-attachments/assets/4acba0ac-64cb-40f8-825b-9302841daff0" />
