### PR TITLE
feat: add manual Maidenhead locator input to DX panel

### DIFF
--- a/src/DockableApp.jsx
+++ b/src/DockableApp.jsx
@@ -35,6 +35,7 @@ import { loadLayout, saveLayout } from './store/layoutStore.js';
 import { DockableLayoutProvider } from './contexts';
 import { useRig } from './contexts/RigContext.jsx';
 import { calculateBearing, calculateDistance, formatDistance } from './utils/geo.js';
+import { DXGridInput } from './components/DXGridInput.jsx';
 import './styles/flexlayout-openhamclock.css';
 import useMapLayers from './hooks/app/useMapLayers';
 import useRotator from './hooks/useRotator';
@@ -457,7 +458,14 @@ export const DockableApp = ({
         </div>
         <div style={{ display: 'flex', alignItems: 'flex-start', gap: '12px' }}>
           <div style={{ fontFamily: 'JetBrains Mono', fontSize: '14px', flex: '1 1 auto', minWidth: 0 }}>
-            <div style={{ color: 'var(--accent-amber)', fontSize: '22px', fontWeight: '700' }}>{dxGrid}</div>
+            <div style={{ color: 'var(--accent-amber)', fontSize: '22px', fontWeight: '700' }}>
+              <DXGridInput
+                dxGrid={dxGrid}
+                onDXChange={handleDXChange}
+                dxLocked={dxLocked}
+                style={{ color: 'var(--accent-amber)', fontSize: '22px', fontWeight: '700' }}
+              />
+            </div>
             <DXLocalTime
               currentTime={currentTime}
               dxLocation={dxLocation}

--- a/src/components/DXGridInput.jsx
+++ b/src/components/DXGridInput.jsx
@@ -1,0 +1,102 @@
+/**
+ * DXGridInput Component
+ * Editable Maidenhead locator display for the DX target section.
+ * Visually identical to the existing static grid square text; becomes
+ * interactive on focus so the user can type a locator manually.
+ *
+ * Calls onDXChange({ lat, lon }) with parsed coordinates on commit
+ * (Enter key or blur). Reverts to the current grid on Escape or invalid input.
+ * Read-only when dxLocked is true.
+ */
+import React, { useState, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { parseGridSquare } from '../utils/geo.js';
+
+export function DXGridInput({ dxGrid, onDXChange, dxLocked, style }) {
+  const { t } = useTranslation();
+  const [inputValue, setInputValue] = useState(dxGrid);
+  const inputRef = useRef(null);
+  // Tracks whether the user pressed Escape so blur skips the commit
+  const escapingRef = useRef(false);
+
+  // Sync display whenever the external dxGrid changes (map click, spot click, etc.)
+  useEffect(() => {
+    setInputValue(dxGrid);
+  }, [dxGrid]);
+
+  const commit = (value) => {
+    const trimmed = value.trim();
+    const parsed = parseGridSquare(trimmed);
+    if (parsed) {
+      onDXChange({ lat: parsed.lat, lon: parsed.lon });
+    } else {
+      setInputValue(dxGrid); // revert to last known good value
+    }
+  };
+
+  const handleChange = (e) => {
+    setInputValue(e.target.value.toUpperCase());
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      inputRef.current?.blur();
+    } else if (e.key === 'Escape') {
+      escapingRef.current = true;
+      setInputValue(dxGrid);
+      inputRef.current?.blur();
+    }
+  };
+
+  const handleBlur = () => {
+    if (inputRef.current) {
+      inputRef.current.style.borderBottomColor = 'transparent';
+    }
+    if (escapingRef.current) {
+      escapingRef.current = false;
+      return;
+    }
+    commit(inputValue);
+  };
+
+  const handleFocus = () => {
+    if (!dxLocked && inputRef.current) {
+      inputRef.current.style.borderBottomColor = 'var(--border-color)';
+    }
+  };
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      value={inputValue}
+      readOnly={dxLocked}
+      maxLength={6}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      onFocus={handleFocus}
+      onKeyDown={handleKeyDown}
+      title={
+        dxLocked
+          ? t('app.dxLocation.gridInputTitleLocked', 'Unlock DX position to enter a locator')
+          : t('app.dxLocation.gridInputTitle', 'Type a Maidenhead locator (e.g. JN58sm), press Enter')
+      }
+      style={{
+        background: 'transparent',
+        border: 'none',
+        borderBottom: '1px solid transparent',
+        outline: 'none',
+        cursor: dxLocked ? 'not-allowed' : 'text',
+        width: '7ch',
+        textAlign: 'right',
+        padding: 0,
+        margin: 0,
+        fontFamily: 'JetBrains Mono, monospace',
+        ...style,
+      }}
+    />
+  );
+}
+
+export default DXGridInput;

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -3,7 +3,7 @@
  * Full settings modal with map layer controls
  */
 import { useState, useEffect, useRef } from 'react';
-import { calculateGridSquare } from '../utils/geo.js';
+import { calculateGridSquare, parseGridSquare } from '../utils/geo.js';
 import { useTranslation, Trans } from 'react-i18next';
 import { LANGUAGES } from '../lang/i18n.js';
 import {
@@ -268,28 +268,6 @@ export const SettingsPanel = ({
         setLon(parsed.lon);
       }
     }
-  };
-
-  const parseGridSquare = (grid) => {
-    grid = grid.toUpperCase();
-    if (grid.length < 4) return null;
-
-    const lon1 = (grid.charCodeAt(0) - 65) * 20 - 180;
-    const lat1 = (grid.charCodeAt(1) - 65) * 10 - 90;
-    const lon2 = parseInt(grid[2]) * 2;
-    const lat2 = parseInt(grid[3]) * 1;
-
-    let lon = lon1 + lon2 + 1;
-    let lat = lat1 + lat2 + 0.5;
-
-    if (grid.length >= 6) {
-      const lon3 = (grid.charCodeAt(4) - 65) * (2 / 24);
-      const lat3 = (grid.charCodeAt(5) - 65) * (1 / 24);
-      lon = lon1 + lon2 + lon3 + 1 / 24;
-      lat = lat1 + lat2 + lat3 + 1 / 48;
-    }
-
-    return { lat, lon };
   };
 
   useEffect(() => {

--- a/src/lang/ca.json
+++ b/src/lang/ca.json
@@ -7,6 +7,8 @@
   "app.dxLocation.beamDir": "Direcció del feix:",
   "app.dxLocation.deTitle": "📍 DE - LA TEVA UBICACIÓ",
   "app.dxLocation.dxTitle": "📍 DX - OBJECTIU",
+  "app.dxLocation.gridInputTitle": "Escriviu un locator Maidenhead (p. ex. JN58sm), premeu Intro",
+  "app.dxLocation.gridInputTitleLocked": "Desbloquegeu la posició DX per introduir un locator manualment",
   "app.dxLocation.lp": "LP:",
   "app.dxLocation.sp": "SP:",
   "app.dxLock.clickToSet": "Clica el mapa per definir DX",

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -7,6 +7,8 @@
   "app.dxLocation.beamDir": "Strahlrichtung:",
   "app.dxLocation.deTitle": "📍 DE - IHR STANDORT",
   "app.dxLocation.dxTitle": "📍 DX - ZIEL",
+  "app.dxLocation.gridInputTitle": "Maidenhead-Locator eingeben (z.B. JN58sm), Enter drücken",
+  "app.dxLocation.gridInputTitleLocked": "DX-Position entsperren, um einen Locator einzugeben",
   "app.dxLocation.lp": "LP:",
   "app.dxLocation.sp": "SP:",
   "app.dxLock.clickToSet": "Karte klicken, um DX zu setzen",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -218,6 +218,8 @@
   "app.donate.paypal": "Donate via PayPal",
   "app.dxLocation.deTitle": "📍 DE - YOUR LOCATION",
   "app.dxLocation.dxTitle": "📍 DX - TARGET",
+  "app.dxLocation.gridInputTitle": "Type a Maidenhead locator (e.g. JN58sm), press Enter",
+  "app.dxLocation.gridInputTitleLocked": "Unlock DX position to enter a locator manually",
   "app.dxLocation.beamDir": "Beam Dir:",
   "app.dxLocation.sp": "SP:",
   "app.dxLocation.lp": "LP:",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -7,6 +7,8 @@
   "app.dxLocation.beamDir": "Dirección del haz:",
   "app.dxLocation.deTitle": "📍 DE - TU UBICACIÓN",
   "app.dxLocation.dxTitle": "📍 DX - OBJETIVO",
+  "app.dxLocation.gridInputTitle": "Introduzca un localizador Maidenhead (p. ej. JN58sm), pulse Intro",
+  "app.dxLocation.gridInputTitleLocked": "Desbloquear posición DX para introducir un localizador manualmente",
   "app.dxLocation.lp": "LP:",
   "app.dxLocation.sp": "SP:",
   "app.dxLock.clickToSet": "Haz clic en el mapa para definir DX",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -7,6 +7,8 @@
   "app.dxLocation.beamDir": "Direction du faisceau :",
   "app.dxLocation.deTitle": "📍 DE - VOTRE POSITION",
   "app.dxLocation.dxTitle": "📍 DX - CIBLE",
+  "app.dxLocation.gridInputTitle": "Saisissez un locator Maidenhead (ex. JN58sm), appuyez sur Entrée",
+  "app.dxLocation.gridInputTitleLocked": "Déverrouillez la position DX pour saisir un locator manuellement",
   "app.dxLocation.lp": "LP :",
   "app.dxLocation.sp": "SP :",
   "app.dxLock.clickToSet": "Cliquez sur la carte pour définir le DX",

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -7,6 +7,8 @@
   "app.dxLocation.beamDir": "Direzione fascio:",
   "app.dxLocation.deTitle": "📍 DE - LA TUA POSIZIONE",
   "app.dxLocation.dxTitle": "📍 DX - OBIETTIVO",
+  "app.dxLocation.gridInputTitle": "Inserire un locatore Maidenhead (es. JN58sm), premere Invio",
+  "app.dxLocation.gridInputTitleLocked": "Sbloccare la posizione DX per inserire un locatore manualmente",
   "app.dxLocation.lp": "LP:",
   "app.dxLocation.sp": "SP:",
   "app.dxLock.clickToSet": "Clicca sulla mappa per impostare DX",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -7,6 +7,8 @@
   "app.dxLocation.beamDir": "ビーム方向:",
   "app.dxLocation.deTitle": "📍 DE - あなたの位置",
   "app.dxLocation.dxTitle": "📍 DX - ターゲット",
+  "app.dxLocation.gridInputTitle": "メイデンヘッドロケーターを入力（例：JN58sm）、Enterを押す",
+  "app.dxLocation.gridInputTitleLocked": "手動でロケーターを入力するにはDX位置のロックを解除してください",
   "app.dxLocation.lp": "LP:",
   "app.dxLocation.sp": "SP:",
   "app.dxLock.clickToSet": "マップをクリックして DX 設定",

--- a/src/lang/ka.json
+++ b/src/lang/ka.json
@@ -207,6 +207,8 @@
   "app.donate.paypal": "შემოწირულობა PayPal-ით",
   "app.dxLocation.deTitle": "📍 DE - თქვენი მდებარეობა",
   "app.dxLocation.dxTitle": "📍 DX - სამიზნე",
+  "app.dxLocation.gridInputTitle": "შეიყვანეთ Maidenhead ლოკატორი (მაგ. JN58sm), დააჭირეთ Enter",
+  "app.dxLocation.gridInputTitleLocked": "განბლოკეთ DX პოზიცია ლოკატორის ხელით შესაყვანად",
   "app.dxLocation.beamDir": "მიმართულება:",
   "app.dxLocation.sp": "მოკლე:",
   "app.dxLocation.lp": "გრძელი:",

--- a/src/lang/ko.json
+++ b/src/lang/ko.json
@@ -7,6 +7,8 @@
   "app.dxLocation.beamDir": "방향:",
   "app.dxLocation.deTitle": "📍 DE – 내 위치",
   "app.dxLocation.dxTitle": "📍 DX – 대상",
+  "app.dxLocation.gridInputTitle": "메이든헤드 로케이터 입력 (예: JN58sm), Enter 누르기",
+  "app.dxLocation.gridInputTitleLocked": "로케이터를 수동으로 입력하려면 DX 위치 잠금 해제",
   "app.dxLocation.lp": "LP:",
   "app.dxLocation.sp": "SP:",
   "app.dxLock.clickToSet": "지도를 클릭하여 DX 설정",

--- a/src/lang/ms.json
+++ b/src/lang/ms.json
@@ -7,6 +7,8 @@
   "app.dxLocation.beamDir": "Arah Pancaran:",
   "app.dxLocation.deTitle": "📍 DE - LOKASI ANDA",
   "app.dxLocation.dxTitle": "📍 DX - SASARAN",
+  "app.dxLocation.gridInputTitle": "Taip penempatan Maidenhead (cth. JN58sm), tekan Enter",
+  "app.dxLocation.gridInputTitleLocked": "Buka kunci kedudukan DX untuk memasukkan penempatan secara manual",
   "app.dxLocation.lp": "LP:",
   "app.dxLocation.sp": "SP:",
   "app.dxLock.clickToSet": "Klik peta untuk tetap DX",

--- a/src/lang/nl.json
+++ b/src/lang/nl.json
@@ -7,6 +7,8 @@
   "app.dxLocation.beamDir": "Straalrichting:",
   "app.dxLocation.deTitle": "📍 DE - JOUW LOCATIE",
   "app.dxLocation.dxTitle": "📍 DX - DOEL",
+  "app.dxLocation.gridInputTitle": "Voer een Maidenhead-locator in (bijv. JN58sm), druk op Enter",
+  "app.dxLocation.gridInputTitleLocked": "Ontgrendel DX-positie om een locator handmatig in te voeren",
   "app.dxLocation.lp": "LP:",
   "app.dxLocation.sp": "SP:",
   "app.dxLock.clickToSet": "Klik op de kaart om DX in te stellen",

--- a/src/lang/pt.json
+++ b/src/lang/pt.json
@@ -7,6 +7,8 @@
   "app.dxLocation.beamDir": "Direção do feixe:",
   "app.dxLocation.deTitle": "📍 DE - SUA LOCALIZAÇÃO",
   "app.dxLocation.dxTitle": "📍 DX - ALVO",
+  "app.dxLocation.gridInputTitle": "Digite um localizador Maidenhead (ex. JN58sm), pressione Enter",
+  "app.dxLocation.gridInputTitleLocked": "Desbloqueie a posição DX para inserir um localizador manualmente",
   "app.dxLocation.lp": "LP:",
   "app.dxLocation.sp": "SP:",
   "app.dxLock.clickToSet": "Clique no mapa para definir DX",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -207,6 +207,8 @@
   "app.donate.paypal": "Поддержать через PayPal",
   "app.dxLocation.deTitle": "📍 DE - ВАШЕ РАСПОЛОЖЕНИЕ",
   "app.dxLocation.dxTitle": "📍 DX - ЦЕЛЬ",
+  "app.dxLocation.gridInputTitle": "Введите локатор Maidenhead (напр. JN58sm), нажмите Enter",
+  "app.dxLocation.gridInputTitleLocked": "Разблокируйте позицию DX для ввода локатора вручную",
   "app.dxLocation.beamDir": "Направление:",
   "app.dxLocation.sp": "КП:",
   "app.dxLocation.lp": "ДП:",

--- a/src/lang/sl.json
+++ b/src/lang/sl.json
@@ -7,6 +7,8 @@
   "app.dxLocation.beamDir": "Smer žarka:",
   "app.dxLocation.deTitle": "📍 DE - VAŠA LOKACIJA",
   "app.dxLocation.dxTitle": "📍 DX - CILJ",
+  "app.dxLocation.gridInputTitle": "Vnesite Maidenhead lokator (npr. JN58sm), pritisnite Enter",
+  "app.dxLocation.gridInputTitleLocked": "Odklenite položaj DX za ročni vnos lokatorja",
   "app.dxLocation.lp": "LP:",
   "app.dxLocation.sp": "SP:",
   "app.dxLock.clickToSet": "Kliknite na zemljevid za nastavitev DX",

--- a/src/lang/zh.json
+++ b/src/lang/zh.json
@@ -189,6 +189,8 @@
   "app.donate.paypal": "通过 PayPal 捐赠",
   "app.dxLocation.deTitle": "📍 DE - 您的位置",
   "app.dxLocation.dxTitle": "📍 DX - 目标位置",
+  "app.dxLocation.gridInputTitle": "输入梅登黑德网格（如 JN58sm），按回车确认",
+  "app.dxLocation.gridInputTitleLocked": "解锁DX位置以手动输入网格坐标",
   "app.dxLocation.beamDir": "波束方向:",
   "app.dxLocation.sp": "短径:",
   "app.dxLocation.lp": "长径:",

--- a/src/layouts/ClassicLayout.jsx
+++ b/src/layouts/ClassicLayout.jsx
@@ -2,6 +2,7 @@
  * Classic HamClock-style layout
  */
 import { DXNewsTicker, WorldMap } from '../components';
+import { DXGridInput } from '../components/DXGridInput.jsx';
 import { getBandColor, getBandColorForBand } from '../utils';
 import CallsignLink from '../components/CallsignLink.jsx';
 import DonateButton from '../components/DonateButton.jsx';
@@ -1418,7 +1419,14 @@ export default function ClassicLayout(props) {
             }}
           >
             <span>
-              {deGrid} → {dxGrid} • {dxLocked ? t('app.dxLock.lockedShort') : t('app.dxLock.clickToSet')}
+              {deGrid} →{' '}
+              <DXGridInput
+                dxGrid={dxGrid}
+                onDXChange={handleDXChange}
+                dxLocked={dxLocked}
+                style={{ color: 'var(--text-muted)', fontSize: '14px' }}
+              />{' '}
+              • {dxLocked ? t('app.dxLock.lockedShort') : t('app.dxLock.clickToSet')}
             </span>
             <button
               onClick={handleToggleDxLock}

--- a/src/layouts/ModernLayout.jsx
+++ b/src/layouts/ModernLayout.jsx
@@ -26,6 +26,7 @@ import {
 } from '../components';
 import { useRig } from '../contexts/RigContext.jsx';
 import { calculateDistance, formatDistance } from '../utils/geo.js';
+import { DXGridInput } from '../components/DXGridInput.jsx';
 import useBreakpoint from '../hooks/app/useBreakpoint';
 
 export default function ModernLayout(props) {
@@ -240,7 +241,12 @@ export default function ModernLayout(props) {
       </div>
       <div style={{ fontFamily: 'JetBrains Mono', fontSize: '14px' }}>
         <div style={{ color: 'var(--accent-green)', fontSize: '22px', fontWeight: '700', letterSpacing: '1px' }}>
-          {dxGrid}
+          <DXGridInput
+            dxGrid={dxGrid}
+            onDXChange={handleDXChange}
+            dxLocked={dxLocked}
+            style={{ color: 'var(--accent-green)', fontSize: '22px', fontWeight: '700', letterSpacing: '1px' }}
+          />
         </div>
         <DXLocalTime
           currentTime={currentTime}

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -4,6 +4,30 @@
  */
 
 /**
+ * Parse a Maidenhead grid square string into lat/lon coordinates.
+ * Supports 4-character (e.g. "JN58") and 6-character (e.g. "JN58sm") locators.
+ * Returns { lat, lon } of the grid square center, or null if input is invalid.
+ */
+export const parseGridSquare = (grid) => {
+  const g = grid.toUpperCase();
+  if (g.length < 4) return null;
+  const lon1 = (g.charCodeAt(0) - 65) * 20 - 180;
+  const lat1 = (g.charCodeAt(1) - 65) * 10 - 90;
+  const lon2 = parseInt(g[2]) * 2;
+  const lat2 = parseInt(g[3]) * 1;
+  if (isNaN(lon2) || isNaN(lat2)) return null;
+  let lon = lon1 + lon2 + 1;
+  let lat = lat1 + lat2 + 0.5;
+  if (g.length >= 6) {
+    const lon3 = (g.charCodeAt(4) - 65) * (2 / 24);
+    const lat3 = (g.charCodeAt(5) - 65) * (1 / 24);
+    lon = lon1 + lon2 + lon3 + 1 / 24;
+    lat = lat1 + lat2 + lat3 + 1 / 48;
+  }
+  return { lat, lon };
+};
+
+/**
  * Calculate Maidenhead grid square from coordinates
  */
 export const calculateGridSquare = (lat, lon) => {
@@ -414,6 +438,7 @@ export const classifyTwilight = (solarElevationDeg) => {
 };
 
 export default {
+  parseGridSquare,
   calculateGridSquare,
   calculateBearing,
   calculateDistance,


### PR DESCRIPTION
## Summary

- Add a manual Maidenhead locator text input to the DX target panel in all three layouts (Modern, Classic, Dockable)
- The existing DX grid square display is converted into an editable field — no extra space is consumed
- Typing a valid 4- or 6-character locator (e.g. `JN58` or `JN58sm`) and pressing **Enter** (or leaving the field) moves the DX map marker and updates all derived data: bearing, distance, and sunrise/sunset times
- The field is **read-only** when the DX lock 🔒 is active, and **reverts** on Escape or invalid input
- Map clicks and spot clicks continue to work as before and sync back into the field
- Addresses https://github.com/accius/openhamclock/issues/622 

## Changes

| File | What changed |
|------|-------------|
| `src/utils/geo.js` | Export `parseGridSquare` (grid → lat/lon); was previously a private duplicate inside SettingsPanel |
| `src/components/SettingsPanel.jsx` | Import shared `parseGridSquare` from geo.js; remove local duplicate |
| `src/components/DXGridInput.jsx` | **New** reusable editable locator component used by all three layouts |
| `src/layouts/ModernLayout.jsx` | Replace static `{dxGrid}` span with `<DXGridInput>` |
| `src/layouts/ClassicLayout.jsx` | Replace static `{dxGrid}` span with `<DXGridInput>` |
| `src/DockableApp.jsx` | Replace static `{dxGrid}` div with `<DXGridInput>` |
| `src/lang/*.json` | Add `app.dxLocation.gridInputTitle` / `gridInputTitleLocked` — translated for all 14 supported languages |

## Test plan

- [ ] Typing `JN58sm` moves the DX marker to the Munich area
- [ ] Typing a 4-char grid `JN58` also works (centers on the grid square)
- [ ] Bearing, distance and sun times update after input
- [ ] Invalid input (e.g. `XY`) reverts to the current grid on blur
- [ ] Escape reverts without updating
- [ ] Map click still updates the input field
- [ ] DX cluster spot click still updates the input field
- [ ] Lock active → input is read-only (cursor: not-allowed)
- [ ] Verified in all three layouts: Modern, Classic, Dockable
- [ ] No regressions in DE location display or SettingsPanel grid input

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## Checklist

- [x] App loads without console errors
- [x] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [x] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [x] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

