### PR TITLE
Make the spot reference column a little wider

### DIFF
--- a/src/components/ActivatePanel.jsx
+++ b/src/components/ActivatePanel.jsx
@@ -145,7 +145,7 @@ export const ActivatePanel = ({
                 key={`${spot.call}-${spot.ref}-${i}`}
                 style={{
                   display: 'grid',
-                  gridTemplateColumns: '62px 62px 58px 1fr',
+                  gridTemplateColumns: '62px 72px 58px 1fr',
                   gap: '4px',
                   padding: '3px 0',
                   borderBottom: i < data.length - 1 ? '1px solid var(--border-color)' : 'none',


### PR DESCRIPTION
## What does this PR do?

There was a discussion in FaceBook about the width of the spot reference column being not quite wide enough. This fix increases it from 62px to 72px.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Look at one of the ActivatorPanel panels (e.g. SOTA)
2. Verify that more of the reference/name string is visible.

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

Before
<img width="338" height="176" alt="Screenshot 2026-02-28 at 10 44 14 am" src="https://github.com/user-attachments/assets/87611340-22e8-4bd7-a2a1-ed99acc78375" />

After:
<img width="344" height="190" alt="image" src="https://github.com/user-attachments/assets/822c48d9-342a-466c-a579-0e54643d86fd" />
