### PR TITLE
[Bug 607] Incorrect dependency on filtered spots

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -264,19 +264,19 @@ const App = () => {
 
   const filteredPotaSpots = useMemo(() => {
     return ActivateFilter(potaSpots, potaFilters);
-  }, [potaSpots, potaFilters]);
+  }, [potaSpots.data, potaFilters]);
 
   const filteredWwffSpots = useMemo(() => {
     return ActivateFilter(wwffSpots, wwffFilters);
-  }, [wwffSpots, wwffFilters]);
+  }, [wwffSpots.data, wwffFilters]);
 
   const filteredSotaSpots = useMemo(() => {
     return ActivateFilter(sotaSpots, sotaFilters);
-  }, [sotaSpots, sotaFilters]);
+  }, [sotaSpots.data, sotaFilters]);
 
   const filteredWwbotaSpots = useMemo(() => {
     return ActivateFilter(wwbotaSpots, wwbotaFilters);
-  }, [wwbotaSpots, wwbotaFilters]);
+  }, [wwbotaSpots.data, wwbotaFilters]);
 
   const wsjtxMapSpots = useMemo(() => {
     // Apply same age filter as panel (stored in localStorage)


### PR DESCRIPTION
## What does this PR do?

Whenever a filter was enabled on an ActivatePanel, WorldMap was refreshing far too quickly, meaning that if we had clicked on a spot to show it's data it woudl either disappear almost immediately or even seem to NOT have appeared.

The issue appears e when we set up the filtered spots constants, we were listing {potaSpots, WwffSpots, SotaSpots, WwbotaSpots} as the dependency. We should have been listing the *Spots.data structure element.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Enable a filter on an ActivatePanel
2. Click a on of its spots on the map

The popup should remain until the hooks update teh underlying spot information from the API.

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [X] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

