### PR TITLE
simplify portainer deployment from GitHub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,23 +8,59 @@ services:
     build: .
     container_name: openhamclock
     ports:
-      - '3000:3000'
+      - '3000:3000' # HTTP
       - '2237:2237/udp' # WSJT-X UDP — point WSJT-X to 127.0.0.1:2237
+      - '12060:12060/udp' # N1MM UDP
     environment:
-      - NODE_ENV=production
       - PORT=3000
-      # Uncomment and set your timezone (IANA format)
-      # This ensures correct local time display, especially with privacy browsers
-      # - TZ=America/New_York
-      # Uncomment to enable WSJT-X relay from local machine (cloud deployments)
-      # - WSJTX_RELAY_KEY=your-secret-relay-key-here
+      - WSJTX_UDP_PORT=2237
+      - N1MM_UDP_PORT=12060
+      - NODE_ENV=${NODE_ENV:-production}
+      - CALLSIGN=${CALLSIGN:-N0CALL}
+      - LOCATOR=${LOCATOR-FN31}
+      - LATITUDE=${LATITUDE}
+      - LONGITUDE=${LONGITUDE}
+      - HOST=${HOST}
+      - CORS_ORIGINS=${CORS_ORIGINS}
+      - AUTO_UPDATE_ENABLED=${AUTO_UPDATE_ENABLED}
+      - AUTO_UPDATE_INTERVAL_MINUTES=${AUTO_UPDATE_INTERVAL_MINUTES}
+      - AUTO_UPDATE_ON_START=${AUTO_UPDATE_ON_START}
+      - AUTO_UPDATE_EXIT_AFTER=${AUTO_UPDATE_EXIT_AFTER}
+      - SETTINGS_SYNC=${SETTINGS_SYNC}
+      - SETTINGS_FILE=${SETTINGS_FILE}
+      - UNITS=${UNITS}
+      - TIME_FORMAT=${TIME_FORMAT}
+      - THEME=${THEME}
+      - LAYOUT=${LAYOUT}
+      - TZ=${TZ}
+      - ITURHFPROP_URL=${ITURHFPROP_URL}
+      - DXSPIDER_PROXY_URL=${DXSPIDER_PROXY_URL}
+      - DX_CLUSTER_SOURCE=${DX_CLUSTER_SOURCE}
+      - OPENWEATHER_API_KEY=${OPENWEATHER_API_KEY}
+      - VITE_OPENWEATHER_API_KEY=${VITE_OPENWEATHER_API_KEY}
+      - SHOW_POTA=${SHOW_POTA}
+      - SHOW_SATELLITES=${SHOW_SATELLITES}
+      - SHOW_DX_PATHS=${SHOW_DX_PATHS}
+      - SHOW_DX_WEATHER=${SHOW_DX_WEATHER}
+      - CLASSIC_ANALOG_CLOCK=${CLASSIC_ANALOG_CLOCK}
+      - WSJTX_ENABLED=${WSJTX_ENABLED}
+      - WSJTX_RELAY_KEY=${WSJTX_RELAY_KEY}
+      - DX_CLUSTER_CALLSIGN=${DX_CLUSTER_CALLSIGN}
+      - SPOT_RETENTION_MINUTES=${SPOT_RETENTION_MINUTES}
+      - N1MM_UDP_ENABLED=${N1MM_UDP_ENABLED}
+      - N1MM_MAX_QSOS=${N1MM_MAX_QSOS}
+      - N1MM_QSO_MAX_AGE_MINUTES=${N1MM_QSO_MAX_AGE_MINUTES}
+      - VITE_AMBIENT_APPLICATION_KEY=${VITE_AMBIENT_APPLICATION_KEY}
+      - VITE_AMBIENT_API_KEY=${VITE_AMBIENT_API_KEY}
+      - VITE_AMBIENT_DEVICE_MAC=${VITE_AMBIENT_DEVICE_MAC}
+      - VITE_AMBIENT_POLL_SECONDS=${VITE_AMBIENT_POLL_SECONDS}
     restart: unless-stopped
     healthcheck:
-      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:3000/api/health']
+      test:
+        ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', '${HEALTH_ENDPOINT:-http://localhost:3000/api/health}']
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 10s
-
 # For development with hot reload:
 # docker compose -f docker-compose.dev.yml up


### PR DESCRIPTION
## What does this PR do?

This change defines all environment variables used to configure OpenHamClock within the `docker-compose.yml` file. This allows to easily deploy OpenHamClock (for example) in a portainer installation by using the OpenHamClock GitHub repository as source. 

The configuration can simply be managed within portainer's UI by setting environment variables. No external .env file needed.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1. create a new stack in portainer using the GitHub repo https://github.com/accius/openhamclock as source
2. define the local configuration as environment variables in portainer
3. make sure to set the variable HEALTH_ENDPOINT=http://<portainer-host>:3000/api/health
4. check if http://<portainer-host>:3000 is working and is configured as desired

## Checklist

- [ ] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<!-- Before/after screenshots or a quick screen recording help reviewers a lot -->
