### PR TITLE
Add AM to the list of filters in PSKReporter and ActivatePanel filters

### DIFF
--- a/src/components/ActivateFilterManager.jsx
+++ b/src/components/ActivateFilterManager.jsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 const BANDS = ['160m', '80m', '60m', '40m', '30m', '20m', '17m', '15m', '12m', '10m', '6m', '2m', '70cm'];
 const MODES = [
   '-FT8',
+  'AM',
   'CONTESTI',
   'CW',
   'CWU',

--- a/src/components/PSKFilterManager.jsx
+++ b/src/components/PSKFilterManager.jsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 const BANDS = ['160m', '80m', '60m', '40m', '30m', '20m', '17m', '15m', '12m', '10m', '8m', '6m', '4m', '2m', '70cm'];
 const MODES = [
   '-FT8',
+  'AM',
   'CONTESTI',
   'CW',
   'CWU',


### PR DESCRIPTION
## What does this PR do?

Add AM to the list of filters in PSKReporter and ActivatePanel filters

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Select the PSKReporter or an Activate (POTA, SOTA, WWFF, WWBOTA) Panel
2. Click the Filter button
3. Select the Modes panel
4. Verify that the is a selection for AM

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

Before
<img width="493" height="238" alt="image" src="https://github.com/user-attachments/assets/77b3bee8-d49f-4cf0-b155-d6402c6cc781" />

After
<img width="494" height="269" alt="image" src="https://github.com/user-attachments/assets/0731d382-f29a-4a79-bb8c-2e2196b631bd" />

