### PR TITLE
fix(dx-grid-input): validate Maidenhead ranges and tighten length check

### DIFF
--- a/src/DockableApp.jsx
+++ b/src/DockableApp.jsx
@@ -458,14 +458,12 @@ export const DockableApp = ({
         </div>
         <div style={{ display: 'flex', alignItems: 'flex-start', gap: '12px' }}>
           <div style={{ fontFamily: 'JetBrains Mono', fontSize: '14px', flex: '1 1 auto', minWidth: 0 }}>
-            <div style={{ color: 'var(--accent-amber)', fontSize: '22px', fontWeight: '700' }}>
-              <DXGridInput
-                dxGrid={dxGrid}
-                onDXChange={handleDXChange}
-                dxLocked={dxLocked}
-                style={{ color: 'var(--accent-amber)', fontSize: '22px', fontWeight: '700' }}
-              />
-            </div>
+            <DXGridInput
+              dxGrid={dxGrid}
+              onDXChange={handleDXChange}
+              dxLocked={dxLocked}
+              style={{ color: 'var(--accent-amber)', fontSize: '22px', fontWeight: '700' }}
+            />
             <DXLocalTime
               currentTime={currentTime}
               dxLocation={dxLocation}

--- a/src/components/DXGridInput.jsx
+++ b/src/components/DXGridInput.jsx
@@ -8,7 +8,7 @@
  * (Enter key or blur). Reverts to the current grid on Escape or invalid input.
  * Read-only when dxLocked is true.
  */
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { parseGridSquare } from '../utils/geo.js';
 

--- a/src/layouts/ModernLayout.jsx
+++ b/src/layouts/ModernLayout.jsx
@@ -240,14 +240,12 @@ export default function ModernLayout(props) {
         </button>
       </div>
       <div style={{ fontFamily: 'JetBrains Mono', fontSize: '14px' }}>
-        <div style={{ color: 'var(--accent-green)', fontSize: '22px', fontWeight: '700', letterSpacing: '1px' }}>
-          <DXGridInput
-            dxGrid={dxGrid}
-            onDXChange={handleDXChange}
-            dxLocked={dxLocked}
-            style={{ color: 'var(--accent-green)', fontSize: '22px', fontWeight: '700', letterSpacing: '1px' }}
-          />
-        </div>
+        <DXGridInput
+          dxGrid={dxGrid}
+          onDXChange={handleDXChange}
+          dxLocked={dxLocked}
+          style={{ color: 'var(--accent-green)', fontSize: '22px', fontWeight: '700', letterSpacing: '1px' }}
+        />
         <DXLocalTime
           currentTime={currentTime}
           dxLocation={dxLocation}

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -10,20 +10,33 @@
  */
 export const parseGridSquare = (grid) => {
   const g = grid.toUpperCase();
-  if (g.length < 4) return null;
-  const lon1 = (g.charCodeAt(0) - 65) * 20 - 180;
-  const lat1 = (g.charCodeAt(1) - 65) * 10 - 90;
+  // Must be exactly 4 (field + square) or 6 (+ subsquare) characters
+  if (g.length !== 4 && g.length !== 6) return null;
+
+  // Field letters: A–R (18 fields, covering 360° lon / 180° lat)
+  const f0 = g.charCodeAt(0) - 65;
+  const f1 = g.charCodeAt(1) - 65;
+  if (f0 < 0 || f0 > 17 || f1 < 0 || f1 > 17) return null;
+
+  const lon1 = f0 * 20 - 180;
+  const lat1 = f1 * 10 - 90;
+
   const lon2 = parseInt(g[2]) * 2;
-  const lat2 = parseInt(g[3]) * 1;
+  const lat2 = parseInt(g[3]);
   if (isNaN(lon2) || isNaN(lat2)) return null;
+
   let lon = lon1 + lon2 + 1;
   let lat = lat1 + lat2 + 0.5;
-  if (g.length >= 6) {
-    const lon3 = (g.charCodeAt(4) - 65) * (2 / 24);
-    const lat3 = (g.charCodeAt(5) - 65) * (1 / 24);
-    lon = lon1 + lon2 + lon3 + 1 / 24;
-    lat = lat1 + lat2 + lat3 + 1 / 48;
+
+  if (g.length === 6) {
+    // Subsquare letters: A–X (24 divisions per axis)
+    const s0 = g.charCodeAt(4) - 65;
+    const s1 = g.charCodeAt(5) - 65;
+    if (s0 < 0 || s0 > 23 || s1 < 0 || s1 > 23) return null;
+    lon = lon1 + lon2 + s0 * (2 / 24) + 1 / 24;
+    lat = lat1 + lat2 + s1 * (1 / 24) + 1 / 48;
   }
+
   return { lat, lon };
 };
 


### PR DESCRIPTION
## What does this PR do?

- parseGridSquare now rejects anything that is not exactly 4 or 6 chars, so a 5-char input like JN58s no longer silently drops the 5th character
- Field letters are validated to A–R (0–17); out-of-range chars like Z previously produced coordinates outside ±90/±180 instead of null
- Subsquare letters are validated to A–X (0–23)
- Remove redundant React default import from DXGridInput.jsx (automatic JSX transform, consistent with the rest of the codebase)
- Drop the now-redundant style wrapper <div> around DXGridInput in DockableApp and ModernLayout; the same color/fontSize/fontWeight values are already passed via the style prop directly to the <input>

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## Checklist

- [x] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

