### PR TITLE
[bug] bug-set-default-theme-active

### DIFF
--- a/src/components/ThemeSelector.jsx
+++ b/src/components/ThemeSelector.jsx
@@ -1,6 +1,12 @@
+import { useEffect } from 'react';
+import { setActiveThemeButton } from '../theme/themeUtils';
 import { AVAILABLE_THEMES } from '../theme/themeConfig';
 
 export default function ThemeSelector({ id, theme, setTheme }) {
+  useEffect(() => {
+    setActiveThemeButton(theme);
+  }, []);
+
   return (
     <>
       <div id={id} style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: '8px' }}>

--- a/src/theme/themeUtils.js
+++ b/src/theme/themeUtils.js
@@ -1,5 +1,18 @@
 import { THEME_VARS } from './themeConfig';
 
+/* Add "active" class to theme button that is selected */
+export function setActiveThemeButton(selectorString) {
+  const allThemeButtons = document.querySelectorAll('.theme-select-button');
+  allThemeButtons.forEach((element) => {
+    element.classList.remove('active');
+  });
+
+  const activeButton = document.querySelector('.' + selectorString + '-theme-select-button');
+  if (activeButton) {
+    activeButton.classList.add('active');
+  }
+}
+
 /* Read CSS variables from the active theme */
 export function readCssVariables() {
   const styles = getComputedStyle(document.documentElement);

--- a/src/theme/useTheme.js
+++ b/src/theme/useTheme.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { loadConfig, saveConfig } from './themeStorage';
-import { readCssVariables, applyCustomTheme, applyPrebuiltTheme } from './themeUtils';
+import { setActiveThemeButton, readCssVariables, applyCustomTheme, applyPrebuiltTheme } from './themeUtils';
 
 export function useTheme() {
   const config = loadConfig();
@@ -32,15 +32,7 @@ export function useTheme() {
     }
     saveConfig({ theme });
 
-    const allThemeButtons = document.querySelectorAll('.theme-select-button');
-    allThemeButtons.forEach((element) => {
-      element.classList.remove('active');
-    });
-
-    const activeButton = document.querySelector('.' + theme + '-theme-select-button');
-    if (activeButton) {
-      activeButton.classList.add('active');
-    }
+    setActiveThemeButton(theme);
   }, [theme]);
 
   /* Custom edits */


### PR DESCRIPTION
## What does this PR do?

Sets active class for theme selector button for the first DOM render of the theme selector component.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Clear local storage and load the site
2. Open the settings panel and select the Display tab
3. Confirm that there is a theme button with "active" class styling

## Checklist

- [X] App loads without console errors
- [X] Tested in **Dark**, **Light**, and **Retro** themes
- [X] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [X] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<img width="745" height="196" alt="Screenshot 2026-03-01 at 12 13 27 AM" src="https://github.com/user-attachments/assets/8a04388a-494c-4088-a1b4-306c24d85853" />

<img width="749" height="193" alt="Screenshot 2026-03-01 at 12 14 30 AM" src="https://github.com/user-attachments/assets/554407a9-32ea-4eec-a00b-b896a2be40d5" />

