### PR TITLE
Fix/setup pi bookworm trixie

### DIFF
--- a/README.md
+++ b/README.md
@@ -822,13 +822,21 @@ To find your local IP: run `ipconfig` (Windows) or `ifconfig` / `ip addr` (Mac/L
 
 One-line install for Raspberry Pi (3B, 3B+, 4, 5). Supports both graphical and headless operation.
 
+**Supported operating systems:**
+
+| OS                       | Debian | Status                 | Display              |
+| ------------------------ | ------ | ---------------------- | -------------------- |
+| Raspberry Pi OS Bookworm | 12     | ✅ Recommended         | X11 (openbox / LXDE) |
+| Raspberry Pi OS Trixie   | 13     | ✅ Supported           | Wayland (labwc)      |
+| Raspberry Pi OS Bullseye | 11     | ⚠️ Legacy, best-effort | X11                  |
+
 **Standard install (kiosk mode — auto-starts fullscreen on boot):**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/accius/openhamclock/main/scripts/setup-pi.sh | bash -s -- --kiosk
 ```
 
-This is the recommended option for a dedicated shack display. The Pi boots directly into a fullscreen Chromium browser showing OpenHamClock. No desktop environment needed.
+This is the recommended option for a dedicated shack display. The Pi boots directly into a fullscreen Chromium browser showing OpenHamClock. The kiosk launcher automatically detects Wayland (Trixie/labwc) or X11 (Bookworm/LXDE) and adjusts accordingly — no manual configuration needed.
 
 **Server-only install (headless, no GUI):**
 
@@ -847,12 +855,13 @@ curl -fsSL https://raw.githubusercontent.com/accius/openhamclock/main/scripts/se
 After installation, configure your station:
 
 ```bash
-cd ~/openhamclock
-nano .env          # Set your callsign and locator
-./restart.sh       # Apply changes
+nano ~/openhamclock/.env              # Set CALLSIGN and LOCATOR
+sudo systemctl restart openhamclock   # Apply changes
 ```
 
-The Pi setup script installs Node.js 20, clones the repository, builds the frontend, creates a systemd service (`openhamclock.service`) for automatic startup, and optionally configures Chromium in kiosk mode. It also installs `fonts-noto-color-emoji` so that all emoji icons display correctly in Chromium.
+The setup script creates `.env` automatically from the built-in template and enables server-side settings sync (`SETTINGS_SYNC=true`) for Pi installs. This means your `CALLSIGN` and `LOCATOR` values from `.env` appear on screen as soon as the service restarts — no manual UI configuration step required.
+
+The Pi setup script installs Node.js 22 LTS, clones the repository, builds the frontend, creates a systemd service (`openhamclock.service`) for automatic startup, and optionally configures Chromium in kiosk mode. It also installs `fonts-noto-color-emoji` so that all emoji icons display correctly in Chromium.
 
 ### Docker
 
@@ -1214,6 +1223,9 @@ sudo apt install fonts-noto-color-emoji
 ```
 
 Then restart your browser (or reboot if running in kiosk mode). The Raspberry Pi setup script now installs this automatically. On Windows and macOS, emoji fonts are bundled with the OS and no action is needed.
+
+**Q: Chromium shows a "keyring" unlock prompt on every boot in kiosk mode — how do I prevent it?**
+A: This happens when Chromium tries to use the system keyring (gnome-keyring / kwallet) to protect its internal credential store, but the desktop session manager hasn't unlocked it yet. The Pi setup script already passes `--password-store=basic` to Chromium, which tells it to use a plain local store instead and avoids the prompt entirely. If you installed OpenHamClock before this fix was included, update your `kiosk.sh` by re-running the setup script, or add `--password-store=basic` manually to the Chromium launch line in `~/openhamclock/kiosk.sh`.
 
 ---
 

--- a/scripts/setup-pi.sh
+++ b/scripts/setup-pi.sh
@@ -177,7 +177,13 @@ check_raspberry_pi() {
 update_system() {
     echo -e "${BLUE}>>> Updating system packages...${NC}"
     sudo apt-get update -qq
-    sudo apt-get upgrade -y -qq
+    # DEBIAN_FRONTEND=noninteractive suppresses dpkg interactive prompts.
+    # --force-confold keeps existing config files when a package ships a new version
+    # (e.g. rpi-chromium-mods updating master_preferences).
+    # --force-confdef handles any remaining unset choices with the package default.
+    sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y -qq \
+        -o Dpkg::Options::="--force-confold" \
+        -o Dpkg::Options::="--force-confdef"
 }
 
 # Install Node.js
@@ -263,8 +269,15 @@ setup_repository() {
         cp .env.example .env
         # Switch to the production port used by the systemd service and kiosk
         sed -i 's/^PORT=3001$/PORT=3000/' .env
+        # Enable server-side settings sync for Pi (single-user kiosk deployment).
+        # With SETTINGS_SYNC=true the UI reads/writes its settings (callsign, locator,
+        # layout, theme, etc.) from the server instead of browser localStorage.
+        # This means editing CALLSIGN and LOCATOR in .env and restarting the service
+        # is enough to update what is shown on screen — no manual UI step required.
+        sed -i 's/^SETTINGS_SYNC=false$/SETTINGS_SYNC=true/' .env
         echo -e "${YELLOW}⚠ A default .env file has been created at $INSTALL_DIR/.env${NC}"
-        echo -e "${YELLOW}  Edit it to set your CALLSIGN and LOCATOR before starting.${NC}"
+        echo -e "${YELLOW}  Edit CALLSIGN and LOCATOR in $INSTALL_DIR/.env, then run:${NC}"
+        echo -e "${YELLOW}  sudo systemctl restart openhamclock${NC}"
     else
         echo -e "${GREEN}✓ Existing .env kept — not overwritten${NC}"
     fi
@@ -428,6 +441,7 @@ $CHROME_CMD \
     --disable-component-update \
     --overscroll-history-navigation=0 \
     --disable-pinch \
+    --password-store=basic \
     --user-data-dir="$HOME/.config/openhamclock-kiosk" \
     $CHROMIUM_EXTRA_FLAGS \
     http://localhost:3000 &


### PR DESCRIPTION
## What does this PR do?

## Summary

Fixes: https://github.com/accius/openhamclock/issues/636

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

### fix(setup-pi): support Raspberry Pi OS Bookworm and Trixie

- Bump Node.js from 20 to 22 LTS — NodeSource 20.x has no Trixie packages and Node 20 is insufficient to build the frontend
- Add error message when NodeSource setup script fails
- Resolve node binary path at install time (`command -v node`) so the systemd service works with nvm-installed Node, not just `/usr/bin/node`
- Fix `do_blanking` argument: was `1` (enable), now `0` (disable) for kiosk
- Fix boot config path: check `/boot/firmware/config.txt` first (Bookworm/Trixie/Pi5), fall back to `/boot/config.txt` (Bullseye and older)
- Create `.env` from `.env.example` if missing, patching `PORT` to `3000` so the service, `start.sh` and kiosk all agree on the same port
- Rewrite `kiosk.sh` to detect Wayland vs X11 at runtime:
  - **Wayland** (Trixie/labwc): skips `xset`/`unclutter`, adds `--ozone-platform=wayland` to Chromium flags
  - **X11** (Bookworm/LXDE): sets `DISPLAY=:0` explicitly before `xset`/`unclutter`
- Add 60-second timeout with error message to the server health-check loop so `kiosk.sh` does not hang forever if the service failed to start

---

### docs(setup-pi): add comprehensive environment compatibility header

Added a full inline header to `setup-pi.sh` documenting:
- Supported hardware (Pi 3B/4/5)
- Supported OS versions (Bookworm/Trixie/Bullseye) with notes on display server and boot config path
- Explicitly unsupported environments (Ubuntu, Buster, Pi Zero in kiosk mode, Windows/macOS)
- Prerequisites (disk space, RAM, internet, sudo)
- Summary of what the script does step by step
- Kiosk mode Wayland-vs-X11 runtime behaviour

---

### fix(setup-pi): prevent interactive apt prompts, set SETTINGS_SYNC, fix keyring

Three issues reported by a tester running the script on Bookworm:

- **`apt-get upgrade` interactive prompt** — `rpi-chromium-mods` ships an updated `master_preferences` which dpkg stops to ask about. `DEBIAN_FRONTEND=noninteractive` plus `--force-confold`/`--force-confdef` are added so config-file conflicts are resolved silently without aborting the script.
- **CALLSIGN / LOCATOR from `.env` not shown on screen** — When creating `.env` from the template, `SETTINGS_SYNC=true` is now set automatically. The UI reads settings from the server instead of browser localStorage, so editing `.env` and running `sudo systemctl restart openhamclock` is all that is needed.
- **Chromium keyring unlock prompt on every kiosk boot** — `--password-store=basic` is added to the Chromium launch flags in `kiosk.sh`, telling Chromium to use a plain local credential store and avoiding the gnome-keyring / kwallet popup entirely.
- `README.md` updated: OS compatibility table, Node.js 20 → 22 LTS, Wayland/X11 auto-detection note, updated after-install instructions, `SETTINGS_SYNC` behaviour explained, new FAQ entry for the Chromium keyring prompt.

## Test plan

- [ ] Run `./setup-pi.sh --kiosk` on a clean Raspberry Pi OS **Bookworm** image — confirm no interactive dpkg prompts during `apt-get upgrade`
- [ ] Run `./setup-pi.sh --kiosk` on a clean Raspberry Pi OS **Trixie** image — confirm Chromium launches with Wayland flags
- [ ] After install, edit `CALLSIGN` and `LOCATOR` in `~/openhamclock/.env`, run `sudo systemctl restart openhamclock` — confirm values appear on screen without any extra UI step
- [ ] Reboot the Pi — confirm Chromium launches in kiosk mode without the keyring unlock dialog
- [ ] Confirm existing `.env` files are not overwritten on re-runs






