### PR TITLE
Feature 634 - Map Widgets Alignment

### DIFF
--- a/src/plugins/layers/addMinimizeToggle.js
+++ b/src/plugins/layers/addMinimizeToggle.js
@@ -6,7 +6,6 @@ export function addMinimizeToggle(element, storageKey, options = {}) {
   const {
     contentClassName = 'panel-content',
     buttonClassName = 'panel-minimize-btn',
-    titleColor = '#00b4ff',
     getIsMinimized,
     onToggle,
     persist = true,
@@ -25,16 +24,8 @@ export function addMinimizeToggle(element, storageKey, options = {}) {
   const header = element.firstElementChild;
   if (!header) return;
 
-  const existingTitle = header.querySelector('[data-drag-handle="true"]');
   const existingButton = header.querySelector(`.${buttonClassName}`);
   const existingWrapper = element.querySelector(`.${contentClassName}`);
-
-  if (existingTitle) {
-    existingTitle.style.fontFamily = "'JetBrains Mono', monospace";
-    existingTitle.style.fontSize = '13px';
-    existingTitle.style.fontWeight = '700';
-    existingTitle.style.color = titleColor;
-  }
 
   const readState = () => {
     if (typeof getIsMinimized === 'function') return !!getIsMinimized();
@@ -49,7 +40,8 @@ export function addMinimizeToggle(element, storageKey, options = {}) {
   const syncState = (button, wrapper) => {
     const isMinimized = readState();
     wrapper.style.display = isMinimized ? 'none' : 'block';
-    button.innerHTML = isMinimized ? '▶' : '▼';
+    button.innerHTML = '▶';
+    button.style.transform = isMinimized ? 'rotate(0deg)' : 'rotate(90deg)';
     element.style.cursor = isMinimized ? 'pointer' : 'default';
   };
 
@@ -68,7 +60,8 @@ export function addMinimizeToggle(element, storageKey, options = {}) {
           e.stopPropagation();
           const next = existingWrapper.style.display !== 'none';
           existingWrapper.style.display = next ? 'none' : 'block';
-          existingButton.innerHTML = next ? '▶' : '▼';
+          existingButton.innerHTML = '▶';
+          existingButton.style.transform = next ? 'rotate(90deg)' : 'rotate(0deg)';
           element.style.cursor = next ? 'pointer' : 'default';
           writeState(next);
         },
@@ -87,23 +80,14 @@ export function addMinimizeToggle(element, storageKey, options = {}) {
 
   const minimizeBtn = document.createElement('button');
   minimizeBtn.className = buttonClassName;
-  minimizeBtn.innerHTML = '▼';
+  minimizeBtn.innerHTML = '▶';
   minimizeBtn.style.cssText = `
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 16px;
-    min-width: 16px;
-    height: 16px;
-    background: none;
-    border: none;
-    color: #888;
     cursor: pointer;
     user-select: none;
-    padding: 2px 4px;
-    margin: 0;
-    font-size: 10px;
-    line-height: 1;
+    transform: rotate(0deg);
   `;
   minimizeBtn.title = 'Minimize/Maximize';
   minimizeBtn.addEventListener(
@@ -122,12 +106,6 @@ export function addMinimizeToggle(element, storageKey, options = {}) {
   title.textContent = header.textContent.replace(/[▼▶]/g, '').trim();
   title.dataset.dragHandle = 'true';
   title.style.flex = '1';
-  title.style.cursor = 'grab';
-  title.style.userSelect = 'none';
-  title.style.fontFamily = "'JetBrains Mono', monospace";
-  title.style.fontSize = '13px';
-  title.style.fontWeight = '700';
-  title.style.color = titleColor;
 
   header.textContent = '';
   header.appendChild(title);
@@ -141,7 +119,7 @@ export function addMinimizeToggle(element, storageKey, options = {}) {
       e.stopPropagation();
       const hidden = contentWrapper.style.display === 'none';
       contentWrapper.style.display = hidden ? 'block' : 'none';
-      minimizeBtn.innerHTML = hidden ? '▼' : '▶';
+      minimizeBtn.style.transform = hidden ? 'rotate(90deg)' : 'rotate(0deg)';
       element.style.cursor = hidden ? 'default' : 'pointer';
       writeState(!hidden);
     },

--- a/src/plugins/layers/makeDraggable.js
+++ b/src/plugins/layers/makeDraggable.js
@@ -157,6 +157,7 @@ export function makeDraggable(
     (e) => {
       if (e.button !== 0) return;
       isDragging = true;
+      updateCursor();
       didDrag = false;
       startX = e.clientX;
       startY = e.clientY;
@@ -178,6 +179,10 @@ export function makeDraggable(
     (e) => {
       if (!isDragging) return;
 
+      if (!didDrag && (Math.abs(e.clientX - startX) > 2 || Math.abs(e.clientY - startY) > 2)) {
+        didDrag = true;
+      }
+
       let nextLeft = startLeft + (e.clientX - startX);
       let nextTop = startTop + (e.clientY - startY);
 
@@ -198,7 +203,8 @@ export function makeDraggable(
       if (!isDragging) return;
       isDragging = false;
       el.style.opacity = '1';
-      updateCursor(e);
+      el.style.transition = previousTransition;
+      updateCursor();
       suppressClick = didDrag;
 
       if (snap) {

--- a/src/plugins/layers/useGrayLine.js
+++ b/src/plugins/layers/useGrayLine.js
@@ -288,23 +288,12 @@ export function useLayer({ enabled = false, opacity = 0.5, map = null }) {
       onAdd: function () {
         const panelWrapper = L.DomUtil.create('div', 'panel-wrapper');
         const container = L.DomUtil.create('div', 'grayline-control', panelWrapper);
-        container.style.cssText = `
-          background: var(--bg-panel);
-          border-radius: 5px;
-          font-family: 'JetBrains Mono', monospace;
-          font-size: 11px;
-          color: var(--text-primary);
-          border: 1px solid var(--border-color);
-          box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-          min-width: 200px;
-          max-width: 280px;
-        `;
 
         const now = new Date();
         const timeStr = now.toUTCString();
 
         container.innerHTML = `
-          <div style="font-family: 'JetBrains Mono', monospace; font-weight: 700; margin: 0; padding: 10px; font-size: 13px; color: #00b4ff;">🌅 Gray Line</div>
+          <div class="floating-panel-header">🌅 Gray Line</div>
 
           <div style="margin-bottom: 8px; padding: 8px; background: var(--bg-tertiary); border-radius: 3px;">
             <div style="font-size: 9px; opacity: 0.7; margin-bottom: 2px;">UTC TIME</div>

--- a/src/plugins/layers/useLightning.js
+++ b/src/plugins/layers/useLightning.js
@@ -446,17 +446,9 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
         console.log('[Lightning] StatsControl onAdd called');
         const panelWrapper = L.DomUtil.create('div', 'panel-wrapper');
         const div = L.DomUtil.create('div', 'lightning-stats', panelWrapper);
-        div.style.cssText = `
-          background: var(--bg-panel);
-          border-radius: 5px;
-          border: 1px solid var(--border-color);
-          font-family: 'JetBrains Mono', monospace;
-          font-size: 11px;
-          color: var(--text-primary);
-          min-width: 180px;
-        `;
+
         div.innerHTML = `
-          <div data-drag-handle="true" style="font-family: 'JetBrains Mono', monospace; font-weight: 700; font-size: 13px; margin: 0; padding: 10px; cursor: grab; user-select: none; color: #00b4ff;">⚡️ Lightning Activity</div>
+          <div class="floating-panel-header">⚡️ Lightning Activity</div>
           <div style="opacity: 0.7; font-size: 10px;">Connecting...</div>
         `;
 
@@ -694,19 +686,9 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
       onAdd: function () {
         const panelWrapper = L.DomUtil.create('div', 'panel-wrapper');
         const div = L.DomUtil.create('div', 'lightning-proximity', panelWrapper);
-        div.style.cssText = `
-          background: var(--bg-panel);
-          border-radius: 5px;
-          font-family: 'JetBrains Mono', monospace;
-          font-size: 11px;
-          color: var(--text-primary);
-          border: 1px solid var(--border-color);
-          box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-          min-width: 200px;
-          max-width: 280px;
-        `;
+
         div.innerHTML =
-          '<div style="font-family: \'JetBrains Mono\', monospace; font-weight: 700; margin: 0; padding: 10px; font-size: 13px; color: #00b4ff;">📍 Nearby Strikes (30km)</div><div style="opacity: 0.7; font-size: 10px; text-align: center;">No recent strikes</div>';
+          '<div class="floating-panel-header">📍 Nearby Strikes (30km)</div><div style="opacity: 0.7; font-size: 10px; text-align: center;">No recent strikes</div>';
 
         // Prevent map interaction
         L.DomEvent.disableClickPropagation(div);

--- a/src/plugins/layers/useMUFMap.js
+++ b/src/plugins/layers/useMUFMap.js
@@ -298,19 +298,10 @@ export function useLayer({ map, enabled, opacity }) {
       onAdd: function () {
         const panelWrapper = L.DomUtil.create('div', 'panel-wrapper');
         const container = L.DomUtil.create('div', 'muf-map-control', panelWrapper);
-        container.style.cssText = `
-          background: var(--bg-panel);
-          border-radius: 5px;
-          font-family: 'JetBrains Mono', monospace;
-          font-size: 11px;
-          color: var(--text-primary);
-          border: 1px solid var(--border-color);
-          box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-          min-width: 200px;
-          backdrop-filter: blur(8px);
-        `;
 
-        container.innerHTML = `<div style="font-family: 'JetBrains Mono', monospace; font-weight: 700; margin: 0; padding: 10px; font-size: 13px; color: #00b4ff;">📡 MUF Map</div>
+        container.innerHTML = `
+            <div class="floating-panel-header">📡 MUF Map</div>
+
               <div style="
                 display: flex; align-items: center; gap: 2px;
                 background: var(--bg-tertiary); border-radius: 4px; padding: 6px;

--- a/src/plugins/layers/useN3FJPLoggedQSOs.js
+++ b/src/plugins/layers/useN3FJPLoggedQSOs.js
@@ -84,19 +84,9 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
       onAdd: function () {
         const panelWrapper = L.DomUtil.create('div', 'panel-wrapper');
         const div = L.DomUtil.create('div', 'n3fjp-control', panelWrapper);
-        div.style.cssText = `
-          background: var(--bg-panel);
-          border-radius: 5px;
-          font-family: 'JetBrains Mono', monospace;
-          font-size: 11px;
-          color: var(--text-primary);
-          border: 1px solid var(--border-color);
-          box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-          min-width: 200px;
-          max-width: 280px;
-        `;
+
         div.innerHTML = `
-        <div style="font-family: 'JetBrains Mono', monospace; font-weight: 700; margin: 0; padding: 10px; font-size: 13px; color: #00b4ff;">🗺️ N3FJP Logged QSOs</div>
+        <div class="floating-panel-header">🗺️ N3FJP Logged QSOs</div>
 
           <div id="n3fjp-stats" style="display: grid; gap: 4px;">
             <div>QSOs: <span style="color: var(--accent-cyan);">${qsos.length}</span></div>

--- a/src/plugins/layers/useRBN.js
+++ b/src/plugins/layers/useRBN.js
@@ -462,18 +462,11 @@ export function useLayer({
         const panelWrapper = L.DomUtil.create('div', 'panel-wrapper');
         const div = L.DomUtil.create('div', 'rbn-control', panelWrapper);
         div.style.cssText = `
-          background: var(--bg-panel);
-          border-radius: 5px;
-          font-family: 'JetBrains Mono', monospace;
-          font-size: 11px;
-          color: var(--text-primary);
-          border: 1px solid var(--border-color);
-          box-shadow: 0 2px 8px rgba(0,0,0,0.3);
           min-width: 250px;
           max-width: 300px;
         `;
         div.innerHTML = `
-        <div style="font-family: 'JetBrains Mono', monospace; font-weight: 700; margin: 0; padding: 10px; font-size: 13px; color: #00b4ff;">📡 RBN: ${callsign}</div>
+        <div class="floating-panel-header">📡 RBN: ${callsign}</div>
 
           <div id="rbn-stats-display" style="margin-bottom: 8px; color: var(--text-secondary);">
           Spots: <strong>0</strong> | Skimmers: <strong>0</strong><br>

--- a/src/plugins/layers/useVOACAPHeatmap.js
+++ b/src/plugins/layers/useVOACAPHeatmap.js
@@ -211,20 +211,8 @@ export function useLayer({ map, enabled, opacity, locator }) {
           .map((p) => `<option value="${p}" ${p === propPower ? 'selected' : ''}>${p}W</option>`)
           .join('');
 
-        container.style.cssText = `
-          background: var(--bg-panel);
-          border-radius: 5px;
-          font-family: 'JetBrains Mono', monospace;
-          font-size: 11px;
-          color: var(--text-primary);
-          border: 1px solid var(--border-color);
-          box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-          min-width: 200px;
-          max-width: 280px;
-        `;
-
         container.innerHTML = `
-            <div style="font-family: 'JetBrains Mono', monospace; font-weight: 700; margin: 0; padding: 10px; font-size: 13px; color: #00b4ff;">🌐 VOACAP Heatmap</div>
+            <div class="floating-panel-header">🌐 VOACAP Heatmap</div>
 
               <div style="margin-bottom: 6px;">
                 <label style="color: var(--text-secondary); font-size: 10px;">Band</label>

--- a/src/plugins/layers/useWSPR.js
+++ b/src/plugins/layers/useWSPR.js
@@ -401,20 +401,10 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
       onAdd: function () {
         const panelWrapper = L.DomUtil.create('div', 'panel-wrapper');
         const container = L.DomUtil.create('div', 'wspr-filter-control', panelWrapper);
-        container.style.cssText = `
-          background: var(--bg-panel);
-          border-radius: 5px;
-          font-family: 'JetBrains Mono', monospace;
-          font-size: 11px;
-          color: var(--text-primary);
-          border: 1px solid var(--border-color);
-          box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-          min-width: 200px;
-          max-width: 280px;
-        `;
 
         container.innerHTML = `
-          <div style="font-family: 'JetBrains Mono', monospace; font-weight: 700; margin: 0; padding: 10px; font-size: 13px; color: #00b4ff;">🎛️ Filters</div>
+          <div class="floating-panel-header">🎛️ Filters</div>
+
           <div style="margin-bottom: 8px;">
             <label style="display: block; margin-bottom: 3px;">Band:</label>
             <select id="wspr-band-filter" style="width: 100%; padding: 4px; background: var(--bg-tertiary); color: var(--text-primary); border: 1px solid var(--border-color); border-radius: 3px;">
@@ -596,19 +586,10 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
       onAdd: function () {
         const panelWrapper = L.DomUtil.create('div', 'panel-wrapper');
         const div = L.DomUtil.create('div', 'wspr-stats', panelWrapper);
-        div.style.cssText = `
-          background: var(--bg-panel);
-          border-radius: 5px;
-          font-family: 'JetBrains Mono', monospace;
-          font-size: 11px;
-          color: var(--text-primary);
-          border: 1px solid var(--border-color);
-          box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-          min-width: 200px;
-          max-width: 280px;
-        `;
+
         div.innerHTML = `
-          <div style="font-family: 'JetBrains Mono', monospace; font-weight: 700; margin: 0; padding: 10px; font-size: 13px; color: #00b4ff;">📊 WSPR Activity</div>
+          <div class="floating-panel-header">📊 WSPR Activity</div>
+
           <div style="margin-bottom: 8px; padding: 6px; background: var(--bg-tertiary); border-radius: 3px;">
             <div style="font-size: 10px; opacity: 0.8; margin-bottom: 2px;">Propagation Score</div>
             <div style="font-size: 18px; font-weight: bold; color: var(--text-muted);">--/100</div>
@@ -663,19 +644,10 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
       onAdd: function () {
         const panelWrapper = L.DomUtil.create('div', 'panel-wrapper');
         const div = L.DomUtil.create('div', 'wspr-legend', panelWrapper);
-        div.style.cssText = `
-          background: var(--bg-panel);
-          border-radius: 5px;
-          font-family: 'JetBrains Mono', monospace;
-          font-size: 11px;
-          color: var(--text-primary);
-          border: 1px solid var(--border-color);
-          box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-          min-width: 200px;
-          max-width: 280px;
-        `;
+
         div.innerHTML = `
-          <div style="font-family: 'JetBrains Mono', monospace; font-weight: 700; margin: 0; padding: 10px; font-size: 13px; color: #00b4ff;">📡 Signal Strength</div>
+          <div class="floating-panel-header">📡 Signal Strength</div>
+
           <div><span style="color: var(--accent-green);">●</span> Excellent (&gt; 5 dB)</div>
           <div><span style="color: var(--accent-green-dim);">●</span> Good (0 to 5 dB)</div>
           <div><span style="color: var(--accent-amber);">●</span> Moderate (-10 to 0 dB)</div>
@@ -724,19 +696,9 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
       onAdd: function () {
         const panelWrapper = L.DomUtil.create('div', 'panel-wrapper');
         const div = L.DomUtil.create('div', 'wspr-chart', panelWrapper);
-        div.style.cssText = `
-          background: var(--bg-panel);
-          border-radius: 5px;
-          font-family: 'JetBrains Mono', monospace;
-          font-size: 11px;
-          color: var(--text-primary);
-          border: 1px solid var(--border-color);
-          box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-          min-width: 200px;
-          max-width: 280px;
-        `;
+
         div.innerHTML =
-          '<div style="font-family: \'JetBrains Mono\', monospace; font-weight: 700; margin: 0; padding: 10px; font-size: 13px; color: #00b4ff;">📊 Band Activity</div><div style="opacity: 0.7;">Loading...</div>';
+          '<div class="floating-panel-header">📊 Band Activity</div><div style="opacity: 0.7;">Loading...</div>';
 
         // Prevent map interaction when clicking/dragging on this control
         L.DomEvent.disableClickPropagation(div);
@@ -1148,7 +1110,8 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
         } else {
           // Initial render before minimize toggle is added
           statsContainer.innerHTML = `
-            <div style="font-family: 'JetBrains Mono', monospace; font-weight: 700; margin-bottom: 6px; font-size: 13px; color: #00b4ff;">📊 WSPR Activity</div>
+            <div class="floating-panel-header">📊 WSPR Activity</div>
+
             ${contentHTML}
           `;
         }
@@ -1194,7 +1157,8 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
         } else {
           // Initial render before minimize toggle is added
           chartContainer.innerHTML = `
-            <div style="font-family: 'JetBrains Mono', monospace; font-weight: 700; margin-bottom: 6px; font-size: 13px; color: #00b4ff;">📊 Band Activity</div>
+            <div class="floating-panel-header">📊 Band Activity</div>
+
             ${chartContentHTML}
           `;
         }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -490,6 +490,51 @@ body::before {
 }
 
 /* ============================================
+   Leaflet Control Panels
+   ============================================ */
+.panel-wrapper > div {
+  transition: all 0.3s ease;
+  background: var(--bg-panel);
+  border-radius: 5px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  min-width: 200px;
+  max-width: 280px;
+}
+
+.panel-wrapper > div:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4) !important;
+}
+
+.panel-wrapper > div .floating-panel-header {
+  user-select: none;
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 700;
+  margin: 0;
+  padding: 10px;
+  font-size: 13px;
+  color: var(--accent-cyan);
+  letter-spacing: 0.5px;
+}
+
+/* minimize toggle */
+.panel-wrapper > div .floating-panel-header button {
+  color: var(--text-secondary);
+  width: 1em;
+  min-width: 1em;
+  height: 1em;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font-size: 1.1em;
+  line-height: 1em;
+}
+
+/* ============================================
    DX CLUSTER MAP TOOLTIPS
    ============================================ */
 .dx-tooltip {
@@ -599,7 +644,6 @@ body::before {
 }
 
 /* Theme controls */
-
 #theme-selector-component .theme-select-button {
   padding: 10px;
   background: var(--bg-tertiary);
@@ -702,21 +746,6 @@ body::before {
 
 .wspr-marker {
   animation: wspr-marker-pulse 2s ease-in-out infinite;
-}
-
-/* Control panel transitions */
-.wspr-filter-control,
-.wspr-stats,
-.wspr-legend,
-.wspr-chart {
-  transition: all 0.3s ease;
-}
-
-.wspr-filter-control:hover,
-.wspr-stats:hover,
-.wspr-legend:hover,
-.wspr-chart:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4) !important;
 }
 
 /* Filter input styles */
@@ -864,9 +893,6 @@ body::before {
 /* No animation for regular earthquake markers */
 .earthquake-marker {
   /* Static, no animation */
-}
-
-.lightning-proximity {
 }
 
 /* Lightning strike animations */


### PR DESCRIPTION
## What does this PR do?

This PR affects all draggable map layers. 

- Add a snap grid to assist with item control alignment
- Address the margins used by Leaflet for corner positioning by placing controls in a div.panelWrapper 
- Remove the position translation used by the element's hover state for useWSPR.js
- Updated panel structure for several layers and changed to using standard theme variables for styles
- Removed margin and added padding for grab handle in order to allow a larger target area for dragging panels
- Lightning: "nearby strikes" was setting initial position centered, but that used transform which was not changed when draggable, resulting in large jumps after mouseup
- Control styles were all adapted to use color variables

Layers updated...

- WSPR
- VOACAP Heatmap
- RBN
- N3FJP Logged QSOs
- MUF Map
- Lightning
- Gray Line

## Type of change

- [X] Bug fix
- [X] New feature
- [ ] Performance improvement
- [X] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Activate any map layer that has a panel control
2. Confirm dragging to reposition, with no changes after mouseup or reload
3. Confirm double-clicking header to reset position to default
4. Confirm show / hide of panel contents
5. Confirm theme consistency for all panel elements

## Checklist

- [X] App loads without console errors
- [X] Tested in **Dark**, **Light**, **Legacy**, and **Retro** themes
- [X] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [X] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

**BEFORE**

<img width="1075" height="373" alt="556042139-3342f0d8-2674-47c4-a585-342dee94fd1c" src="https://github.com/user-attachments/assets/2fa99ac2-97c2-4e72-b20d-46d5834bcfe0" />

**AFTER**

<img width="1279" height="894" alt="Screenshot 2026-03-03 014011" src="https://github.com/user-attachments/assets/f0220350-342a-4da4-adf2-11b0130dc04b" />

<img width="1317" height="813" alt="Screenshot 2026-03-03 013733" src="https://github.com/user-attachments/assets/f3373380-ba75-452f-a1b5-9eac002a2d6d" />

This PR addresses issue #634 .