### PR TITLE
Fix lightning map layer timestamps

### DIFF
--- a/src/plugins/layers/useLightning.js
+++ b/src/plugins/layers/useLightning.js
@@ -14,7 +14,7 @@ export const metadata = {
   category: 'weather',
   defaultEnabled: false,
   defaultOpacity: 0.9,
-  version: '2.0.0',
+  version: '2.0.1',
 };
 
 // LZW decompression - Blitzortung uses LZW compression for WebSocket data
@@ -81,7 +81,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
 
   // Low memory mode limits
   const MAX_STRIKES = lowMemoryMode ? 100 : 500;
-  const STRIKE_RETENTION_MS = lowMemoryMode ? 60000 : 300000; // 1 min vs 5 min
+  const STRIKE_RETENTION_MS = 1800000; // 30 min
 
   // Fetch WebSocket key from Blitzortung (fallback to 111)
   useEffect(() => {
@@ -131,8 +131,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
                 id: `strike_${data.time}_${data.lat}_${data.lon}`,
                 lat: parseFloat(data.lat),
                 lon: parseFloat(data.lon),
-                timestamp: parseInt(data.time),
-                age: (Date.now() - parseInt(data.time)) / 1000,
+                timestamp: parseInt(data.time / 1000000),
                 intensity: Math.abs(data.pol || 0),
                 polarity: (data.pol || 0) >= 0 ? 'positive' : 'negative',
                 altitude: data.alt || 0,
@@ -245,12 +244,14 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
 
     const newMarkers = [];
     const currentStrikeIds = new Set();
+    const now = Date.now();
 
     lightningData.forEach((strike) => {
-      const { id, lat, lon, age, intensity, polarity } = strike;
+      const { id, lat, lon, timestamp, intensity, polarity } = strike;
 
       currentStrikeIds.add(id);
-      const ageMinutes = age / 60;
+      const ageSeconds = (now - timestamp) / 1000;
+      const ageMinutes = ageSeconds / 60;
 
       // Only animate NEW strikes (not seen before)
       const isNewStrike = !previousStrikeIds.current.has(id);
@@ -303,7 +304,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
       });
 
       // Popup with strike details
-      const ageStr = ageMinutes < 1 ? `${Math.round(age)}s ago` : `${Math.round(ageMinutes)}m ago`;
+      const ageStr = ageMinutes < 1 ? `${Math.round(ageSeconds)}s ago` : `${Math.round(ageMinutes)}m ago`;
 
       marker.bindPopup(`
         <div style="font-family: 'JetBrains Mono', monospace; font-size: 12px;">


### PR DESCRIPTION
## What does this PR do?

Primarily this updates the Lightning Map Layer to convert the nanosecond timestamp from Blitzortung, to a millisecond timestamp so it's consistent with the rest of the JS, After that it refactors some related code,

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Activate Lightning Layer
2. View the Lightning Activity panel and see numbers show up in the "Recent (<5 min)" section
3. Click the Lightning Strike indicators and see the Time label make sense

## Checklist

- [x] App loads without console errors
- [x] Tested in **Dark**, **Light**, and **Retro** themes
- [x] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [x] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [x] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

Before

<img width="219" height="222" alt="image" src="https://github.com/user-attachments/assets/6ac0b613-a69a-4dde-a34f-211f498d9a5e" />
<img width="245" height="110" alt="image" src="https://github.com/user-attachments/assets/746aa463-6831-4ff8-b31b-c19f2f48ded4" />

After

<img width="220" height="221" alt="image" src="https://github.com/user-attachments/assets/3b7c8052-efe9-4448-9893-67e63e4f5474" />
<img width="241" height="103" alt="image" src="https://github.com/user-attachments/assets/4be18a1f-a573-49e9-a74b-d4dbc47f2cb1" />