### PR TITLE
docs: clarify contributor setup and staging PR workflow, Fixes #663

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,16 +10,14 @@ Thank you for helping build OpenHamClock! Whether you're fixing a bug, adding a 
 # 1. Fork and clone
 git clone https://github.com/YOUR_USERNAME/openhamclock.git
 cd openhamclock
+npm ci
 git checkout Staging
 
-# 2. Install dependencies
-npm install
-
-# 3. Start the backend (Terminal 1)
+# 2. Start the backend (Terminal 1)
 node server.js
 # → Server running on http://localhost:3001
 
-# 4. Start the frontend dev server (Terminal 2)
+# 3. Start the frontend dev server (Terminal 2)
 npm run dev
 # → App running on http://localhost:3000 (proxies API to :3001)
 ```
@@ -113,7 +111,7 @@ docs/update-readme
 
 We use **Prettier** to enforce consistent formatting across the codebase. This eliminates quote style, indentation, and whitespace noise from PRs so code review can focus on logic.
 
-**It happens automatically:** If you run `npm install`, a git pre-commit hook (via Husky + lint-staged) will auto-format any staged files before each commit. You don't need to think about it.
+**It happens automatically:** After you run `npm ci`, a git pre-commit hook (via Husky + lint-staged) will auto-format any staged files before each commit. You don't need to think about it.
 
 **Manual commands:**
 
@@ -227,6 +225,7 @@ This repository uses shared formatting and dependency lock conventions so contri
 
 ```bash
 npm ci
+git checkout Staging
 npm run dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ OpenHamClock brings DX cluster spots, space weather, propagation predictions, PO
 ```bash
 git clone https://github.com/accius/openhamclock.git
 cd openhamclock
-npm install
+npm ci
 npm start
 ```
 
@@ -1266,10 +1266,14 @@ OpenHamClock is built by the ham radio community. We have 28+ contributors and g
 
 ```bash
 git clone https://github.com/accius/openhamclock.git
-cd openhamclock && npm install
+cd openhamclock
+git checkout Staging
+npm ci
 node server.js   # Terminal 1 — Backend on :3001
 npm run dev      # Terminal 2 — Frontend on :3000
 ```
+
+Open pull requests against `Staging`, not `main`.
 
 **Read first:**
 


### PR DESCRIPTION
Updated the root documentation to make the contributor workflow consistent and explicit. The setup instructions now tell contributors to use `npm ci` instead of `npm install`, and the contribution guidance now clearly states that all pull requests must be opened against the `Staging` branch rather than `main`. Fixes #663.