### PR TITLE
Add TCI/SDR plugin to rig-bridge + bump to v1.2.0

### DIFF
--- a/rig-bridge/README.md
+++ b/rig-bridge/README.md
@@ -18,6 +18,16 @@ Built on a **plugin architecture** — each radio integration is a standalone mo
 
 Also works with **Elecraft** radios (K3, K4, KX3, KX2) using the Kenwood plugin.
 
+### SDR Radios via TCI (WebSocket)
+
+TCI (Transceiver Control Interface) is a WebSocket-based protocol used by modern SDR applications. Unlike serial CAT, TCI **pushes** frequency, mode, and PTT changes in real-time — no polling, no serial port conflicts.
+
+| Application   | Radios                | Default TCI Port |
+| ------------- | --------------------- | ---------------- |
+| **Thetis**    | Hermes Lite 2, ANAN   | 40001            |
+| **ExpertSDR** | SunSDR2               | 40001            |
+| **SmartSDR**  | Flex (via TCI bridge) | varies           |
+
 ### Via Control Software (Legacy)
 
 | Software    | Protocol | Default Port |
@@ -75,6 +85,54 @@ node rig-bridge.js --debug       # Enable raw hex/ASCII CAT traffic logging
 1. Connect USB cable from radio to computer
 2. In Rig Bridge: Select **Kenwood**, pick COM port, baud **9600**, stop bits **1**
 
+### SDR Radios via TCI
+
+#### 1. Enable TCI in your SDR application
+
+**Thetis (HL2 / ANAN):** Setup → CAT Control → check **Enable TCI Server** (default port 40001)
+
+**ExpertSDR:** Settings → TCI → Enable (default port 40001)
+
+#### 2. Configure rig-bridge
+
+Edit `rig-bridge-config.json`:
+
+```json
+{
+  "radio": { "type": "tci" },
+  "tci": {
+    "host": "localhost",
+    "port": 40001,
+    "trx": 0,
+    "vfo": 0
+  }
+}
+```
+
+| Field  | Description                      | Default     |
+| ------ | -------------------------------- | ----------- |
+| `host` | Host running the SDR application | `localhost` |
+| `port` | TCI WebSocket port               | `40001`     |
+| `trx`  | Transceiver index (0 = primary)  | `0`         |
+| `vfo`  | VFO index (0 = VFO-A, 1 = VFO-B) | `0`         |
+
+#### 3. Run rig-bridge
+
+```bash
+node rig-bridge.js
+```
+
+You should see:
+
+```
+[TCI] Connecting to ws://localhost:40001...
+[TCI] ✅ Connected to ws://localhost:40001
+[TCI] Device: Thetis
+[TCI] Server ready
+```
+
+The bridge auto-reconnects every 5 s if the connection drops — just restart your SDR app and it will reconnect automatically.
+
 ---
 
 ## OpenHamClock Setup
@@ -109,15 +167,18 @@ Executables are output to the `dist/` folder.
 
 ## Troubleshooting
 
-| Problem                | Solution                                                                  |
-| ---------------------- | ------------------------------------------------------------------------- |
-| No COM ports found     | Install USB driver (Silicon Labs CP210x for Yaesu, FTDI for some Kenwood) |
-| Port opens but no data | Check baud rate matches radio's CAT Rate setting                          |
-| Icom not responding    | Verify CI-V address matches your radio model                              |
-| CORS errors in browser | The bridge allows all origins by default                                  |
-| Port already in use    | Close flrig/rigctld if running — you don't need them anymore              |
-| PTT not responsive     | Enable **Hardware Flow (RTS/CTS)** (especially for FT-991A/FT-710)        |
-| macOS Comms Failure    | The bridge automatically applies a `stty` fix for CP210x drivers.         |
+| Problem                   | Solution                                                                         |
+| ------------------------- | -------------------------------------------------------------------------------- |
+| No COM ports found        | Install USB driver (Silicon Labs CP210x for Yaesu, FTDI for some Kenwood)        |
+| Port opens but no data    | Check baud rate matches radio's CAT Rate setting                                 |
+| Icom not responding       | Verify CI-V address matches your radio model                                     |
+| CORS errors in browser    | The bridge allows all origins by default                                         |
+| Port already in use       | Close flrig/rigctld if running — you don't need them anymore                     |
+| PTT not responsive        | Enable **Hardware Flow (RTS/CTS)** (especially for FT-991A/FT-710)               |
+| macOS Comms Failure       | The bridge automatically applies a `stty` fix for CP210x drivers.                |
+| TCI: Connection refused   | Enable TCI in your SDR app (Thetis → Setup → CAT Control → Enable TCI Server)    |
+| TCI: No frequency updates | Check `trx` / `vfo` index in config match the active transceiver in your SDR app |
+| TCI: Remote SDR           | Set `tci.host` to the IP of the machine running the SDR application              |
 
 ---
 
@@ -159,7 +220,8 @@ rig-bridge/
     │   ├── protocol-kenwood.js# Kenwood ASCII protocol
     │   └── protocol-icom.js   # Icom CI-V binary protocol
     ├── rigctld.js         # rigctld TCP plugin
-    └── flrig.js           # flrig XML-RPC plugin
+    ├── flrig.js           # flrig XML-RPC plugin
+    └── tci.js             # TCI/SDR WebSocket plugin (Thetis, ExpertSDR, etc.)
 ```
 
 ---

--- a/rig-bridge/core/config.js
+++ b/rig-bridge/core/config.js
@@ -15,7 +15,7 @@ const DEFAULT_CONFIG = {
   debug: false, // Centralized verbose CAT logging flag
   logging: true, // Enable/disable console log capture & broadcast to UI
   radio: {
-    type: 'none', // none | yaesu | kenwood | icom | flrig | rigctld
+    type: 'none', // none | yaesu | kenwood | icom | flrig | rigctld | tci
     serialPort: '', // COM3, /dev/ttyUSB0, etc.
     baudRate: 38400,
     dataBits: 8,
@@ -32,6 +32,12 @@ const DEFAULT_CONFIG = {
     rigctldPort: 4532,
     flrigHost: '127.0.0.1',
     flrigPort: 12345,
+  },
+  tci: {
+    host: 'localhost',
+    port: 40001,
+    trx: 0, // transceiver index (0 = primary)
+    vfo: 0, // VFO index (0 = A, 1 = B)
   },
   wsjtxRelay: {
     enabled: false,
@@ -63,6 +69,7 @@ function loadConfig() {
         ...DEFAULT_CONFIG,
         ...raw,
         radio: { ...DEFAULT_CONFIG.radio, ...(raw.radio || {}) },
+        tci: { ...DEFAULT_CONFIG.tci, ...(raw.tci || {}) },
         wsjtxRelay: { ...DEFAULT_CONFIG.wsjtxRelay, ...(raw.wsjtxRelay || {}) },
         // Coerce logging to boolean in case the stored value is a string
         logging: raw.logging !== undefined ? !!raw.logging : DEFAULT_CONFIG.logging,

--- a/rig-bridge/core/plugin-registry.js
+++ b/rig-bridge/core/plugin-registry.js
@@ -47,7 +47,7 @@ class PluginRegistry {
     }
 
     // Single-export rig plugins
-    for (const file of ['rigctld', 'flrig', 'mock']) {
+    for (const file of ['rigctld', 'flrig', 'mock', 'tci']) {
       try {
         const p = require(`../plugins/${file}`);
         this._descriptors.set(p.id, p);

--- a/rig-bridge/core/server.js
+++ b/rig-bridge/core/server.js
@@ -244,6 +244,8 @@ function buildSetupHtml(version) {
     }
     .icom-addr { display: none; }
     .icom-addr.show { display: block; }
+    .tci-opts { display: none; }
+    .tci-opts.show { display: block; }
     .ohc-instructions {
       background: #0f1923;
       border: 1px dashed #2a3040;
@@ -389,6 +391,9 @@ function buildSetupHtml(version) {
             <option value="kenwood">Kenwood (TS-890, TS-590, TS-2000, etc.)</option>
             <option value="icom">Icom (IC-7300, IC-7610, IC-9700, IC-705, etc.)</option>
           </optgroup>
+          <optgroup label="SDR Radios (TCI)">
+            <option value="tci">TCI/SDR (Thetis, ExpertSDR, SunSDR2, etc.)</option>
+          </optgroup>
           <optgroup label="Via Control Software (Legacy)">
             <option value="flrig">flrig (XML-RPC)</option>
             <option value="rigctld">rigctld / Hamlib (TCP)</option>
@@ -455,6 +460,31 @@ function buildSetupHtml(version) {
               <input type="number" id="legacyPort" value="12345">
             </div>
           </div>
+        </div>
+
+        <!-- TCI/SDR options -->
+        <div class="tci-opts" id="tciOpts">
+          <div class="row">
+            <div>
+              <label>TCI Host</label>
+              <input type="text" id="tciHost" value="localhost" placeholder="localhost">
+            </div>
+            <div>
+              <label>TCI Port</label>
+              <input type="number" id="tciPort" value="40001" placeholder="40001" min="1" max="65535">
+            </div>
+          </div>
+          <div class="row">
+            <div>
+              <label>Transceiver (TRX)</label>
+              <input type="number" id="tciTrx" value="0" min="0" max="7" placeholder="0">
+            </div>
+            <div>
+              <label>VFO (0 = A, 1 = B)</label>
+              <input type="number" id="tciVfo" value="0" min="0" max="1" placeholder="0">
+            </div>
+          </div>
+          <div class="help-text">Enable TCI in your SDR app: Thetis → Setup → CAT Control → Enable TCI Server (port 40001)</div>
         </div>
 
         <div class="section-divider"></div>
@@ -684,6 +714,11 @@ function buildSetupHtml(version) {
         r.type === 'rigctld' ? (r.rigctldHost || '127.0.0.1') : (r.flrigHost || '127.0.0.1');
       document.getElementById('legacyPort').value =
         r.type === 'rigctld' ? (r.rigctldPort || 4532) : (r.flrigPort || 12345);
+      const tci = cfg.tci || {};
+      document.getElementById('tciHost').value = tci.host || 'localhost';
+      document.getElementById('tciPort').value = tci.port || 40001;
+      document.getElementById('tciTrx').value = tci.trx ?? 0;
+      document.getElementById('tciVfo').value = tci.vfo ?? 0;
       onTypeChange(true); // Don't overwrite loaded values with model defaults
     }
 
@@ -691,10 +726,12 @@ function buildSetupHtml(version) {
       const type = document.getElementById('radioType').value;
       const isDirect = ['yaesu', 'kenwood', 'icom'].includes(type);
       const isLegacy = ['flrig', 'rigctld'].includes(type);
+      const isTci = type === 'tci';
 
       document.getElementById('serialOpts').className = 'serial-opts' + (isDirect ? ' show' : '');
       document.getElementById('legacyOpts').className = 'legacy-opts' + (isLegacy ? ' show' : '');
       document.getElementById('icomAddr').className = 'icom-addr' + (type === 'icom' ? ' show' : '');
+      document.getElementById('tciOpts').className = 'tci-opts' + (isTci ? ' show' : '');
 
       if (!skipDefaults) {
         if (type === 'yaesu') {
@@ -787,11 +824,23 @@ function buildSetupHtml(version) {
         radio.flrigPort = parseInt(document.getElementById('legacyPort').value);
       }
 
+      const tci = {
+        host: document.getElementById('tciHost').value.trim() || 'localhost',
+        port: parseInt(document.getElementById('tciPort').value) || 40001,
+        trx: Math.max(0, parseInt(document.getElementById('tciTrx').value) || 0),
+        vfo: Math.max(0, parseInt(document.getElementById('tciVfo').value) || 0),
+      };
+
+      if (type === 'tci') {
+        if (!tci.host) return showToast('TCI host cannot be empty', 'error');
+        if (tci.port < 1 || tci.port > 65535) return showToast('TCI port must be 1–65535', 'error');
+      }
+
       try {
         const res = await fetch('/api/config', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ radio }),
+          body: JSON.stringify({ radio, tci }),
         });
         const data = await res.json();
         if (data.success) {
@@ -1059,6 +1108,9 @@ function createServer(registry, version) {
     }
     if (newConfig.wsjtxRelay) {
       config.wsjtxRelay = { ...config.wsjtxRelay, ...newConfig.wsjtxRelay };
+    }
+    if (newConfig.tci) {
+      config.tci = { ...config.tci, ...newConfig.tci };
     }
     // macOS: tty.* (dial-in) blocks open() — silently upgrade to cu.* (call-out)
     if (process.platform === 'darwin' && config.radio.serialPort?.startsWith('/dev/tty.')) {

--- a/rig-bridge/package-lock.json
+++ b/rig-bridge/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "openhamclock-rig-bridge",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openhamclock-rig-bridge",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "serialport": "^12.0.0",
+        "ws": "^8.14.2",
         "xmlrpc": "^1.3.2"
       },
       "bin": {
@@ -2745,6 +2746,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "8.2.2",

--- a/rig-bridge/package.json
+++ b/rig-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhamclock-rig-bridge",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Universal rig control bridge for OpenHamClock — plugin architecture supporting USB, flrig, rigctld, and more",
   "main": "rig-bridge.js",
   "bin": "rig-bridge.js",
@@ -24,6 +24,7 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "serialport": "^12.0.0",
+    "ws": "^8.14.2",
     "xmlrpc": "^1.3.2"
   },
   "devDependencies": {

--- a/rig-bridge/plugins/tci.js
+++ b/rig-bridge/plugins/tci.js
@@ -1,0 +1,284 @@
+'use strict';
+/**
+ * plugins/tci.js — TCI (Transceiver Control Interface) WebSocket plugin
+ *
+ * Connects to an SDR application's TCI server via WebSocket and provides
+ * real-time rig control without polling. TCI pushes frequency, mode, and
+ * PTT changes as they happen.
+ *
+ * Supported applications:
+ *   Thetis        — Hermes Lite 2, ANAN  (default port 40001)
+ *   ExpertSDR     — SunSDR2              (default port 40001)
+ *   SmartSDR      — Flex (via TCI bridge)
+ *
+ * Config key: config.tci  { host, port, trx, vfo }
+ *
+ * TCI reference: https://github.com/ExpertSDR3/TCI
+ */
+
+// TCI mode name → OpenHamClock mode name
+const TCI_MODES = {
+  am: 'AM',
+  sam: 'SAM',
+  dsb: 'DSB',
+  lsb: 'LSB',
+  usb: 'USB',
+  cw: 'CW',
+  nfm: 'FM',
+  wfm: 'WFM',
+  digl: 'DATA-LSB',
+  digu: 'DATA-USB',
+  spec: 'SPEC',
+  drm: 'DRM',
+};
+
+// OpenHamClock mode name → TCI mode name
+const TCI_MODES_REV = {};
+for (const [tci, ohc] of Object.entries(TCI_MODES)) {
+  TCI_MODES_REV[ohc] = tci;
+}
+
+module.exports = {
+  id: 'tci',
+  name: 'TCI/SDR (WebSocket)',
+  category: 'rig',
+  configKey: 'tci',
+
+  create(config, { updateState, state }) {
+    // Resolve WebSocket implementation: prefer 'ws' npm package (works inside
+    // pkg snapshots), fall back to Node 21+ built-in WebSocket.
+    let WS;
+    try {
+      WS = require('ws');
+    } catch {
+      if (typeof globalThis.WebSocket !== 'undefined') {
+        WS = globalThis.WebSocket;
+      } else {
+        console.error('[TCI] WebSocket library not available. Run: npm install ws');
+        WS = null;
+      }
+    }
+
+    const tciCfg = config.tci || {};
+    const trx = tciCfg.trx ?? 0;
+    const vfo = tciCfg.vfo ?? 0;
+    const host = tciCfg.host || 'localhost';
+    const port = tciCfg.port || 40001;
+    const url = `ws://${host}:${port}`;
+
+    let ws = null;
+    let reconnectTimer = null;
+    let wasExplicitlyDisconnected = false;
+    let msgBuffer = ''; // TCI messages end with ';', may arrive chunked
+
+    function parseMessage(msg) {
+      // Accumulate into buffer; split on ';' delimiter
+      msgBuffer += msg;
+      const parts = msgBuffer.split(';');
+      // Last element is either empty (complete) or a partial message
+      msgBuffer = parts.pop();
+
+      for (const raw of parts) {
+        const trimmed = raw.trim();
+        if (!trimmed) continue;
+
+        // Format: "name:arg1,arg2,..." or just "name"
+        const colonIdx = trimmed.indexOf(':');
+        const name = colonIdx >= 0 ? trimmed.slice(0, colonIdx).toLowerCase() : trimmed.toLowerCase();
+        const argStr = colonIdx >= 0 ? trimmed.slice(colonIdx + 1) : '';
+        const args = argStr ? argStr.split(',') : [];
+
+        switch (name) {
+          case 'vfo': {
+            // vfo:rx,sub_vfo,freq_hz
+            const rxIdx = parseInt(args[0]);
+            const vfoIdx = parseInt(args[1]);
+            if (rxIdx === trx && vfoIdx === vfo) {
+              const freq = parseInt(args[2]);
+              if (freq > 0 && state.freq !== freq) {
+                console.log(`[TCI] freq → ${(freq / 1e6).toFixed(6)} MHz`);
+                updateState('freq', freq);
+              }
+            }
+            break;
+          }
+          case 'modulation': {
+            // modulation:rx,mode_name
+            const rxIdx = parseInt(args[0]);
+            if (rxIdx === trx) {
+              const modeName = (args[1] || '').toLowerCase();
+              const ohcMode = TCI_MODES[modeName] || modeName.toUpperCase();
+              if (state.mode !== ohcMode) {
+                console.log(`[TCI] mode → ${ohcMode}`);
+                updateState('mode', ohcMode);
+              }
+            }
+            break;
+          }
+          case 'trx': {
+            // trx:rx,true|false  — transmit state
+            const rxIdx = parseInt(args[0]);
+            if (rxIdx === trx) {
+              const ptt = args[1] === 'true';
+              if (state.ptt !== ptt) {
+                console.log(`[TCI] PTT → ${ptt ? 'TX' : 'RX'}`);
+                updateState('ptt', ptt);
+              }
+            }
+            break;
+          }
+          case 'rx_filter_band': {
+            // rx_filter_band:rx,low_hz,high_hz
+            const rxIdx = parseInt(args[0]);
+            if (rxIdx === trx) {
+              const lo = parseInt(args[1]);
+              const hi = parseInt(args[2]);
+              const width = hi - lo;
+              if (width > 0 && state.width !== width) updateState('width', width);
+            }
+            break;
+          }
+          case 'protocol':
+            console.log(`[TCI] Server protocol: ${argStr}`);
+            break;
+          case 'device':
+            console.log(`[TCI] Device: ${argStr}`);
+            break;
+          case 'receive_only':
+            if (args[0] === 'true') {
+              console.log('[TCI] ⚠️  Radio is in receive-only mode (PTT disabled server-side)');
+            }
+            break;
+          case 'ready':
+            console.log('[TCI] Server ready');
+            break;
+          // Silently ignore high-volume / irrelevant TCI messages
+          case 'iq_samplerate':
+          case 'audio_samplerate':
+          case 'iq_start':
+          case 'iq_stop':
+          case 'audio_start':
+          case 'audio_stop':
+          case 'spot':
+          case 'drive':
+          case 'sql_enable':
+          case 'mute':
+          case 'rx_enable':
+          case 'sensors_enable':
+          case 'cw_macros_speed':
+          case 'volume':
+          case 'rx_smeter':
+            break;
+          default:
+            // Uncomment for debugging unknown TCI messages:
+            // console.log(`[TCI] Unhandled: ${trimmed}`);
+            break;
+        }
+      }
+    }
+
+    function send(data) {
+      if (!ws || ws.readyState !== 1 /* OPEN */) return false;
+      try {
+        ws.send(data);
+        return true;
+      } catch (e) {
+        console.error(`[TCI] Send error: ${e.message}`);
+        return false;
+      }
+    }
+
+    function scheduleReconnect() {
+      if (reconnectTimer || wasExplicitlyDisconnected) return;
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        connect(); // eslint-disable-line no-use-before-define
+      }, 5000);
+    }
+
+    function connect() {
+      if (ws || wasExplicitlyDisconnected) return;
+      if (!WS) return;
+
+      console.log(`[TCI] Connecting to ${url}...`);
+      try {
+        ws = new WS(url);
+      } catch (e) {
+        console.error(`[TCI] Connection failed: ${e.message}`);
+        scheduleReconnect();
+        return;
+      }
+
+      // Use addEventListener — works on both 'ws' npm lib AND Node 21+ native
+      // WebSocket. (.on() is ws-library-only and crashes with native WebSocket.)
+      ws.addEventListener('open', () => {
+        console.log(`[TCI] ✅ Connected to ${url}`);
+        msgBuffer = '';
+        updateState('connected', true);
+        // Initiate TCI session — server will send device info, then state dump
+        ws.send('start;');
+      });
+
+      ws.addEventListener('message', (evt) => {
+        // ws lib: evt is the data directly (string or Buffer)
+        // native WebSocket: evt is a MessageEvent with .data property
+        const raw = evt.data !== undefined ? evt.data : evt;
+        const msg = typeof raw === 'string' ? raw : raw.toString('utf8');
+        parseMessage(msg);
+      });
+
+      ws.addEventListener('error', (evt) => {
+        // 'error' fires before 'close' — just log; reconnect happens on 'close'
+        const err = evt.error || evt;
+        if (err && err.code === 'ECONNREFUSED') {
+          console.error('[TCI] Connection refused — is the SDR app running with TCI enabled?');
+        } else {
+          console.error(`[TCI] Error: ${(err && err.message) || 'connection error'}`);
+        }
+      });
+
+      ws.addEventListener('close', () => {
+        console.log('[TCI] Disconnected');
+        ws = null;
+        updateState('connected', false);
+        scheduleReconnect();
+      });
+    }
+
+    function disconnect() {
+      wasExplicitlyDisconnected = true;
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      if (ws) {
+        try {
+          ws.send('stop;');
+          ws.close();
+        } catch (e) {}
+        ws = null;
+      }
+      msgBuffer = '';
+      updateState('connected', false);
+      console.log('[TCI] Disconnected');
+    }
+
+    function setFreq(hz) {
+      console.log(`[TCI] SET FREQ: ${(hz / 1e6).toFixed(6)} MHz`);
+      send(`VFO:${trx},${vfo},${hz};`);
+    }
+
+    function setMode(mode) {
+      console.log(`[TCI] SET MODE: ${mode}`);
+      const tciMode = TCI_MODES_REV[mode] || TCI_MODES_REV[mode.toUpperCase()] || mode.toLowerCase();
+      send(`MODULATION:${trx},${tciMode};`);
+    }
+
+    function setPTT(on) {
+      console.log(`[TCI] SET PTT: ${on ? 'TX' : 'RX'}`);
+      send(`TRX:${trx},${on};`);
+    }
+
+    return { connect, disconnect, setFreq, setMode, setPTT };
+  },
+};

--- a/rig-bridge/rig-bridge.js
+++ b/rig-bridge/rig-bridge.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * OpenHamClock Rig Bridge v1.1.0
+ * OpenHamClock Rig Bridge v1.2.0
  *
  * Universal bridge connecting radios and other ham radio services to OpenHamClock.
  * Uses a plugin architecture — each integration is a standalone module.
@@ -19,7 +19,7 @@
 
 'use strict';
 
-const VERSION = '1.1.0';
+const VERSION = '1.2.0';
 
 const { config, loadConfig, applyCliArgs } = require('./core/config');
 const { updateState, state } = require('./core/state');


### PR DESCRIPTION
## What does this PR do?

## Summary

- **New plugin** `rig-bridge/plugins/tci.js` ported from rig-listener — connects to SDR applications (Thetis, ExpertSDR, SunSDR2, SmartSDR) via WebSocket using the TCI (Transceiver Control Interface) protocol
- **Web config UI** updated with TCI form section (host, port, TRX index, VFO index) including full input validation
- **Version bump** rig-bridge 1.1.0 → 1.2.0
- **README** updated with TCI setup guide, supported apps table, config reference, and troubleshooting rows

## Changes

### `rig-bridge/plugins/tci.js` (new)
- Full TCI mode map (AM, SAM, DSB, LSB, USB, CW, FM, WFM, DATA-LSB, DATA-USB, SPEC, DRM)
- WebSocket resolved via `require('ws')` with fallback to `globalThis.WebSocket` (Node 21+ native)
- All event bindings use `addEventListener` — avoids the `tciSocket.on is not a function` crash with Node 21+ built-in WebSocket (W3C `EventTarget` has no `.on()`)
- Message parser with `;` delimiter buffering: handles `vfo`, `modulation`, `trx`, `rx_filter_band`
- Auto-reconnects every 5 s on disconnect
- `setFreq` / `setMode` / `setPTT` send correct TCI commands

### `rig-bridge/core/config.js`
- Added `tci` section to `DEFAULT_CONFIG` (`host`, `port: 40001`, `trx: 0`, `vfo: 0`)
- `loadConfig()` now merges the `tci` section from persisted config

### `rig-bridge/core/plugin-registry.js`
- Registered `'tci'` in `registerBuiltins()`

### `rig-bridge/core/server.js`
- Dropdown: added SDR Radios (TCI) optgroup
- Form: TCI host, port (`min=1 max=65535`), TRX index (`min=0 max=7`), VFO index (`min=0 max=1`)
- `onTypeChange()` shows/hides TCI form section
- `populateForm()` loads TCI values from config
- `saveAndConnect()` validates TCI fields and includes them in POST body
- `POST /api/config` merges `newConfig.tci` into `config.tci`

### `rig-bridge/package.json`
- Added `ws ^8.14.2` dependency (rig-bridge had no WebSocket dep previously)
- Version bumped to `1.2.0`

## Test plan

- [ ] `cd rig-bridge && npm install` — `ws` installs cleanly
- [ ] Select TCI in web UI at `http://localhost:5555` — TCI form section appears
- [ ] Save with empty host — shows validation error
- [ ] Save with port out of range — shows validation error
- [ ] Set `tci.host`/`port` pointing at a running Thetis/ExpertSDR instance — bridge logs `[TCI] ✅ Connected`, `/status` returns correct frequency and mode
- [ ] Stop SDR app — bridge logs reconnect attempts every 5 s, no crash
- [ ] `POST /freq` and `POST /mode` — correct TCI commands sent over socket
- [ ] Run with Node 21+ without `ws` installed — no `tciSocket.on is not a function` error

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## Checklist

- [x] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

@accius it also changed a few lines in rig listener (see diff). Probably because I fed it with the issue you opened. If it makes sense to you take it, if not you can leave it. Unfortunately I cannot really test this properly by myself.