### PR TITLE
Update to reduce SOTA API load

### DIFF
--- a/server.js
+++ b/server.js
@@ -2720,13 +2720,18 @@ app.get('/api/sota/spots', async (req, res) => {
       return res.json(sotaCache.data);
     }
 
-    const ep = await fetch('https://api-db2.sota.org.uk/api/spots/epoch');
-    const epoch = await ep.text();
-
-    // epoch is consistent with previous fetched spots, do not refetch
-    if (epoch == sotaEpoch) {
-      res.set('Cache-Control', 'no-store');
-      return res.json(sotaCache.data);
+    // Check epoch to avoid unnecessary refetch (wrapped in try/catch so
+    // a failing epoch endpoint doesn't 500 the whole spots route)
+    let epoch = '';
+    try {
+      const ep = await fetch('https://api-db2.sota.org.uk/api/spots/epoch');
+      epoch = await ep.text();
+      if (epoch === sotaEpoch && sotaCache.data) {
+        res.set('Cache-Control', 'no-store');
+        return res.json(sotaCache.data);
+      }
+    } catch (e) {
+      // Epoch check failed — fall through to normal spots fetch
     }
 
     checkSummitCache(); // Updates sotaSummits if required


### PR DESCRIPTION
## What does this PR do?

The current implementation of SOTA Spots uses deprecated SOTA APIs and violates terms of service as the SOTA MT have not been contacted to sign-off on API usage.  This has resulted in substantial load increase on the SOTA servers.  This PR implements the correct usage of the SOTA API.  

It does *not* alter the code under /hooks/useSOTASpots.js, which I'll leave as an exercise for someone else to tackle as I don't know your internal spots format and a lot of what is going on there seems more OHC internal.  I will note that:
 - the ISO8601 hacks are not needed if using the modern Spot format, as this always returns a timestamp that is ISO8601 compliant - indeed that is why the old endpoints are deprecated and have been for years.
 - QRT spots are a specific type of spot and handled via a SpotType field, so you can usually find this without having to scan comments fields (which is unreliable)
 - Frequency is consistently a float/number value, so I imagine line 73 is ok, but the whole line appears to be a no-op to me at present based on the comments.

## Type of change

- [ X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1. Run the server, fetch the spots
2. Contact the SOTA MT via https://www.sota.org.uk/Contact to agree to terms of service and verify load is dropping.
3. ???
4. Profit.

## Checklist

- [ N/A] App loads without console errors
- [ N/A ] Tested in **Dark**, **Light**, and **Retro** themes
- [ N/A  ] Responsive at different screen sizes (desktop + mobile)
- [ X ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ N/A ] If adding an API route: includes caching and error handling
- [ N/A ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ N/A ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ N/A ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<!-- Before/after screenshots or a quick screen recording help reviewers a lot -->
