### PR TITLE
[BUG 660] POTA & SOTA panels truncate information

### DIFF
--- a/src/components/ActivatePanel.jsx
+++ b/src/components/ActivatePanel.jsx
@@ -175,8 +175,9 @@ export const ActivatePanel = ({
                     textOverflow: 'ellipsis',
                     whiteSpace: 'nowrap',
                   }}
+                  title={`${spot.ref} - ${spot.name}`}
                 >
-                  {`${spot.ref} - ${spot.name}`}
+                  {spot.ref}
                 </span>
                 <span style={{ color: 'var(--accent-cyan)', textAlign: 'right' }}>
                   {(() => {


### PR DESCRIPTION
## What does this PR do?

Updates ActivatePanel to only show the spot.ref in the reference column, but populates the title with "spot.ref - spot.name".

There has been some confusion about how I previously implemented this by putting the reference and name in the displayed column, and letting it display an ellipsis so that mousing over would display the reference and name.

This is a cleaner way of doing it.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. View an ActivatePanel and verify that we only see the reference and no ellipsis in the reference column
2. Mouse over the reference
3. Verify that the popup displays the reference and name

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

Before:
<img width="322" height="93" alt="image" src="https://github.com/user-attachments/assets/93a78104-56be-492e-a0a1-92160cf876fb" />

After:
<img width="330" height="104" alt="image" src="https://github.com/user-attachments/assets/6d1afb11-decb-467a-aecb-47e24e863106" />
