### PR TITLE
[BUG 673] PSKReporter Always Uses FN31 as Grid Square

### DIFF
--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -41,7 +41,7 @@ export const SettingsPanel = ({
 
   const [callsign, setCallsign] = useState(config?.callsign || '');
   const [headerSize, setheaderSize] = useState(config?.headerSize || 1.0);
-  const [gridSquare, setGridSquare] = useState('');
+  const [gridSquare, setGridSquare] = useState(config?.locator || '');
   const [lat, setLat] = useState(config?.location?.lat || 0);
   const [lon, setLon] = useState(config?.location?.lon || 0);
   const [layout, setLayout] = useState(config?.layout || 'modern');
@@ -172,7 +172,9 @@ export const SettingsPanel = ({
       setTuneEnabled(config.rigControl?.tuneEnabled || false);
       setAutoMode(config.rigControl?.autoMode !== false);
       if (config.location?.lat && config.location?.lon) {
-        setGridSquare(calculateGridSquare(config.location.lat, config.location.lon));
+        const grid = calculateGridSquare(config.location.lat, config.location.lon);
+        setGridSquare(grid);
+        setConfigLocator(grid);
       }
     }
   }, [config, isOpen]);
@@ -276,6 +278,13 @@ export const SettingsPanel = ({
     }
   };
 
+  function setConfigLocator(grid) {
+    if (grid.length >= 4) {
+      config.locator = grid.slice(0, 4).toUpperCase() + grid.slice(4).toLowerCase();
+    } else {
+      config.locator = grid.toUpperCase();
+    }
+  }
   const handleGridChange = (grid) => {
     setGridSquare(grid.toUpperCase());
     if (grid.length >= 4) {
@@ -285,11 +294,14 @@ export const SettingsPanel = ({
         setLon(parsed.lon);
       }
     }
+    setConfigLocator(grid);
   };
 
   useEffect(() => {
     if (lat && lon) {
-      setGridSquare(calculateGridSquare(lat, lon));
+      const grid = calculateGridSquare(lat, lon);
+      setGridSquare(grid);
+      setConfigLocator(grid);
     }
   }, [lat, lon]);
 


### PR DESCRIPTION
## What does this PR do?

Addresses https://github.com/users/accius/projects/1/views/1?pane=issue&itemId=161965444&issue=accius%7Copenhamclock%7C673

Updates SettingsPanel so that any update to the local "grid" variable results in an update to config.locator. Other functions (e.g. PSKFilterManager) pull the grid from config.locator, and as such were pulling a (very) incorrect value.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Go to the PSKFilterManager
2. Select "Source"
3. My Grid Square should be correct

## Checklist

- [X] App loads without console errors
- [N/A] Tested in **Dark**, **Light**, and **Retro** themes
- [N/A] Responsive at different screen sizes (desktop + mobile)
- [N/A] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [N/A] If adding an API route: includes caching and error handling
- [N/A] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [N/A] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [N/A] No `.bak`, `.old`, `console.log` debug lines, or test scripts included
