### PR TITLE
Fix/setup pi electron winstaller arm

### DIFF
--- a/scripts/setup-pi.sh
+++ b/scripts/setup-pi.sh
@@ -218,12 +218,26 @@ install_nodejs() {
             exit 1
         fi
 
+        # Download to a temp file with retry support.
+        # Piping curl directly into tar gives no retry opportunity on a
+        # dropped connection; saving to disk first lets curl resume/retry
+        # and keeps extraction separate so errors are easier to diagnose.
         echo -e "${BLUE}  Installing $NODE_TARBALL ...${NC}"
-        curl -fsSL "$NODE_DIST_BASE/$NODE_TARBALL" \
-            | sudo tar -xz -C /usr/local --strip-components=1 || {
-            echo -e "${RED}✗ Failed to download or extract Node.js armv7l binary.${NC}"
+        NODE_TMPFILE=$(mktemp /tmp/nodejs-armv7l-XXXXXX.tar.gz)
+        curl -fsSL \
+            --retry 3 --retry-delay 5 --retry-connrefused \
+            "$NODE_DIST_BASE/$NODE_TARBALL" \
+            -o "$NODE_TMPFILE" || {
+            rm -f "$NODE_TMPFILE"
+            echo -e "${RED}✗ Failed to download Node.js armv7l binary (tried 3 times).${NC}"
             exit 1
         }
+        sudo tar -xz -C /usr/local --strip-components=1 -f "$NODE_TMPFILE" || {
+            rm -f "$NODE_TMPFILE"
+            echo -e "${RED}✗ Failed to extract Node.js armv7l binary.${NC}"
+            exit 1
+        }
+        rm -f "$NODE_TMPFILE"
     else
         # amd64 and arm64 are supported by NodeSource.
         curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo -E bash - || {


### PR DESCRIPTION
## What does this PR do?

## Fix `setup-pi.sh` failures on ARM / 32-bit Raspberry Pi OS

### Problem

Three cascading failures were reported by users running `setup-pi.sh` on ARM hardware:

1. **`electron-winstaller` ENOENT on ARM** — `npm install --include=dev` installs `electron-builder`, which pulls in `electron-winstaller`. Its `postinstall` script tries to copy `vendor/7z-arm.exe → vendor/7z.exe`. This Windows-only file does not exist on Linux targets, causing a hard failure. npm v10's rollback-on-failure behaviour then removes `node_modules` entirely, leaving the install in a broken state. https://github.com/accius/openhamclock/issues/682

2. **NodeSource rejects 32-bit ARM (armhf)** — NodeSource dropped `armhf` support from Node.js 20 onwards. Running the NodeSource setup script on a 32-bit Raspberry Pi OS (Bookworm or Bullseye) produces:
   ```
   Error: Unsupported architecture: armhf. Only amd64, arm64 are supported.
   ```
   The script header claimed 32-bit support but never handled this case.

3. **Fragile download on weak Pi connections** — The initial armhf fix piped `curl` directly into `tar`. A single dropped connection mid-download resulted in a corrupt/partial extraction with no retry.

---

### Changes

#### `scripts/setup-pi.sh`

**Fix 1 — Skip harmful `postinstall` lifecycle scripts during `npm install`**

```diff
- npm install --include=dev
+ ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm install --include=dev --ignore-scripts
```

`--ignore-scripts` prevents all lifecycle hooks from running during install, specifically blocking `electron-winstaller`'s `postinstall`. This is safe on a Pi because:
- `npm run build` (Vite) is an explicit call, unaffected by `--ignore-scripts`
- Husky git-hooks (`prepare`) are irrelevant on a production kiosk
- No other devDependency requires a postinstall to function

A `npm prune --omit=dev` step is added after the build to remove `electron`, `electron-builder`, and related tooling (~500 MB) from `node_modules` on the Pi.

**Fix 2 — Install Node.js from `nodejs.org` on 32-bit ARM**

`install_nodejs()` now detects architecture via `dpkg --print-architecture` before invoking NodeSource. On `armhf`, it falls back to the official `nodejs.org` `armv7l` tarball, which Node.js continues to publish for all LTS releases including v22:

```
nodejs.org/dist/latest-v22.x/node-v22.x.x-linux-armv7l.tar.gz
```

`amd64` and `arm64` continue to use NodeSource unchanged.

**Fix 3 — Robust download with retry for the armv7l tarball**

The ~40 MB tarball download is split into two discrete steps:

1. `curl` downloads to a `mktemp` file with `--retry 3 --retry-delay 5 --retry-connrefused`
2. `tar` extracts from the file after a confirmed successful download
3. The temp file is cleaned up afterwards

Download and extraction failures are reported separately, making future diagnosis easier.

---

### Tested against

| Hardware | OS | Arch | Mode |
|---|---|---|---|
| Raspberry Pi CM3 8GB | Bullseye (6.1.21-v7+) | armhf (32-bit) | `--kiosk` |
| Raspberry Pi (generic) | Bookworm (32-bit) | armhf | `--kiosk` |

---

### Related issues

- `electron-winstaller` ENOENT on ARM — reported by CM3/Bullseye user
- NodeSource `armhf` rejection — reported by Bookworm 32-bit user
- `curl | tar` connection reset — follow-up from same Bookworm 32-bit user
