### PR TITLE
[BUG 695] Lightning layer is not using settable distance units

### DIFF
--- a/src/plugins/layers/lightning/README.md
+++ b/src/plugins/layers/lightning/README.md
@@ -32,7 +32,7 @@ The Lightning Detection plugin visualizes real-time lightning strikes on the map
 - **Colored Circle Markers**: Background color shows strike age (size 12-32px)
 - **Lightning Bolt Icon**: White ⚡ symbol centered on circle
 - **Flash Animation**: New strikes appear with bright gold glow (0.8s)
-- **Pulse Ring**: Expanding 30km radius ring for new strikes (2s)
+- **Pulse Ring**: Expanding 30km or 20 mile radius ring for new strikes (2s)
 - **White Border**: 2px white border for contrast on all backgrounds
 - **Box Shadow**: Depth effect for better visibility
 - **🆕 Badge**: New strikes marked in popup
@@ -316,11 +316,11 @@ const fetchLightning = async () => {
 
 ## 🌐 External Links
 
-- **Blitzortung.org**: https://www.blitzortung.org/
-- **LightningMaps.org**: https://www.lightningmaps.org/
-- **NOAA Lightning Data**: https://www.nesdis.noaa.gov/our-satellites/currently-flying/goes-east-west/geostationary-lightning-mapper-glm
-- **Lightning Safety**: https://www.weather.gov/safety/lightning
-- **30/30 Rule**: https://www.weather.gov/safety/lightning-30-30-rule
+- **Blitzortung.org**: <https://www.blitzortung.org/>
+- **LightningMaps.org**: <https://www.lightningmaps.org/>
+- **NOAA Lightning Data**: <https://www.nesdis.noaa.gov/our-satellites/currently-flying/goes-east-west/geostationary-lightning-mapper-glm>
+- **Lightning Safety**: <https://www.weather.gov/safety/lightning>
+- **30/30 Rule**: <https://www.weather.gov/safety/lightning-30-30-rule>
 
 ---
 
@@ -333,7 +333,7 @@ const fetchLightning = async () => {
 - Age-based color coding (gold → brown)
 - Intensity and polarity display
 - Flash animation for new strikes (0.8s)
-- Pulse ring effect (2s, 30km radius)
+- Pulse ring effect (2s, 30km or 20 mile radius)
 - Continuous subtle pulse on all strikes
 - Statistics panel (top-left)
 - 30-second auto-refresh

--- a/src/plugins/layers/useLightning.js
+++ b/src/plugins/layers/useLightning.js
@@ -45,8 +45,8 @@ function lzwDecode(compressed) {
 }
 
 // Haversine formula for distance calculation
-function calculateDistance(lat1, lon1, lat2, lon2, unit = 'km') {
-  const R = unit === 'km' ? 6371.14 : 3963.1; // Earth radius in km or miles
+function calculateDistance(lat1, lon1, lat2, lon2, unit = 'metric') {
+  const R = unit === 'metric' ? 6371.14 : 3963.1; // Earth radius in km or miles
   const dLat = ((lat2 - lat1) * Math.PI) / 180;
   const dLon = ((lon2 - lon1) * Math.PI) / 180;
   const a =
@@ -65,7 +65,7 @@ function getStrikeColor(ageMinutes) {
   return '#8B4513'; // Brown (very old, >30 min)
 }
 
-export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemoryMode = false }) {
+export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemoryMode = false, allUnits }) {
   const [strikeMarkers, setStrikeMarkers] = useState([]);
   const [lightningData, setLightningData] = useState([]);
   const [statsControl, setStatsControl] = useState(null);
@@ -82,6 +82,12 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
   // Low memory mode limits
   const MAX_STRIKES = lowMemoryMode ? 100 : 500;
   const STRIKE_RETENTION_MS = 1800000; // 30 min
+
+  const unitStr = allUnits.dist === 'metric' ? 'km' : 'miles';
+
+  const PROXIMITY_RADIUS_KM = 30;
+  const PROXIMITY_RADIUS_MILES = 20; // It's not the same as 30km, but it looks weird using a radius of 18.6411 miles
+  const PROXIMITY_RADIUS = allUnits.dist === 'metric' ? PROXIMITY_RADIUS_KM : PROXIMITY_RADIUS_MILES;
 
   // Fetch WebSocket key from Blitzortung (fallback to 111)
   useEffect(() => {
@@ -568,7 +574,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
     }
   }, [statsControl, enabled, lightningData]);
 
-  // Proximity detection and alerts (30km radius)
+  // Proximity detection and alerts (within PROXIMITY_RADIUS)
   useEffect(() => {
     if (!enabled) return;
 
@@ -591,11 +597,11 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
     const now = Date.now();
     const ONE_MINUTE_AGO = now - 60000;
 
-    // Check for new strikes within 30km in the last minute
+    // Check for new strikes within PROXIMITY_RADIUS in the last minute
     const nearbyNewStrikes = lightningData.filter((strike) => {
       if (strike.timestamp < ONE_MINUTE_AGO) return false;
 
-      const distance = calculateDistance(stationLat, stationLon, strike.lat, strike.lon, 'km');
+      const distance = calculateDistance(stationLat, stationLon, strike.lat, strike.lon, allUnits.dist);
       return distance <= ALERT_RADIUS_KM;
     });
 
@@ -624,7 +630,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
     }
   }, [enabled, lightningData]);
 
-  // Create proximity panel control (30km radius)
+  // Create proximity panel control (within PROXIMITY_RADIUS)
   useEffect(() => {
     console.log(
       '[Lightning] Proximity effect triggered - enabled:',
@@ -688,8 +694,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
         const panelWrapper = L.DomUtil.create('div', 'panel-wrapper');
         const div = L.DomUtil.create('div', 'lightning-proximity', panelWrapper);
 
-        div.innerHTML =
-          '<div class="floating-panel-header">📍 Nearby Strikes (30km)</div><div style="opacity: 0.7; font-size: 10px; text-align: center;">No recent strikes</div>';
+        div.innerHTML = `<div class="floating-panel-header">📍 Nearby Strikes (${PROXIMITY_RADIUS} ${unitStr})</div><div style="opacity: 0.7; font-size: 10px; text-align: center;">No recent strikes</div>`;
 
         // Prevent map interaction
         L.DomEvent.disableClickPropagation(div);
@@ -823,16 +828,15 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
 
     if (!stationLat || !stationLon) return;
 
-    const PROXIMITY_RADIUS_KM = 30;
     const now = Date.now();
 
-    // Find all strikes within 30km
+    // Find all strikes within PROXIMITY_RADIUS
     const nearbyStrikes = lightningData
       .map((strike) => {
-        const distance = calculateDistance(stationLat, stationLon, strike.lat, strike.lon, 'km');
+        const distance = calculateDistance(stationLat, stationLon, strike.lat, strike.lon, allUnits.dist);
         return { ...strike, distance };
       })
-      .filter((strike) => strike.distance <= PROXIMITY_RADIUS_KM)
+      .filter((strike) => strike.distance <= PROXIMITY_RADIUS)
       .sort((a, b) => a.distance - b.distance); // Sort by distance (closest first)
 
     let contentHTML = '';
@@ -840,7 +844,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
     if (nearbyStrikes.length === 0) {
       contentHTML = `
         <div style="font-size: 10px; text-align: center;">
-          ✅ No strikes within 30km<br/>
+          ✅ No strikes within ${PROXIMITY_RADIUS} ${unitStr}<br/>
           <span style="font-size: 9px; color: var(--text-muted);">All clear</span>
         </div>
       `;
@@ -856,7 +860,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
             ⚡ ${nearbyStrikes.length} strike${nearbyStrikes.length > 1 ? 's' : ''} detected
           </div>
           <div style="font-size: 10px;">
-            <strong>Closest:</strong> ${closestStrike.distance.toFixed(1)} km<br>
+            <strong>Closest:</strong> ${closestStrike.distance.toFixed(1)} ${unitStr}<br>
             <strong>Time:</strong> ${ageStr}<br>
             <strong>Polarity:</strong> ${closestStrike.polarity === 'positive' ? '+' : '-'} ${Math.round(closestStrike.intensity)} kA
           </div>
@@ -871,7 +875,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
                 const timeStr = age < 60 ? `${age}s` : `${Math.floor(age / 60)}m`;
                 return `
                 <div style="padding: 2px 0; border-bottom: 1px dotted var(--border-color);">
-                  ${idx + 1}. ${strike.distance.toFixed(1)} km • ${timeStr} • ${strike.polarity === 'positive' ? '+' : '-'}${Math.round(strike.intensity)} kA
+                  ${idx + 1}. ${strike.distance.toFixed(1)} ${unitStr} • ${timeStr} • ${strike.polarity === 'positive' ? '+' : '-'}${Math.round(strike.intensity)} kA
                 </div>
               `;
               })


### PR DESCRIPTION
## What does this PR do?

Updated to use the global `allUnits.dist` for 'metric' vs 'imperlal'.

If `allUnits.dist` is 'imperial', make the proximity radius `20 miles` rather than `30km` which translates to `18.6411 miles` and just looks strange.
    
Updated documentation to reflect this.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Set distance units to Imperial in the settings
2. Bring up the lightning layer (hotkey 'L')
3. Verify distances are listed in miles

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

Before:
<img width="867" height="375" alt="image" src="https://github.com/user-attachments/assets/d605ec9a-f479-4fc0-8c7c-e7480fb0c6e2" />

After:
<img width="721" height="355" alt="image" src="https://github.com/user-attachments/assets/3a6bf514-7462-4429-99bf-5df214255718" />


