### PR TITLE
fix: persist pending settings before profile save snapshots

### DIFF
--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -358,7 +358,7 @@ export const SettingsPanel = ({
     }
   };
 
-  const handleSave = () => {
+  const persistCurrentSettings = () => {
     const rigPortValue = String(rigPort ?? '').trim();
     let nextRigPort = 5555;
     if (rigPortValue === '0') {
@@ -396,6 +396,10 @@ export const SettingsPanel = ({
         autoMode,
       },
     });
+  };
+
+  const handleSave = () => {
+    persistCurrentSettings();
     onClose();
   };
 
@@ -2923,6 +2927,7 @@ export const SettingsPanel = ({
                       const exists = profiles[newProfileName.trim()];
                       if (exists && !window.confirm(`Profile "${newProfileName.trim()}" already exists. Overwrite?`))
                         return;
+                      persistCurrentSettings();
                       saveProfile(newProfileName.trim());
                       setNewProfileName('');
                       refreshProfiles();
@@ -2948,6 +2953,7 @@ export const SettingsPanel = ({
                     const exists = profiles[newProfileName.trim()];
                     if (exists && !window.confirm(`Profile "${newProfileName.trim()}" already exists. Overwrite?`))
                       return;
+                    persistCurrentSettings();
                     saveProfile(newProfileName.trim());
                     setNewProfileName('');
                     refreshProfiles();
@@ -3167,6 +3173,7 @@ export const SettingsPanel = ({
                               {/* Update (overwrite with current state) */}
                               <button
                                 onClick={() => {
+                                  persistCurrentSettings();
                                   saveProfile(name);
                                   refreshProfiles();
                                   setProfileMessage({ type: 'success', text: `"${name}" updated with current state` });


### PR DESCRIPTION
## Bug
https://github.com/accius/openhamclock/issues/724 — saving a profile could capture stale unit settings because profile snapshots read localStorage, while Settings edits stay in component state until Save is applied.

## Fix
- Added a `persistCurrentSettings()` helper in SettingsPanel that writes the current in-memory form state via `onSave` without closing the dialog
- Call this helper immediately before every profile snapshot save action (new profile save and profile update)
- Keep existing Save button behavior by reusing the same helper there

## Testing
- `npx prettier --check src/components/SettingsPanel.jsx`

Happy to address any feedback.

Greetings, saschabuehrle
