### PR TITLE
Make the SOTA code more error resilient and tidy up debug messages

### DIFF
--- a/server/routes/spots.js
+++ b/server/routes/spots.js
@@ -3,8 +3,6 @@
  * Lines ~2657-2830 of original server.js
  */
 
-const { logWarn } = require('../utils/logging');
-
 module.exports = function (app, ctx) {
   const { fetch, logDebug, logErrorOnce } = ctx;
 
@@ -26,7 +24,6 @@ module.exports = function (app, ctx) {
 
       // Log diagnostic info about the response
       if (Array.isArray(data) && data.length > 0) {
-        const sample = data[0];
         logDebug(`[POTA] API returned ${data.length} spots.`);
 
         // Count coordinate coverage
@@ -66,7 +63,6 @@ module.exports = function (app, ctx) {
 
       // Log diagnostic info about the response
       if (Array.isArray(data) && data.length > 0) {
-        const sample = data[0];
         logDebug(`[WWFF] API returned ${data.length} spots.`);
       }
 
@@ -103,33 +99,28 @@ module.exports = function (app, ctx) {
       const response = await fetch('https://storage.sota.org.uk/summitslist.csv');
       const data = await response.text();
       const Papa = require('papaparse');
-
-      Papa.parse(data, {
+      const csvresults = Papa.parse(data, {
         skipFirstNLines: 1,
         header: true,
         skipEmptyLines: true,
-        complete: function (results) {
-          let summit = {};
-          if (results.errors.length > 0) {
-            logWarn('[SOTA] Papa.parse returned error code ', results.errors);
-          } else {
-            results.data.forEach((obj) => {
-              summit[obj['SummitCode']] = {
-                latitude: obj['Latitude'],
-                longitude: obj['Longitude'],
-                name: obj['SummitName'],
-                altM: obj['AltM'],
-                points: obj['Points'],
-              };
-            });
-
-            sotaSummits = {
-              data: summit,
-              timestamp: now,
-            };
-          }
-        },
       });
+
+      let summit = {};
+
+      csvresults.data.forEach((obj) => {
+        summit[obj['SummitCode']] = {
+          latitude: obj['Latitude'],
+          longitude: obj['Longitude'],
+          name: obj['SummitName'],
+          altM: obj['AltM'],
+          points: obj['Points'],
+        };
+      });
+
+      sotaSummits = {
+        data: summit,
+        timestamp: now,
+      };
     } catch (error) {
       logErrorOnce('[SOTA]', error.message);
     }
@@ -174,7 +165,6 @@ module.exports = function (app, ctx) {
         logDebug('[SOTA] Summits Cache empty');
       }
       if (Array.isArray(data) && data.length > 0) {
-        const sample = data[0];
         sotaEpoch = data[0].epoch;
         logDebug(`[SOTA] API returned ${data.length} spots.`);
       }


### PR DESCRIPTION
## What does this PR do?

### Make the SOTA code more error resilient
- moves the creation of the summit array and to be a function within Papa.parse upon completion.
- tells Papa.parse to skip empty lines
- catches if there are any CSV parsing issues

### Tidy up debug messages
- specifically we really don't need to know about the sample fields for POTA, SOTA and WWFF any more.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Note that `server/routes/spot.js` is less chatty

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included


