### PR TITLE
DX locator not moving when wsjt-x is making a contact

### DIFF
--- a/server/routes/wsjtx.js
+++ b/server/routes/wsjtx.js
@@ -514,7 +514,7 @@ module.exports = function (app, ctx) {
           // 1. Try dxGrid from WSJT-X (if it knows the DX station's grid)
           if (dxGrid) {
             const coords = gridToLatLon(dxGrid);
-            if (coords) {
+            if (coords !== null) {
               dxLat = coords.lat;
               dxLon = coords.lon;
             }


### PR DESCRIPTION
## What does this PR do?

It looks like when refactoring the server code, the incorrect element names from a call to `gridToLatLon()`. Coords has elements `{lat, lon}`, not `{latitude, longitude}` when setting up `state.clients[]`. This PR addresses the so that the DX locator will be moved when wsjt-x indicates that we have selected a callsign.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

Make an FT-8 contact while watching OHC.

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included
