### PR TITLE
[Refactor / translation] Add 'Alerts' in settings to language lookup

### DIFF
--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -650,7 +650,7 @@ export const SettingsPanel = ({
               fontFamily: 'JetBrains Mono, monospace',
             }}
           >
-            🔔 Alerts
+            🔔 {t('station.settings.tab.title.alerts')}
           </button>
         </div>
 

--- a/src/components/SidebarMenu.jsx
+++ b/src/components/SidebarMenu.jsx
@@ -61,7 +61,7 @@ export default function SidebarMenu({
       { id: 'satellites', icon: '🛰️', label: t('station.settings.tab.title.satellites') },
       { id: 'profiles', icon: '👤', label: t('station.settings.tab.title.profiles') },
       { id: 'community', icon: '🌐', label: t('station.settings.tab.title.community') },
-      { id: 'alerts', icon: '🔔', label: 'Alerts' },
+      { id: 'alerts', icon: '🔔', label: t('station.settings.tab.title.alerts') },
     ],
     [t],
   );

--- a/src/lang/ca.json
+++ b/src/lang/ca.json
@@ -331,6 +331,7 @@
   "station.settings.satellites.selectedCount": "{{count}} satèl·lit(s) seleccionat(s)",
   "station.settings.satellites.showAll": "Mostrant tots els satèl·lits (sense filtre)",
   "station.settings.satellites.visible": "✓ Visible",
+  "station.settings.tab.title.alerts": "Alerts",
   "station.settings.tab.title.community": "Community",
   "station.settings.tab.title.display": "Display",
   "station.settings.tab.title.integrations": "Integrations",

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -331,6 +331,7 @@
   "station.settings.satellites.selectedCount": "{{count}} Satellit(en) ausgewählt",
   "station.settings.satellites.showAll": "Alle Satelliten werden angezeigt (kein Filter)",
   "station.settings.satellites.visible": "✓ Sichtbar",
+  "station.settings.tab.title.alerts": "Alerts",
   "station.settings.tab.title.community": "Community",
   "station.settings.tab.title.display": "Display",
   "station.settings.tab.title.integrations": "Integrations",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -334,6 +334,7 @@
   "station.settings.satellites.selectedCount": "{{count}} satellite(s) selected",
   "station.settings.satellites.showAll": "Showing all satellites (no filter)",
   "station.settings.satellites.visible": "✓ Visible",
+  "station.settings.tab.title.alerts": "Alerts",
   "station.settings.tab.title.community": "Community",
   "station.settings.tab.title.display": "Display",
   "station.settings.tab.title.integrations": "Integrations",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -329,6 +329,7 @@
   "station.settings.satellites.selectedCount": "{{count}} satélite(s) seleccionado(s)",
   "station.settings.satellites.showAll": "Mostrando todos los satélites (sin filtro)",
   "station.settings.satellites.visible": "✓ Visible",
+  "station.settings.tab.title.alerts": "Alerts",
   "station.settings.tab.title.community": "Community",
   "station.settings.tab.title.display": "Display",
   "station.settings.tab.title.integrations": "Integrations",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -331,6 +331,7 @@
   "station.settings.satellites.selectedCount": "{{count}} satellite(s) sélectionné(s)",
   "station.settings.satellites.showAll": "Tous les satellites affichés (aucun filtre)",
   "station.settings.satellites.visible": "✓ Visible",
+  "station.settings.tab.title.alerts": "Alerts",
   "station.settings.tab.title.community": "Community",
   "station.settings.tab.title.display": "Display",
   "station.settings.tab.title.integrations": "Integrations",

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -331,6 +331,7 @@
   "station.settings.satellites.selectedCount": "{{count}} satellite(i) selezionato(i)",
   "station.settings.satellites.showAll": "Mostra tutti i satelliti (nessun filtro)",
   "station.settings.satellites.visible": "? Visibile",
+  "station.settings.tab.title.alerts": "Alerts",
   "station.settings.tab.title.community": "Community",
   "station.settings.tab.title.display": "Display",
   "station.settings.tab.title.integrations": "Integrations",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -331,6 +331,7 @@
   "station.settings.satellites.selectedCount": "{{count}}個の衛星を選択",
   "station.settings.satellites.showAll": "全衛星を表示中 (フィルタなし)",
   "station.settings.satellites.visible": "✓ 可視",
+  "station.settings.tab.title.alerts": "Alerts",
   "station.settings.tab.title.community": "Community",
   "station.settings.tab.title.display": "Display",
   "station.settings.tab.title.integrations": "Integrations",

--- a/src/lang/ka.json
+++ b/src/lang/ka.json
@@ -331,6 +331,7 @@
   "station.settings.satellites.selectedCount": "არჩეულია {{count}} თანამგზავრი",
   "station.settings.satellites.showAll": "ნაჩვენებია ყველა თანამგზავრი (ფილტრის გარეშე)",
   "station.settings.satellites.visible": "✓ ხილული",
+  "station.settings.tab.title.alerts": "Alerts",
   "station.settings.tab.title.community": "Community",
   "station.settings.tab.title.display": "Display",
   "station.settings.tab.title.integrations": "Integrations",

--- a/src/lang/ko.json
+++ b/src/lang/ko.json
@@ -331,6 +331,7 @@
   "station.settings.satellites.selectedCount": "{{count}}개 위성 선택됨",
   "station.settings.satellites.showAll": "모든 위성 표시 중 (필터 없음)",
   "station.settings.satellites.visible": "✓ 가시",
+  "station.settings.tab.title.alerts": "Alerts",
   "station.settings.tab.title.community": "Community",
   "station.settings.tab.title.display": "Display",
   "station.settings.tab.title.integrations": "Integrations",

--- a/src/lang/ms.json
+++ b/src/lang/ms.json
@@ -331,6 +331,7 @@
   "station.settings.satellites.selectedCount": "{{count}} satelit dipilih",
   "station.settings.satellites.showAll": "Menunjukkan semua satelit",
   "station.settings.satellites.visible": "✓ Kelihatan",
+  "station.settings.tab.title.alerts": "Alerts",
   "station.settings.tab.title.community": "Community",
   "station.settings.tab.title.display": "Display",
   "station.settings.tab.title.integrations": "Integrations",

--- a/src/lang/nl.json
+++ b/src/lang/nl.json
@@ -331,6 +331,7 @@
   "station.settings.satellites.selectedCount": "{{count}} satelliet(en) geselecteerd",
   "station.settings.satellites.showAll": "Alle satellieten worden getoond (geen filter)",
   "station.settings.satellites.visible": "✓ Zichtbaar",
+  "station.settings.tab.title.alerts": "Alerts",
   "station.settings.tab.title.community": "Community",
   "station.settings.tab.title.display": "Display",
   "station.settings.tab.title.integrations": "Integrations",

--- a/src/lang/pt.json
+++ b/src/lang/pt.json
@@ -331,6 +331,7 @@
   "station.settings.satellites.selectedCount": "{{count}} sat?lite(s) selecionado(s)",
   "station.settings.satellites.showAll": "Mostrando todos os sat?lites (sem filtro)",
   "station.settings.satellites.visible": "✓ Vis?vel",
+  "station.settings.tab.title.alerts": "Alerts",
   "station.settings.tab.title.community": "Community",
   "station.settings.tab.title.display": "Display",
   "station.settings.tab.title.integrations": "Integrations",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -331,6 +331,7 @@
   "station.settings.satellites.selectedCount": "Выбрано спутников: {{count}}",
   "station.settings.satellites.showAll": "Показаны все спутники (без фильтра)",
   "station.settings.satellites.visible": "✓ Виден",
+  "station.settings.tab.title.alerts": "Alerts",
   "station.settings.tab.title.community": "Community",
   "station.settings.tab.title.display": "Display",
   "station.settings.tab.title.integrations": "Integrations",

--- a/src/lang/sl.json
+++ b/src/lang/sl.json
@@ -331,6 +331,7 @@
   "station.settings.satellites.selectedCount": "Izbranih satelitov: {{count}}",
   "station.settings.satellites.showAll": "Prikazani vsi sateliti (brez filtra)",
   "station.settings.satellites.visible": "✔ Vidno",
+  "station.settings.tab.title.alerts": "Alerts",
   "station.settings.tab.title.community": "Community",
   "station.settings.tab.title.display": "Display",
   "station.settings.tab.title.integrations": "Integrations",

--- a/src/lang/th.json
+++ b/src/lang/th.json
@@ -331,6 +331,7 @@
   "station.settings.satellites.selectedCount": "ดาวเทียม {{count}} ที่ได้รับการคัดเลือก",
   "station.settings.satellites.showAll": "แสดงดาวเทียมทั้งหมด (ปิดตัวกรอง)",
   "station.settings.satellites.visible": "✓ มองเห็นได้",
+  "station.settings.tab.title.alerts": "การแจ้งเตือน",
   "station.settings.tab.title.community": "ชุมชน",
   "station.settings.tab.title.display": "แสดง",
   "station.settings.tab.title.integrations": "การรวมระบบ",

--- a/src/lang/zh.json
+++ b/src/lang/zh.json
@@ -331,6 +331,7 @@
   "station.settings.satellites.selectedCount": "已选择 {{count}} 颗卫星",
   "station.settings.satellites.showAll": "显示所有卫星 (无过滤)",
   "station.settings.satellites.visible": "✓ 地平线上",
+  "station.settings.tab.title.alerts": "Alerts",
   "station.settings.tab.title.community": "Community",
   "station.settings.tab.title.display": "Display",
   "station.settings.tab.title.integrations": "Integrations",


### PR DESCRIPTION
## What does this PR do?

'Alerts' tab was recently added to the settings and settings side panel - PR adds it to the language lookup

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [X] Refactor / code cleanup
- [ ] Documentation
- [X] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1.
2.
3.

## Checklist

- [ ] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<!-- Before/after screenshots or a quick screen recording help reviewers a lot -->
<img width="1491" height="126" alt="image" src="https://github.com/user-attachments/assets/1baf3cf5-872d-43c9-baf0-948ecb1e3f18" />
