### PR TITLE
fix: PluginLayer error boundary and map safety checks

### DIFF
--- a/src/components/PluginLayer.jsx
+++ b/src/components/PluginLayer.jsx
@@ -1,10 +1,28 @@
 /**
  * PluginLayer Component
- * Renders a single plugin layer using its hook.
+ * Renders a single plugin layer using its hook, wrapped in an error boundary.
+ *
+ * Validates the Leaflet map instance before passing it to hooks.
+ * A map whose container has been removed from the DOM (or whose panes
+ * are gone after map.remove()) will cause getPane().appendChild errors.
+ *
+ * The error boundary catches crashes from both render and useEffect
+ * phases so a single broken plugin never takes down the whole dashboard.
  */
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 
-export const PluginLayer = ({
+function isMapAlive(map) {
+  if (!map) return false;
+  try {
+    // map._container is null after map.remove(); _panes is cleared too
+    return !!(map._container && map._panes && map._panes.mapPane);
+  } catch {
+    return false;
+  }
+}
+
+// Inner functional component that calls the hook
+const PluginLayerInner = ({
   plugin,
   enabled,
   opacity,
@@ -18,10 +36,11 @@ export const PluginLayer = ({
   config,
 }) => {
   const layerFunc = plugin.useLayer || plugin.hook;
+  const safeMap = isMapAlive(map) ? map : null;
 
   if (typeof layerFunc === 'function') {
     layerFunc({
-      map,
+      map: safeMap,
       enabled,
       opacity,
       callsign,
@@ -35,5 +54,37 @@ export const PluginLayer = ({
   }
   return null;
 };
+
+// Error boundary that catches render AND effect errors from plugin hooks.
+// A crashed plugin is silently disabled rather than crashing the dashboard.
+class PluginErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+  componentDidCatch(error, info) {
+    console.error(`[PluginLayer:${this.props.pluginId}] Crashed:`, error, info);
+  }
+  componentDidUpdate(prevProps) {
+    // Reset the boundary when the map changes (projection switch) so the
+    // plugin gets another chance with the new map instance.
+    if (this.state.hasError && prevProps.map !== this.props.map) {
+      this.setState({ hasError: false });
+    }
+  }
+  render() {
+    if (this.state.hasError) return null;
+    return this.props.children;
+  }
+}
+
+export const PluginLayer = (props) => (
+  <PluginErrorBoundary pluginId={props.plugin?.id} map={props.map}>
+    <PluginLayerInner {...props} />
+  </PluginErrorBoundary>
+);
 
 export default PluginLayer;

--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -400,7 +400,8 @@ export const WorldMap = ({
   // Migration: saved isAzimuthal → split into projection + style
   // Also validate that saved mapStyle still exists in MAP_STYLES to prevent stale references
   const migratedStyle = storedSettings.isAzimuthal ? 'dark' : storedSettings.mapStyle || 'dark';
-  const initialStyle = MAP_STYLES[migratedStyle] ? migratedStyle : 'dark';
+  // Validate style exists and isn't the legacy 'azimuthal' canvas entry
+  const initialStyle = MAP_STYLES[migratedStyle] && !MAP_STYLES[migratedStyle].legacy ? migratedStyle : 'dark';
   const initialProjection = storedSettings.isAzimuthal ? 'azimuthal' : storedSettings.mapProjection || 'mercator';
   const [mapStyle, setMapStyle] = useState(initialStyle);
   const [mapProjection, setMapProjection] = useState(initialProjection);

--- a/src/plugins/layers/useCityLights.js
+++ b/src/plugins/layers/useCityLights.js
@@ -25,11 +25,13 @@ export const useLayer = ({ map, enabled, opacity }) => {
 
     // Create the layer if it doesn't exist
     if (!layerRef.current) {
+      // Use nightPane if it exists on this map (Mercator), otherwise default pane
+      const paneOpts = map.getPane('nightPane') ? { pane: 'nightPane' } : {};
       layerRef.current = L.tileLayer(nightUrl, {
         attribution: 'NASA GIBS',
         noWrap: false,
-        pane: 'nightPane', // Ensure it still uses the blended pane
         zIndex: 1,
+        ...paneOpts,
       });
     }
 


### PR DESCRIPTION
- Wrap each PluginLayer in its own error boundary so a single crashed plugin (getPane().appendChild on a dead map) never takes down the whole dashboard. Boundary auto-resets on projection switch.
- Add isMapAlive() guard: validates map._container and _panes exist before passing to hooks — prevents effects from using destroyed maps.
- PluginLayer key now includes projection (az/merc) so hooks fully remount with clean refs when switching map instances.
- useCityLights: fall back to default pane when nightPane doesn't exist on the azimuthal map.
- Reject legacy 'azimuthal' mapStyle from localStorage.

## What does this PR do?

<!-- A brief description of the change. What problem does it solve or what feature does it add? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1.
2.
3.

## Checklist

- [ ] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<!-- Before/after screenshots or a quick screen recording help reviewers a lot -->
