### PR TITLE
fix: azimuthal tile globe misaligned on Retina/HiDPI displays

### DIFF
--- a/src/components/AzimuthalMap.jsx
+++ b/src/components/AzimuthalMap.jsx
@@ -412,7 +412,13 @@ export default function AzimuthalMap({
           lowMemory: lowMemoryMode,
         });
         if (imageData) {
-          ctx.putImageData(imageData, 0, 0);
+          // putImageData ignores canvas transforms (DPR scaling), so paint
+          // via a temp canvas + drawImage which respects the current transform.
+          const tmp = document.createElement('canvas');
+          tmp.width = imageData.width;
+          tmp.height = imageData.height;
+          tmp.getContext('2d').putImageData(imageData, 0, 0);
+          ctx.drawImage(tmp, 0, 0);
           tileImageDrawn = true;
         }
       } catch (e) {


### PR DESCRIPTION
putImageData() ignores canvas transforms, so on displays with devicePixelRatio > 1 (Mac Retina, etc.) the tile globe rendered at 1/DPR size in the top-left corner while distance rings and spots drew correctly.

Fix: paint tile ImageData onto a temporary canvas, then use drawImage() which respects the active DPR transform.

## What does this PR do?

<!-- A brief description of the change. What problem does it solve or what feature does it add? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1.
2.
3.

## Checklist

- [ ] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<!-- Before/after screenshots or a quick screen recording help reviewers a lot -->
