### PR TITLE
bump version to 26.1.3, add recent fixes to WhatsNew

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhamclock",
-  "version": "26.1.2",
+  "version": "26.1.3",
   "description": "Amateur Radio Dashboard - A modern web-based HamClock alternative",
   "main": "electron/main.js",
   "scripts": {

--- a/src/components/WhatsNew.jsx
+++ b/src/components/WhatsNew.jsx
@@ -29,7 +29,7 @@ const ANNOUNCEMENT = {
 
 const CHANGELOG = [
   {
-    version: '26.1.2',
+    version: '26.1.3',
     date: '2026-03-23',
     heading:
       'EmComm layout with APRS resource tracking, redesigned Classic layout, new versioning scheme, SDR integration, DX cluster text filter, RBN spotter filter, DX favorites, mutual reception indicator, UDP spot listener, WSJT-X multicast, swappable header clocks, Classic VOACAP heatmap, and bug fixes.',
@@ -148,6 +148,21 @@ const CHANGELOG = [
         icon: '🐛',
         title: 'Bug Fix — Edge Browser Cache Issue',
         desc: 'Fixed a crash in Microsoft Edge when switching to azimuthal projection. Leaflet icon creation was happening at module load time before the library was ready, causing a fatal error on browsers with aggressive caching. Azimuthal map now also has its own error boundary — if it fails, it falls back to flat projection instead of crashing the entire dashboard.',
+      },
+      {
+        icon: '🐛',
+        title: 'Bug Fix — Plugin Layer Crash (getPane)',
+        desc: 'Fixed a "getPane().appendChild" crash that could occur when switching projections or opening settings. Each map plugin layer is now wrapped in its own error boundary, so a single broken layer never takes down the whole dashboard. Added map-alive validation to prevent layers from attaching to destroyed or stale Leaflet instances.',
+      },
+      {
+        icon: '🗺️',
+        title: 'Bug Fix — Streets & Terrain Tile Providers',
+        desc: 'Streets map style switched from OpenStreetMap tile servers (blocked for violating tile usage policy) to CARTO Voyager. Terrain switched from OpenTopoMap to Esri World Physical Map. Both now load reliably without access errors.',
+      },
+      {
+        icon: '🐛',
+        title: 'Bug Fix — Azimuthal Tiles on Retina/HiDPI Displays',
+        desc: 'Fixed the azimuthal projection tile imagery appearing as a small globe in the top-left corner on Mac Retina and other HiDPI displays. The tile image was bypassing the canvas DPR scaling transform — now renders at the correct size and position.',
       },
     ],
   },


### PR DESCRIPTION
- Plugin layer getPane crash fix
- Streets & Terrain tile provider swap
- Azimuthal Retina/HiDPI tile alignment fix

## What does this PR do?

<!-- A brief description of the change. What problem does it solve or what feature does it add? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1.
2.
3.

## Checklist

- [ ] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<!-- Before/after screenshots or a quick screen recording help reviewers a lot -->
