### PR TITLE
perf: cache NOAA solar data for propagation heatmap

### DIFF
--- a/server/routes/propagation.js
+++ b/server/routes/propagation.js
@@ -458,6 +458,43 @@ module.exports = function (app, ctx) {
   // ===== PROPAGATION HEATMAP =====
   // Computes reliability grid from DE location to world grid for a selected band
   // Used by VOACAP Heatmap map layer plugin
+
+  // Solar data cache — shared across all heatmap requests so band/mode/power
+  // changes don't each trigger a slow NOAA fetch
+  let solarCache = { sfi: 150, ssn: 100, kIndex: 2, ts: 0 };
+  const SOLAR_CACHE_TTL = 15 * 60 * 1000; // 15 minutes
+
+  async function getSolarData() {
+    const now = Date.now();
+    if (now - solarCache.ts < SOLAR_CACHE_TTL) {
+      return { sfi: solarCache.sfi, ssn: solarCache.ssn, kIndex: solarCache.kIndex };
+    }
+    let sfi = 150,
+      ssn = 100,
+      kIndex = 2;
+    try {
+      const [fluxRes, kRes] = await Promise.allSettled([
+        fetch('https://services.swpc.noaa.gov/json/f107_cm_flux.json', { signal: AbortSignal.timeout(5000) }),
+        fetch('https://services.swpc.noaa.gov/products/noaa-planetary-k-index.json', {
+          signal: AbortSignal.timeout(5000),
+        }),
+      ]);
+      if (fluxRes.status === 'fulfilled' && fluxRes.value.ok) {
+        const data = await fluxRes.value.json();
+        if (data?.length) sfi = Math.round(data[data.length - 1].flux || 150);
+      }
+      if (kRes.status === 'fulfilled' && kRes.value.ok) {
+        const data = await kRes.value.json();
+        if (data?.length > 1) kIndex = parseInt(data[data.length - 1][1]) || 2;
+      }
+      ssn = Math.max(0, Math.round((sfi - 67) / 0.97));
+    } catch (e) {
+      logDebug('[PropHeatmap] Using cached/default solar values');
+    }
+    solarCache = { sfi, ssn, kIndex, ts: now };
+    return { sfi, ssn, kIndex };
+  }
+
   const PROP_HEATMAP_CACHE = {};
   const PROP_HEATMAP_TTL = 5 * 60 * 1000; // 5 minutes
   const PROP_HEATMAP_MAX_ENTRIES = 200; // Hard cap on cache entries
@@ -512,27 +549,9 @@ module.exports = function (app, ctx) {
     }
 
     try {
-      // Fetch current solar conditions (same as main propagation endpoint)
-      let sfi = 150,
-        ssn = 100,
-        kIndex = 2;
-      try {
-        const [fluxRes, kRes] = await Promise.allSettled([
-          fetch('https://services.swpc.noaa.gov/json/f107_cm_flux.json'),
-          fetch('https://services.swpc.noaa.gov/products/noaa-planetary-k-index.json'),
-        ]);
-        if (fluxRes.status === 'fulfilled' && fluxRes.value.ok) {
-          const data = await fluxRes.value.json();
-          if (data?.length) sfi = Math.round(data[data.length - 1].flux || 150);
-        }
-        if (kRes.status === 'fulfilled' && kRes.value.ok) {
-          const data = await kRes.value.json();
-          if (data?.length > 1) kIndex = parseInt(data[data.length - 1][1]) || 2;
-        }
-        ssn = Math.max(0, Math.round((sfi - 67) / 0.97));
-      } catch (e) {
-        logDebug('[PropHeatmap] Using default solar values');
-      }
+      // Solar conditions — cached separately so band/mode/power changes don't
+      // each trigger a slow NOAA round-trip
+      const { sfi, ssn, kIndex } = await getSolarData();
 
       const currentHour = new Date().getUTCHours();
       const de = { lat: deLat, lon: deLon };


### PR DESCRIPTION
Every uncached heatmap request was fetching SFI and K-index from NOAA before computing the grid, adding 1-5s of latency on each band/mode/power change. Solar data now cached for 15 minutes and shared across all heatmap requests. Also added 5s timeout on NOAA fetches to prevent hanging.

## What does this PR do?

<!-- A brief description of the change. What problem does it solve or what feature does it add? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1.
2.
3.

## Checklist

- [ ] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<!-- Before/after screenshots or a quick screen recording help reviewers a lot -->
