### PR TITLE
fix: use DXpedition entity coordinates for active DXpedition spots

### DIFF
--- a/server/routes/dxcluster.js
+++ b/server/routes/dxcluster.js
@@ -39,6 +39,34 @@ module.exports = function (app, ctx) {
 
   const CALLSIGN_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
 
+  // Cross-reference a callsign against active DXpeditions.
+  // Returns { lat, lon, entity } if the call matches a known DXpedition,
+  // using the DXpedition's DXCC entity coordinates from cty.dat.
+  const { lookupCall } = require('../../src/server/ctydat.js');
+
+  function lookupDXpeditionLocation(call) {
+    const cache = ctx.dxpeditionCache;
+    if (!cache?.data?.dxpeditions) return null;
+    const upper = (call || '').toUpperCase();
+    const dxped = cache.data.dxpeditions.find((d) => d.isActive && d.callsign?.toUpperCase() === upper);
+    if (!dxped || !dxped.entity) return null;
+
+    // Look up the DXpedition entity in cty.dat's entity list
+    const { getCtyData } = require('../../src/server/ctydat.js');
+    const cty = getCtyData();
+    if (!cty?.entities) return null;
+
+    const entityName = dxped.entity.toLowerCase().replace(/\s+/g, ' ').trim();
+    const match = cty.entities.find((e) => {
+      const eName = (e.entity || '').toLowerCase().replace(/\s+/g, ' ').trim();
+      return eName === entityName || eName.includes(entityName) || entityName.includes(eName);
+    });
+    if (match && match.lat != null && match.lon != null) {
+      return { lat: match.lat, lon: match.lon, country: match.entity, source: 'dxpedition' };
+    }
+    return null;
+  }
+
   // DX Spider Proxy URL (sibling service on Railway or external)
   const DXSPIDER_PROXY_URL = process.env.DXSPIDER_PROXY_URL || 'https://spider-production-1ec7.up.railway.app';
 
@@ -1648,6 +1676,14 @@ module.exports = function (app, ctx) {
                 };
                 dxGridSquare = extractedGrids.dxGrid;
               }
+            }
+          }
+
+          // Check if this callsign is a known active DXpedition — use entity coordinates
+          if (!dxLoc) {
+            const dxpedLoc = lookupDXpeditionLocation(spot.dxCall);
+            if (dxpedLoc) {
+              dxLoc = dxpedLoc;
             }
           }
 

--- a/server/routes/dxpeditions.js
+++ b/server/routes/dxpeditions.js
@@ -7,7 +7,11 @@ module.exports = function (app, ctx) {
   const { fetch, logDebug, logErrorOnce } = ctx;
 
   // DXpedition Calendar - fetches from NG3K ADXO plain text version
-  let dxpeditionCache = { data: null, timestamp: 0, maxAge: 30 * 60 * 1000 }; // 30 min cache
+  const dxpeditionCache = { data: null, timestamp: 0, maxAge: 30 * 60 * 1000 }; // 30 min cache
+
+  // Expose cache so dxcluster.js can cross-reference spotted callsigns
+  // against active DXpeditions for accurate entity coordinates
+  ctx.dxpeditionCache = dxpeditionCache;
 
   app.get('/api/dxpeditions', async (req, res) => {
     try {


### PR DESCRIPTION
DXpedition callsigns like TX5EU (Austral Islands) were showing at the generic prefix location (TX → France) because CTY.DAT maps TX to Metropolitan France.

Now cross-references DX cluster spots against the active DXpedition list from NG3K. If a spotted callsign matches a known active DXpedition, uses the DXpedition's DXCC entity coordinates from cty.dat instead of the generic prefix. This runs after grid square resolution but before HamQTH/prefix fallbacks.

## What does this PR do?

<!-- A brief description of the change. What problem does it solve or what feature does it add? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1.
2.
3.

## Checklist

- [ ] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<!-- Before/after screenshots or a quick screen recording help reviewers a lot -->
