### PR TITLE
fix: DXpedition spots randomly appearing at wrong locations

### DIFF
--- a/server/routes/dxcluster.js
+++ b/server/routes/dxcluster.js
@@ -1650,8 +1650,17 @@ module.exports = function (app, ctx) {
           let dxLoc = null;
           let dxGridSquare = null;
 
-          // Check if spot already has dxGrid from proxy
-          if (spot.dxGrid) {
+          // Check if this is a known DXpedition FIRST — DXpedition entity
+          // coordinates are authoritative. Cluster nodes often send wrong grids
+          // (spotter's grid, cached home grid, etc.) which would place the
+          // DXpedition in Jersey or Alaska instead of the actual operating location.
+          const dxpedLoc = lookupDXpeditionLocation(spot.dxCall);
+          if (dxpedLoc) {
+            dxLoc = dxpedLoc;
+          }
+
+          // For non-DXpedition spots, use grid from proxy (most precise)
+          if (!dxLoc && spot.dxGrid) {
             const gridLoc = maidenheadToLatLon(spot.dxGrid);
             if (gridLoc) {
               dxLoc = {
@@ -1664,7 +1673,7 @@ module.exports = function (app, ctx) {
             }
           }
 
-          // If no grid yet, try extracting from comment
+          // Try extracting grid from comment
           if (!dxLoc && spot.comment) {
             const extractedGrids = extractGridsFromComment(spot.comment);
             if (extractedGrids.dxGrid) {
@@ -1678,14 +1687,6 @@ module.exports = function (app, ctx) {
                 };
                 dxGridSquare = extractedGrids.dxGrid;
               }
-            }
-          }
-
-          // Check if this callsign is a known DXpedition — use entity coordinates
-          if (!dxLoc) {
-            const dxpedLoc = lookupDXpeditionLocation(spot.dxCall);
-            if (dxpedLoc) {
-              dxLoc = dxpedLoc;
             }
           }
 


### PR DESCRIPTION
DX cluster nodes sometimes populate dxGrid with incorrect data — the spotter's grid, a cached home grid, or just wrong data. Since grid-from-spot was priority #1 (before DXpedition lookup), some TX5EU spots showed in Jersey and VK9 spots showed in Alaska.

DXpedition entity lookup now runs FIRST, before any cluster-provided grid squares. DXpedition coordinates are authoritative — the NG3K entity mapped to cty.dat coordinates won't randomly change per spot.

For non-DXpedition callsigns, the grid-from-spot remains highest priority since it's usually accurate for regular stations.

## What does this PR do?

<!-- A brief description of the change. What problem does it solve or what feature does it add? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1.
2.
3.

## Checklist

- [ ] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<!-- Before/after screenshots or a quick screen recording help reviewers a lot -->
