### PR TITLE
fix: NaN coordinates crash — Invalid LatLng object: (NaN, NaN)

### DIFF
--- a/server/routes/dxcluster.js
+++ b/server/routes/dxcluster.js
@@ -1774,16 +1774,20 @@ module.exports = function (app, ctx) {
 
           // Keep spots even when coordinates are missing so the list view can still show them.
           // World map rendering already filters to entries with valid coordinates.
+          // Sanitize coordinates — NaN must not leak to the frontend
+          // (NaN != null is true, so null checks don't catch it)
+          const safeLat = (v) => (Number.isFinite(v) ? v : null);
+
           return {
             spotter: spot.spotter,
-            spotterLat: spotterLoc?.lat ?? null,
-            spotterLon: spotterLoc?.lon ?? null,
+            spotterLat: safeLat(spotterLoc?.lat),
+            spotterLon: safeLat(spotterLoc?.lon),
             spotterCountry: spotterLoc?.country || '',
             spotterGrid: spotterGridSquare,
             spotterLocSource: spotterLoc?.source || null,
             dxCall: spot.dxCall,
-            dxLat: dxLoc?.lat ?? null,
-            dxLon: dxLoc?.lon ?? null,
+            dxLat: safeLat(dxLoc?.lat),
+            dxLon: safeLat(dxLoc?.lon),
             dxCountry: dxLoc?.country || '',
             dxGrid: dxGridSquare,
             dxLocSource: dxLoc?.source || null,

--- a/src/components/AzimuthalMap.jsx
+++ b/src/components/AzimuthalMap.jsx
@@ -542,7 +542,7 @@ export default function AzimuthalMap({
 
         // Only draw spotter circle and lines if spotter coordinates are valid (not null/undefined).
         // Using != null instead of truthy check (&&) ensures coordinates at 0,0 are handled correctly.
-        if (path.spotterLat != null && path.spotterLon != null) {
+        if (Number.isFinite(path.spotterLat) && Number.isFinite(path.spotterLon)) {
           const s = toCanvas(path.spotterLat, path.spotterLon);
           ctx.beginPath();
           ctx.moveTo(s.x, s.y);
@@ -691,7 +691,7 @@ export default function AzimuthalMap({
     // ── POTA spots ───────────────────────────────────────
     if (showPOTA && potaSpots?.length > 0) {
       potaSpots.forEach((spot) => {
-        if (spot.lat == null || spot.lon == null) return;
+        if (!Number.isFinite(spot.lat) || !Number.isFinite(spot.lon)) return;
         const band = normalizeBandKey(spot.band) || bandFromAnyFrequency(spot.freq);
         if (!bandPassesMapFilter(band)) return;
 
@@ -712,7 +712,7 @@ export default function AzimuthalMap({
     // ── WWFF spots ───────────────────────────────────────
     if (showWWFF && wwffSpots?.length > 0) {
       wwffSpots.forEach((spot) => {
-        if (spot.lat == null || spot.lon == null) return;
+        if (!Number.isFinite(spot.lat) || !Number.isFinite(spot.lon)) return;
         const band = normalizeBandKey(spot.band) || bandFromAnyFrequency(spot.freq);
         if (!bandPassesMapFilter(band)) return;
 
@@ -733,7 +733,7 @@ export default function AzimuthalMap({
     // ── SOTA spots ───────────────────────────────────────
     if (showSOTA && sotaSpots?.length > 0) {
       sotaSpots.forEach((spot) => {
-        if (spot.lat == null || spot.lon == null) return;
+        if (!Number.isFinite(spot.lat) || !Number.isFinite(spot.lon)) return;
         const band = normalizeBandKey(spot.band) || bandFromAnyFrequency(spot.freq);
         if (!bandPassesMapFilter(band)) return;
 
@@ -753,7 +753,7 @@ export default function AzimuthalMap({
     // ── WWBOTA spots ─────────────────────────────────────
     if (showWWBOTA && wwbotaSpots?.length > 0) {
       wwbotaSpots.forEach((spot) => {
-        if (spot.lat == null || spot.lon == null) return;
+        if (!Number.isFinite(spot.lat) || !Number.isFinite(spot.lon)) return;
         const band = normalizeBandKey(spot.band) || bandFromAnyFrequency(spot.freq);
         if (!bandPassesMapFilter(band)) return;
 
@@ -770,7 +770,7 @@ export default function AzimuthalMap({
     }
 
     // ── DX marker ────────────────────────────────────────
-    if (dxLocation?.lat != null && dxLocation?.lon != null) {
+    if (Number.isFinite(dxLocation?.lat) && Number.isFinite(dxLocation?.lon)) {
       const dp = toCanvas(dxLocation.lat, dxLocation.lon);
       ctx.beginPath();
       ctx.arc(dp.x, dp.y, 10, 0, Math.PI * 2);

--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -1193,8 +1193,13 @@ export const WorldMap = ({
         if (!bandPassesMapFilter(band)) return;
 
         try {
-          if (path.spotterLat == null || path.spotterLon == null || path.dxLat == null || path.dxLon == null) return;
-          if (isNaN(path.spotterLat) || isNaN(path.spotterLon) || isNaN(path.dxLat) || isNaN(path.dxLon)) return;
+          if (
+            !Number.isFinite(path.spotterLat) ||
+            !Number.isFinite(path.spotterLon) ||
+            !Number.isFinite(path.dxLat) ||
+            !Number.isFinite(path.dxLon)
+          )
+            return;
 
           const pathPoints = getGreatCirclePoints(path.spotterLat, path.spotterLon, path.dxLat, path.dxLon);
 
@@ -1355,7 +1360,7 @@ export const WorldMap = ({
 
     if (show && spots) {
       spots.forEach((spot) => {
-        if (spot.lat != null && spot.lon != null) {
+        if (Number.isFinite(spot.lat) && Number.isFinite(spot.lon)) {
           const band = normalizeBandKey(spot.band) || bandFromAnyFrequency(spot.freq);
           if (!bandPassesMapFilter(band)) return;
 


### PR DESCRIPTION
NaN != null is true, so all null-checks let NaN coordinates through to Leaflet which crashes with "Invalid LatLng object: (NaN, NaN)".

Server: sanitize coordinates with Number.isFinite() before sending — NaN from bad grid lookups or prefix estimates now becomes null.

Frontend: replaced all spot/path coordinate guards from
  spot.lat != null  →  Number.isFinite(spot.lat)
in WorldMap.jsx (placeSpots, DX paths) and AzimuthalMap.jsx (POTA, WWFF, SOTA, WWBOTA, DX marker, spotter paths).

Credit: Alan (alanhargreaves) caught this.

## What does this PR do?

<!-- A brief description of the change. What problem does it solve or what feature does it add? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1.
2.
3.

## Checklist

- [ ] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<!-- Before/after screenshots or a quick screen recording help reviewers a lot -->
