### PR TITLE
fix: correct falsy checks for zero lat/lon coordinates

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -103,24 +103,24 @@ if (fs.existsSync(configJsonPath)) {
 let stationLat = parseFloat(process.env.LATITUDE);
 let stationLon = parseFloat(process.env.LONGITUDE);
 
-if ((!stationLat || !stationLon) && locator) {
+if ((!Number.isFinite(stationLat) || !Number.isFinite(stationLon)) && locator) {
   const coords = gridToLatLon(locator);
   if (coords) {
-    stationLat = stationLat || coords.latitude;
-    stationLon = stationLon || coords.longitude;
+    stationLat = Number.isFinite(stationLat) ? stationLat : coords.latitude;
+    stationLon = Number.isFinite(stationLon) ? stationLon : coords.longitude;
   }
 }
 
 // Fallback to config.json location if no env
-if (!stationLat && jsonConfig.location?.lat) stationLat = jsonConfig.location.lat;
-if (!stationLon && jsonConfig.location?.lon) stationLon = jsonConfig.location.lon;
+if (!Number.isFinite(stationLat) && jsonConfig.location?.lat != null) stationLat = jsonConfig.location.lat;
+if (!Number.isFinite(stationLon) && jsonConfig.location?.lon != null) stationLon = jsonConfig.location.lon;
 
 const CONFIG = {
   // Station info (env takes precedence over config.json)
   callsign: process.env.CALLSIGN || jsonConfig.callsign || 'N0CALL',
   gridSquare: locator || jsonConfig.locator || '',
-  latitude: stationLat || 40.7128,
-  longitude: stationLon || -74.006,
+  latitude: Number.isFinite(stationLat) ? stationLat : 40.7128,
+  longitude: Number.isFinite(stationLon) ? stationLon : -74.006,
 
   // Display preferences
   units: process.env.UNITS || jsonConfig.units || 'imperial',
@@ -134,8 +134,12 @@ const CONFIG = {
   layout: process.env.LAYOUT || jsonConfig.layout || 'modern',
 
   // DX target
-  dxLatitude: parseFloat(process.env.DX_LATITUDE) || jsonConfig.defaultDX?.lat || 51.5074,
-  dxLongitude: parseFloat(process.env.DX_LONGITUDE) || jsonConfig.defaultDX?.lon || -0.1278,
+  dxLatitude: Number.isFinite(parseFloat(process.env.DX_LATITUDE))
+    ? parseFloat(process.env.DX_LATITUDE)
+    : (jsonConfig.defaultDX?.lat ?? 51.5074),
+  dxLongitude: Number.isFinite(parseFloat(process.env.DX_LONGITUDE))
+    ? parseFloat(process.env.DX_LONGITUDE)
+    : (jsonConfig.defaultDX?.lon ?? -0.1278),
 
   // Feature toggles
   showSatellites: process.env.SHOW_SATELLITES !== 'false' && jsonConfig.features?.showSatellites !== false,

--- a/server/routes/aprs.js
+++ b/server/routes/aprs.js
@@ -400,8 +400,8 @@ module.exports = function (app, ctx) {
                   status: status || 'Checked in',
                   checkinTime: Date.now(),
                   lastHeard: Date.now(),
-                  lat: station.lat || null,
-                  lon: station.lon || null,
+                  lat: station.lat ?? null,
+                  lon: station.lon ?? null,
                   tokens: station.tokens || [],
                   source: station.source || null,
                 });
@@ -545,8 +545,8 @@ module.exports = function (app, ctx) {
       status: status || 'Checked in',
       checkinTime: Date.now(),
       lastHeard: Date.now(),
-      lat: station?.lat || null,
-      lon: station?.lon || null,
+      lat: station?.lat ?? null,
+      lon: station?.lon ?? null,
       tokens: station?.tokens || [],
       source: 'manual',
     });

--- a/server/routes/wsjtx.js
+++ b/server/routes/wsjtx.js
@@ -621,7 +621,7 @@ module.exports = function (app, ctx) {
         }
 
         // If no grid from message, try callsign → grid cache (from prior CQ/exchange with grid)
-        if (!decode.lat) {
+        if (decode.lat == null) {
           const targetCall = (
             parsed.caller ||
             (parsed.deCall == CONFIG.callsign ? parsed.dxCall : parsed.deCall) ||
@@ -639,7 +639,7 @@ module.exports = function (app, ctx) {
         }
 
         // Try HamQTH callsign cache (DXCC-level, more accurate than prefix centroid)
-        if (!decode.lat) {
+        if (decode.lat == null) {
           const rawCall = (
             parsed.caller ||
             (parsed.deCall == CONFIG.callsign ? parsed.dxCall : parsed.deCall) ||
@@ -686,7 +686,7 @@ module.exports = function (app, ctx) {
         }
 
         // Last resort: estimate from callsign prefix
-        if (!decode.lat) {
+        if (decode.lat == null) {
           const rawCall = parsed.caller || (parsed.deCall == CONFIG.callsign ? parsed.dxCall : parsed.deCall) || '';
           const targetCall = extractBaseCallsign(rawCall);
           if (targetCall) {

--- a/src/components/AzimuthalMap.jsx
+++ b/src/components/AzimuthalMap.jsx
@@ -162,8 +162,8 @@ export default function AzimuthalMap({
     return !!key && selectedMapBands.has(key);
   };
 
-  const lat0 = deLocation?.lat || 0;
-  const lon0 = deLocation?.lon || 0;
+  const lat0 = deLocation?.lat ?? 0;
+  const lon0 = deLocation?.lon ?? 0;
 
   // Load GeoJSON once
   useEffect(() => {

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -47,8 +47,8 @@ export const SettingsPanel = ({
   const [swapHeaderClocks, setSwapHeaderClocks] = useState(config?.swapHeaderClocks || false);
   const [showMutualReception, setShowMutualReception] = useState(config?.showMutualReception ?? true);
   const [gridSquare, setGridSquare] = useState(config?.locator || '');
-  const [lat, setLat] = useState(config?.location?.lat || 0);
-  const [lon, setLon] = useState(config?.location?.lon || 0);
+  const [lat, setLat] = useState(config?.location?.lat ?? 0);
+  const [lon, setLon] = useState(config?.location?.lon ?? 0);
   const [layout, setLayout] = useState(config?.layout || 'modern');
   const [mouseZoom, setMouseZoom] = useState(config?.mouseZoom || 50);
   const [timezone, setTimezone] = useState(config?.timezone || '');
@@ -177,8 +177,8 @@ export const SettingsPanel = ({
     if (config) {
       setCallsign(config.callsign || '');
       setheaderSize(config.headerSize || 1.0);
-      setLat(config.location?.lat || 0);
-      setLon(config.location?.lon || 0);
+      setLat(config.location?.lat ?? 0);
+      setLon(config.location?.lon ?? 0);
       setLayout(config.layout || 'modern');
       setMouseZoom(config.mouseZoom || 50);
       setTimezone(config.timezone || '');

--- a/src/hooks/useEmcommData.js
+++ b/src/hooks/useEmcommData.js
@@ -24,7 +24,7 @@ export const useEmcommData = (options = {}) => {
 
   // Reverse geocode lat/lon to state code via Nominatim
   const resolveState = useCallback(async (loc) => {
-    if (loc.state || !loc.lat || !loc.lon) return loc;
+    if (loc.state || loc.lat == null || loc.lon == null) return loc;
     // Use cached result if location hasn't changed
     if (resolvedStateRef.current?.lat === loc.lat && resolvedStateRef.current?.lon === loc.lon) {
       return { ...loc, state: resolvedStateRef.current.state };
@@ -49,7 +49,7 @@ export const useEmcommData = (options = {}) => {
 
   const fetchAlerts = useCallback(async () => {
     const loc = locationRef.current;
-    if (!loc?.lat || !loc?.lon) return;
+    if (loc?.lat == null || loc?.lon == null) return;
     try {
       const res = await apiFetch(`/api/emcomm/alerts?lat=${loc.lat}&lon=${loc.lon}`, { cache: 'no-store' });
       if (res?.ok) {
@@ -63,7 +63,7 @@ export const useEmcommData = (options = {}) => {
 
   const fetchShelters = useCallback(async () => {
     const loc = locationRef.current;
-    if (!loc?.lat || !loc?.lon) return;
+    if (loc?.lat == null || loc?.lon == null) return;
     try {
       const res = await apiFetch(`/api/emcomm/shelters?lat=${loc.lat}&lon=${loc.lon}&radius=200`, {
         cache: 'no-store',

--- a/src/hooks/usePOTASpots.js
+++ b/src/hooks/usePOTASpots.js
@@ -96,17 +96,17 @@ export const usePOTASpots = () => {
           setData(
             validSpots.map((s) => {
               // Use API coordinates, fall back to grid square
-              let lat = s.latitude ? parseFloat(s.latitude) : null;
-              let lon = s.longitude ? parseFloat(s.longitude) : null;
+              let lat = s.latitude != null ? parseFloat(s.latitude) : null;
+              let lon = s.longitude != null ? parseFloat(s.longitude) : null;
 
-              if ((!lat || !lon) && s.grid6) {
+              if ((lat == null || lon == null) && s.grid6) {
                 const loc = gridToLatLon(s.grid6);
                 if (loc) {
                   lat = loc.lat;
                   lon = loc.lon;
                 }
               }
-              if ((!lat || !lon) && s.grid4) {
+              if ((lat == null || lon == null) && s.grid4) {
                 const loc = gridToLatLon(s.grid4);
                 if (loc) {
                   lat = loc.lat;

--- a/src/layouts/EmcommLayout.jsx
+++ b/src/layouts/EmcommLayout.jsx
@@ -191,7 +191,7 @@ export default function EmcommLayout(props) {
 
   // Calculate distance from DE for shelters
   const sheltersWithDistance = useMemo(() => {
-    if (!config.location?.lat || !config.location?.lon) return shelters;
+    if (config.location?.lat == null || config.location?.lon == null) return shelters;
     return shelters
       .map((s) => ({
         ...s,
@@ -202,7 +202,7 @@ export default function EmcommLayout(props) {
 
   // Calculate distance for emcomm APRS stations
   const emcommStationsWithDistance = useMemo(() => {
-    if (!config.location?.lat || !config.location?.lon) return emcommStations;
+    if (config.location?.lat == null || config.location?.lon == null) return emcommStations;
     return emcommStations
       .map((s) => ({
         ...s,
@@ -239,7 +239,7 @@ export default function EmcommLayout(props) {
     overlayLayersRef.current = [];
 
     const de = config.location;
-    if (!de?.lat || !de?.lon) return;
+    if (de?.lat == null || de?.lon == null) return;
 
     // Range rings at 50, 100, 200 km
     [50, 100, 200].forEach((km) => {
@@ -293,7 +293,7 @@ export default function EmcommLayout(props) {
 
     // Shelter markers
     shelters.forEach((shelter) => {
-      if (!shelter.lat || !shelter.lon) return;
+      if (shelter.lat == null || shelter.lon == null) return;
       const color = SHELTER_STATUS_COLORS[shelter.status] || '#6b7280';
       const marker = L.circleMarker([shelter.lat, shelter.lon], {
         radius: 8,
@@ -314,7 +314,7 @@ export default function EmcommLayout(props) {
 
     // EmComm APRS station markers with token popups
     emcommStationsWithDistance.forEach((station) => {
-      if (!station.lat || !station.lon) return;
+      if (station.lat == null || station.lon == null) return;
       const marker = L.circleMarker([station.lat, station.lon], {
         radius: 6,
         color: '#22d3ee',

--- a/src/plugins/layers/useActiveUsers.js
+++ b/src/plugins/layers/useActiveUsers.js
@@ -65,7 +65,7 @@ export function useLayer({ enabled = false, opacity = 0.85, map = null, callsign
     const newMarkers = [];
 
     users.forEach((user) => {
-      if (!user.lat || !user.lon) return;
+      if (user.lat == null || user.lon == null) return;
       const isMe = user.call === myCall;
 
       const bg = isMe ? 'rgba(34, 197, 94, 0.9)' : 'rgba(99, 102, 241, 0.85)';

--- a/src/plugins/layers/useEarthquakes.js
+++ b/src/plugins/layers/useEarthquakes.js
@@ -110,7 +110,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
       currentQuakeIds.add(quakeId);
 
       // Skip if invalid coordinates
-      if (!lat || !lon || isNaN(lat) || isNaN(lon)) return;
+      if (lat == null || lon == null || isNaN(lat) || isNaN(lon)) return;
 
       // Check if this is a new earthquake (but not on first load)
       const isNew = !isFirstLoad.current && !previousQuakeIds.current.has(quakeId);

--- a/src/plugins/layers/useLightning.js
+++ b/src/plugins/layers/useLightning.js
@@ -591,10 +591,10 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
       return;
     }
 
-    const stationLat = config.location?.lat || config.latitude;
-    const stationLon = config.location?.lon || config.longitude;
+    const stationLat = config.location?.lat ?? config.latitude;
+    const stationLon = config.location?.lon ?? config.longitude;
 
-    if (!stationLat || !stationLon || lightningData.length === 0) return;
+    if (!Number.isFinite(stationLat) || !Number.isFinite(stationLon) || lightningData.length === 0) return;
 
     const now = Date.now();
     const ONE_MINUTE_AGO = now - 60000;
@@ -678,12 +678,12 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
       return;
     }
 
-    const stationLat = config.location?.lat || config.latitude;
-    const stationLon = config.location?.lon || config.longitude;
+    const stationLat = config.location?.lat ?? config.latitude;
+    const stationLon = config.location?.lon ?? config.longitude;
 
     console.log('[Lightning] Proximity: Station location:', { stationLat, stationLon });
 
-    if (!stationLat || !stationLon) {
+    if (!Number.isFinite(stationLat) || !Number.isFinite(stationLon)) {
       console.log('[Lightning] Proximity: No station location - aborting');
       return;
     }
@@ -827,10 +827,10 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
       return;
     }
 
-    const stationLat = config.location?.lat || config.latitude;
-    const stationLon = config.location?.lon || config.longitude;
+    const stationLat = config.location?.lat ?? config.latitude;
+    const stationLon = config.location?.lon ?? config.longitude;
 
-    if (!stationLat || !stationLon) return;
+    if (!Number.isFinite(stationLat) || !Number.isFinite(stationLon)) return;
 
     const now = Date.now();
 

--- a/src/plugins/layers/useSatelliteLayer.js
+++ b/src/plugins/layers/useSatelliteLayer.js
@@ -51,8 +51,8 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
       const data = await response.json();
 
       const observerGd = {
-        latitude: satellite.degreesToRadians(config?.lat || 43.44),
-        longitude: satellite.degreesToRadians(config?.lon || -88.63),
+        latitude: satellite.degreesToRadians(config?.lat ?? 43.44),
+        longitude: satellite.degreesToRadians(config?.lon ?? -88.63),
         height: (config?.alt || 260) / 1000,
       };
 

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -107,12 +107,12 @@ export const loadConfig = () => {
       callsign: serverConfig.callsign && serverConfig.callsign !== 'N0CALL' ? serverConfig.callsign : config.callsign,
       locator: serverConfig.locator || config.locator,
       location: {
-        lat: serverConfig.latitude || config.location.lat,
-        lon: serverConfig.longitude || config.location.lon,
+        lat: serverConfig.latitude ?? config.location.lat,
+        lon: serverConfig.longitude ?? config.location.lon,
       },
       defaultDX: {
-        lat: serverConfig.dxLatitude || config.defaultDX.lat,
-        lon: serverConfig.dxLongitude || config.defaultDX.lon,
+        lat: serverConfig.dxLatitude ?? config.defaultDX.lat,
+        lon: serverConfig.dxLongitude ?? config.defaultDX.lon,
       },
       units: serverConfig.units || config.units,
       allUnits: serverConfig.allUnits || config.allUnits,


### PR DESCRIPTION
## Summary

- Replace `||` / `!` falsy checks with nullish-safe alternatives (`??`, `== null`, `Number.isFinite()`) throughout the codebase so that stations on the equator (lat=0) or prime meridian (lon=0) are handled correctly instead of being treated as missing values
- 13 files changed across server config, APRS, WSJTX, POTA spots, lightning, satellites, EmComm, and UI components
- Server-side `parseFloat()` results additionally guarded with `Number.isFinite()` to correctly distinguish an unset env var (NaN) from an explicitly configured zero

## Files changed

| File | Fix applied |
|------|-------------|
| `server/config.js` | `Number.isFinite()` guards + ternaries for fallbacks |
| `src/utils/config.js` | `\|\|` → `??` for lat/lon merging |
| `src/plugins/layers/useLightning.js` | `\|\|` → `??` for assignment; `Number.isFinite()` for guards |
| `src/hooks/usePOTASpots.js` | `!= null` init; `== null` guards for grid fallback |
| `server/routes/wsjtx.js` | `!decode.lat` → `decode.lat == null` (3 locations) |
| `server/routes/aprs.js` | `station.lat \|\| null` → `station.lat ?? null` (2 locations) |
| `src/plugins/layers/useEarthquakes.js` | `!lat \|\| !lon` → `lat == null \|\| lon == null` |
| `src/plugins/layers/useActiveUsers.js` | same |
| `src/plugins/layers/useSatelliteLayer.js` | `\|\|` → `??` for observer position fallbacks |
| `src/layouts/EmcommLayout.jsx` | `== null` checks (5 locations) |
| `src/hooks/useEmcommData.js` | `== null` checks (3 locations) |
| `src/components/AzimuthalMap.jsx` | `\|\| 0` → `?? 0` |
| `src/components/SettingsPanel.jsx` | `\|\| 0` → `?? 0` (4 locations) |

## Test plan

- [ ] Configure a station with `LATITUDE=0` and/or `LONGITUDE=0` (equator / prime meridian) — location should be respected, not fall back to New York default
- [ ] Verify POTA spots for activations at/near 0,0 render on the map correctly
- [ ] Verify WSJTX decode location resolution does not skip a valid lat=0 and fall through to prefix estimation
- [ ] Verify APRS net roster preserves lat=0/lon=0 station coordinates instead of storing null
- [ ] Verify lightning proximity alerts and satellite pass calculations work for a station at lat=0 or lon=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)