### PR TITLE
fix(stats): align unique visitor counting with session tracking scope

### DIFF
--- a/server/services/visitor-stats.js
+++ b/server/services/visitor-stats.js
@@ -365,12 +365,11 @@ function createVisitorStatsService(ctx) {
     rolloverVisitorStats();
 
     const rawIp = req.ip || req.connection?.remoteAddress || 'unknown';
-    if (req.path !== '/api/health' && !req.path.startsWith('/assets/')) {
-      sessionTracker.touch(rawIp);
-    }
+    const isTrackable = req.path !== '/api/health' && !req.path.startsWith('/assets/');
 
-    const countableRoutes = ['/', '/index.html', '/api/config'];
-    if (countableRoutes.includes(req.path)) {
+    if (isTrackable) {
+      sessionTracker.touch(rawIp);
+
       const ipHash = hashIP(rawIp);
 
       const isNewToday = !todayIPHashes.has(ipHash);


### PR DESCRIPTION
## Summary
Unique visitor counting was limited to 3 routes (`/`, `/index.html`, `/api/config`) while session tracking covered all non-health/asset requests. This caused concurrent sessions to far exceed reported unique visitors (e.g. 1900 concurrent but only 1100 unique today).

Now both use the same scope — all requests except `/api/health` and `/assets/*`.

## Test plan
- [ ] Confirm unique visitors today >= concurrent sessions on `/api/health`
- [ ] Confirm `/api/health` and `/assets/*` requests are still excluded from counts
