### PR TITLE
fix(propagation): use usedITURHFProp guard to prevent sparse-array nu…

### DIFF
--- a/server/routes/propagation.js
+++ b/server/routes/propagation.js
@@ -425,8 +425,11 @@ module.exports = function (app, ctx) {
       }
 
       // ===== FALLBACK: Built-in calculations =====
-      // Used when ITURHFProp is unavailable (self-hosted without the service)
-      if (!predictions['160m'] || predictions['160m'].length === 0) {
+      // Used when ITURHFProp is unavailable (self-hosted without the service).
+      // Also fills in the remaining 23 hours when only a single-hour ITURHFProp
+      // result was used — without this the sparse array holes become JSON nulls
+      // and crash the client (.find callback receives null instead of an object).
+      if (!usedITURHFProp) {
         logDebug(
           `[Propagation] Using FALLBACK mode (built-in calculations)${useITURHFProp ? ' — ITURHFProp unavailable' : ''}`,
         );


### PR DESCRIPTION
## What does this PR do?

The crash path was:

1. ITURHFProp full hourly fetch fails → single-hour fetch succeeds → `predictions[band][14] = {...}` (sparse array, `usedITURHFProp` stays `false`)
2. Fallback guard `predictions['160m'].length === 0` is `false` (sparse array length is 15) → fallback skipped
3. Server JSON-serializes sparse array → holes become `null` → client receives `[null, null, ..., {hour:14,...}]`
4. `.find(h => h.hour === hour)` calls callback with `h = null` → **crash**

The fix uses `!usedITURHFProp` which is already the correct semantic: "did we get complete 24-hour ITURHFProp data?" If not, run the fallback to fill all 24 slots (the pre-seeded single-hour entry at `existing[currentHour]` is preserved by the `if (existing[hour])` check on line 440).
## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## Checklist

- [x] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

Before:
<img width="678" height="512" alt="Bildschirmfoto 2026-04-07 um 08 42 38" src="https://github.com/user-attachments/assets/bbafd0a6-ab82-42c0-b591-4737fa5d6ccd" />

After, to be tested.
