### PR TITLE
Make rig-bridge provide all packet fields that useWSJTX expects.

### DIFF
--- a/rig-bridge/rig-bridge.js
+++ b/rig-bridge/rig-bridge.js
@@ -115,6 +115,7 @@ pluginBus.on('decode', (msg) => {
     time: msg.time?.formatted ?? '',
     mode: msg.mode,
     message: msg.message,
+    type: msg.message.startsWith('CQ') ? 'CQ' : 'QSO',
     dialFrequency: msg.dialFrequency,
     timestamp: Date.now(),
   };


### PR DESCRIPTION
## What does this PR do?

`useWSJTX.js` expects each decoded packet to contain a type field set to either 'CQ' or 'QSO', otherwise when we go to display "CQ only", we get nothing.

This change updates rig-bridge.js to provide it.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Bring up the WSJTX panel and select "CQ only"
2. Note that we get entries (assuming we are listening to a radio)

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<img width="343" height="425" alt="image" src="https://github.com/user-attachments/assets/0d29867d-4978-4225-9464-1f986efa4aec" />