### PR TITLE
Don't call fetchFull() on a useVisibilityRefresh() in useWSJTX()

### DIFF
--- a/src/hooks/useWSJTX.js
+++ b/src/hooks/useWSJTX.js
@@ -182,8 +182,10 @@ export function useWSJTX(enabled = true) {
   }, [enabled, fetchFull, pollDecodes]);
 
   // Refresh immediately when tab becomes visible (handles browser throttling)
+  // Don't do this if we are using SSE as fetchFull() flushes our history and
+  // SSE will need to uld it up again from scratch.
   useVisibilityRefresh(() => {
-    if (enabled) fetchFull();
+    if (enabled && !isLocalMode.current) fetchFull();
   }, 5000);
 
   // Receive decode/status/qso events pushed over the rig-bridge SSE /stream


### PR DESCRIPTION


## What does this PR do?

The aim of calling `fetchFull()` in `useVisibilityRefresh()` is to quickly schedule a full next pull from the API (which we are not using). It also clears the current entries as it believes it's going to pull a full history, This is not the case with SSE.

Indeed if you move off a tab or close the browser and then come back, you end up with an empty panel for WSJT-X.

This change ensures that if we are using SSE that we don't make that call.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Display the WSJT-X Panel (I find teh CQ Oly sessions more useful here as they refresh slower)
2. Navigate away from the OHC tab and then back
3. Note that we retain history

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included
