### PR TITLE
Feature/wsjtx sse enrichment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Claude Code local config
+# Claude Code local config — AI assistant instructions, not part of the project source
 .claude/
 CLAUDE.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Claude Code local config
 .claude/
+CLAUDE.md
 
 # Dependencies
 node_modules/

--- a/rig-bridge/README.md
+++ b/rig-bridge/README.md
@@ -438,6 +438,17 @@ By default, WSJT-X sends its decoded packets only to one listener. If you want b
 2. In Rig Bridge → Plugins → WSJT-X Relay → tick **Enable Multicast**, group address `224.0.0.1`
 3. Click **Save**
 
+### HamQTH callsign lookup (optional)
+
+When **HamQTH callsign lookup** is enabled in the WSJT-X Relay settings, Rig Bridge resolves unknown callsigns to country-level coordinates via the public [HamQTH DXCC API](https://www.hamqth.com/dxcc.php). This places map pins for stations whose FT8 message did not include a grid square.
+
+**What to know before enabling it:**
+
+- Lookups use the unauthenticated `dxcc.php` endpoint, which is intended for lookup tools. Rig Bridge caps requests at 2 per second globally and waits at least 60 seconds before retrying any individual callsign, so the traffic volume is modest even on a busy 20m FT8 band.
+- Results are cached for 24 hours in `hamqth-cache.json` (stored alongside `rig-bridge-config.json`) and survive restarts, so each callsign is typically looked up only once per day.
+- Lookups require outbound internet access (port 443) from the machine running Rig Bridge.
+- If HamQTH is unreachable, decodes simply show no lat/lon for unresolved callsigns — no errors are shown and operation is otherwise unaffected.
+
 ---
 
 ## APRS via Local TNC _(Beta)_

--- a/rig-bridge/core/server.js
+++ b/rig-bridge/core/server.js
@@ -820,6 +820,16 @@ function buildSetupHtml(version, firstRunToken = null) {
             </div>
           </div>
 
+          <!-- HamQTH callsign lookup (always visible when enabled) -->
+          <div class="checkbox-row" style="margin-top:10px;">
+            <input type="checkbox" id="wsjtxHamqth">
+            <span>HamQTH callsign lookup</span>
+          </div>
+          <div class="help-text" style="margin-top:-8px; margin-bottom:10px;">
+            Resolve unknown callsigns to country-level coordinates via the HamQTH DXCC database.
+            Results are cached for 24 h. Requires outbound internet access from this machine.
+          </div>
+
           <!-- Server relay fields — only shown in relay mode -->
           <div id="wsjtxServerOpts" style="display:none; margin-top:4px; padding:10px 12px; background:#1a1f2e; border:1px solid #2d3548; border-radius:6px;">
             <label>OpenHamClock Server URL</label>
@@ -1130,6 +1140,7 @@ function buildSetupHtml(version, firstRunToken = null) {
       document.getElementById('wsjtxMulticast').checked = !!w.multicast;
       document.getElementById('wsjtxMulticastGroup').value = w.multicastGroup || '224.0.0.1';
       document.getElementById('wsjtxMulticastInterface').value = w.multicastInterface || '';
+      document.getElementById('wsjtxHamqth').checked = !!w.hamqthLookup;
       // Set delivery mode radio
       const relayMode = !!w.relayToServer;
       document.getElementById('wsjtxModeSSE').checked = !relayMode;
@@ -1200,6 +1211,7 @@ function buildSetupHtml(version, firstRunToken = null) {
         multicast: document.getElementById('wsjtxMulticast').checked,
         multicastGroup: document.getElementById('wsjtxMulticastGroup').value.trim() || '224.0.0.1',
         multicastInterface: document.getElementById('wsjtxMulticastInterface').value.trim(),
+        hamqthLookup: document.getElementById('wsjtxHamqth').checked,
       };
       try {
         const res = await fetch('/api/config', {
@@ -1231,11 +1243,14 @@ function buildSetupHtml(version, firstRunToken = null) {
           if (!data.running) {
             el.textContent = 'Not running';
             el.style.color = '#6b7280';
-          } else if (!data.serverReachable) {
+          } else if (data.relayToServer && !data.serverReachable) {
             el.textContent = 'Running — connecting to server...';
             el.style.color = '#f59e0b';
           } else {
-            el.textContent = 'Running — ' + data.decodeCount + ' decodes, ' + data.relayCount + ' relayed';
+            let status = 'Running — ' + data.decodeCount + ' decodes';
+            if (data.relayToServer) status += ', ' + data.relayCount + ' relayed';
+            if (data.hamqthLookup) status += ', ' + data.callsignCacheSize + ' callsigns cached';
+            el.textContent = status;
             el.style.color = '#22c55e';
           }
         } catch (e) {}

--- a/rig-bridge/lib/wsjtx-enrich.js
+++ b/rig-bridge/lib/wsjtx-enrich.js
@@ -53,7 +53,7 @@ function isGrid(s) {
   if (!s || s.length < 4) return false;
   const g = s.toUpperCase();
   if (FT8_TOKENS.has(g)) return false;
-  return /^[A-R]{2}\d{2}(?:[A-Xa-x]{2})?$/.test(s);
+  return /^[A-R]{2}\d{2}(?:[A-X]{2})?$/.test(g);
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -297,8 +297,8 @@ function triggerHamqthLookup(callsign, callsignCache, inflightSet, onResult) {
       res.on('end', () => {
         inflightSet.delete(callsign);
         if (res.statusCode !== 200) return;
-        const latMatch = body.match(/<lat>([^<]+)<\/lat>/);
-        const lonMatch = body.match(/<lng>([^<]+)<\/lng>/);
+        const latMatch = body.match(/<lat[^>]*>(-?[0-9.]+)<\/lat>/);
+        const lonMatch = body.match(/<lng[^>]*>(-?[0-9.]+)<\/lng>/);
         if (!latMatch || !lonMatch) return;
         const lat = parseFloat(latMatch[1]);
         const lon = parseFloat(lonMatch[1]);

--- a/rig-bridge/lib/wsjtx-enrich.js
+++ b/rig-bridge/lib/wsjtx-enrich.js
@@ -15,14 +15,17 @@
  *  • In-message grid cache               — remembers callsign → grid from CQ
  *    and exchange messages; entries expire after 2 h
  *  • HamQTH callsign lookup (opt-in)     — resolves unknown callsigns to
- *    country-level lat/lon; results cached 24 h, max 5 concurrent requests
+ *    country-level lat/lon; results cached 24 h, max 5 concurrent requests,
+ *    per-callsign 60 s cooldown, global 2 req/s QPS cap
  *
  * Exported helpers
  * ────────────────
  *  gridToLatLon(grid)                         → { lat, lon } | null
  *  getBandFromHz(freqHz)                      → string  (e.g. '20m')
  *  createGridCache()                          → { get, set, prune, size }
- *  createCallsignCache()                      → { get, set, prune, size }
+ *  createCallsignCache()                      → { get, set, prune, serialize, size }
+ *  loadCallsignCache(filePath, cache)         → void  (populates cache from JSON file)
+ *  saveCallsignCache(filePath, cache)         → void  (writes cache entries to JSON file)
  *  parseDecodeMessage(text, cache, myCall)    → parsed object
  *  enrichDecode(msg, clientState, gridCache,
  *               myCall, callsignCache)        → enriched decode object
@@ -30,9 +33,11 @@
  *  enrichQso(msg)                             → enriched QSO object
  *  enrichWspr(msg)                            → enriched WSPR object
  *  triggerHamqthLookup(callsign,
- *    callsignCache, inflightSet, onResult)    → void  (fire-and-forget)
+ *    callsignCache, inflightSet, onResult,
+ *    lastAttemptedMap)                        → void  (fire-and-forget)
  */
 
+const fs = require('fs');
 const https = require('https');
 const http = require('http');
 const { URL } = require('url');
@@ -208,9 +213,11 @@ const CALLSIGN_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
 function createCallsignCache() {
   const _map = new Map();
 
-  function set(callsign, lat, lon) {
+  // timestamp is optional — used when loading persisted entries to preserve
+  // their original expiry time rather than resetting the TTL on every load.
+  function set(callsign, lat, lon, timestamp) {
     if (!callsign || lat == null || lon == null) return;
-    _map.set(callsign.toUpperCase(), { lat, lon, timestamp: Date.now() });
+    _map.set(callsign.toUpperCase(), { lat, lon, timestamp: timestamp ?? Date.now() });
   }
 
   function get(callsign) {
@@ -231,10 +238,21 @@ function createCallsignCache() {
     }
   }
 
+  // Returns an array of { callsign, lat, lon, timestamp } for persistence.
+  function serialize() {
+    return Array.from(_map.entries()).map(([callsign, entry]) => ({
+      callsign,
+      lat: entry.lat,
+      lon: entry.lon,
+      timestamp: entry.timestamp,
+    }));
+  }
+
   return {
     get,
     set,
     prune,
+    serialize,
     get size() {
       return _map.size;
     },
@@ -247,6 +265,67 @@ function createCallsignCache() {
 
 const HAMQTH_MAX_CONCURRENT = 5;
 const HAMQTH_TIMEOUT_MS = 5000;
+// Per-callsign cooldown — don't retry within 60 s of the last attempt
+// (success or failure), preventing rapid hammering on a busy FT8 band.
+const HAMQTH_COOLDOWN_MS = 60_000;
+// Global QPS cap — module-level sliding window shared across all plugin instances.
+const HAMQTH_QPS_MAX = 2;
+const _hamqthQpsWindow = [];
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Callsign cache persistence helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Populate `cache` from a JSON file previously written by saveCallsignCache().
+ * Expired entries (older than CALLSIGN_CACHE_TTL) are silently skipped.
+ * All errors are swallowed — missing or corrupt files result in an empty cache.
+ *
+ * @param {string} filePath  Absolute path to the JSON cache file
+ * @param {object} cache     Cache from createCallsignCache()
+ */
+function loadCallsignCache(filePath, cache) {
+  if (!filePath) return;
+  try {
+    if (!fs.existsSync(filePath)) return;
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    if (!Array.isArray(raw.entries)) return;
+    const cutoff = Date.now() - CALLSIGN_CACHE_TTL;
+    let loaded = 0;
+    for (const entry of raw.entries) {
+      if (!entry.callsign || entry.lat == null || entry.lon == null) continue;
+      if ((entry.timestamp ?? 0) < cutoff) continue; // expired
+      // Preserve the original timestamp so entries expire at the right time
+      cache.set(entry.callsign, entry.lat, entry.lon, entry.timestamp);
+      loaded++;
+    }
+    if (loaded > 0) {
+      console.log(`[wsjtx-enrich] Loaded ${loaded} HamQTH cache entries from ${filePath}`);
+    }
+  } catch {
+    // Non-critical — start with an empty cache on any read/parse error
+  }
+}
+
+/**
+ * Persist all current (non-expired) entries from `cache` to a JSON file.
+ * Creates or overwrites the file atomically via a temp-file rename.
+ * All errors are swallowed — cache persistence is best-effort.
+ *
+ * @param {string} filePath  Absolute path to the JSON cache file
+ * @param {object} cache     Cache from createCallsignCache()
+ */
+function saveCallsignCache(filePath, cache) {
+  if (!filePath) return;
+  try {
+    const entries = cache.serialize();
+    const tmp = `${filePath}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify({ version: 1, entries }, null, 2), 'utf8');
+    fs.renameSync(tmp, filePath);
+  } catch {
+    // Non-critical
+  }
+}
 
 /**
  * Fire-and-forget background callsign → lat/lon lookup via HamQTH DXCC API.
@@ -256,20 +335,40 @@ const HAMQTH_TIMEOUT_MS = 5000;
  * `{ callsign, lat, lon }` when the lookup succeeds, allowing the caller to
  * emit a `decode-update` event for already-displayed decodes.
  *
- * Concurrency is capped at HAMQTH_MAX_CONCURRENT (5) via `inflightSet`.
+ * Rate limiting:
+ *  • `inflightSet`       — max HAMQTH_MAX_CONCURRENT (5) simultaneous requests
+ *  • `lastAttemptedMap`  — per-callsign 60 s cooldown after any attempt
+ *  • `_hamqthQpsWindow`  — global 2 req/s sliding-window cap across all instances
+ *
  * All errors are silently swallowed — this is purely a best-effort enrichment.
  *
- * @param {string}   callsign      Uppercase base callsign (no portable suffixes)
- * @param {object}   callsignCache Cache from createCallsignCache()
- * @param {Set}      inflightSet   Shared Set of in-flight callsigns
- * @param {function} onResult      Called with { callsign, lat, lon } on success
+ * @param {string}   callsign         Uppercase base callsign (no portable suffixes)
+ * @param {object}   callsignCache    Cache from createCallsignCache()
+ * @param {Set}      inflightSet      Shared Set of in-flight callsigns
+ * @param {function} onResult         Called with { callsign, lat, lon } on success
+ * @param {Map}      [lastAttemptedMap]  Optional per-callsign attempt-timestamp Map
  */
-function triggerHamqthLookup(callsign, callsignCache, inflightSet, onResult) {
+function triggerHamqthLookup(callsign, callsignCache, inflightSet, onResult, lastAttemptedMap) {
   if (!callsign || callsign.length < 3) return;
   if (inflightSet.has(callsign)) return;
   if (inflightSet.size >= HAMQTH_MAX_CONCURRENT) return;
   // Already cached — nothing to do
   if (callsignCache.get(callsign)) return;
+
+  // Per-callsign cooldown — skip if we attempted this callsign recently
+  if (lastAttemptedMap) {
+    const lastAt = lastAttemptedMap.get(callsign);
+    if (lastAt && Date.now() - lastAt < HAMQTH_COOLDOWN_MS) return;
+    lastAttemptedMap.set(callsign, Date.now());
+  }
+
+  // Global QPS cap — reject if we've fired HAMQTH_QPS_MAX requests in the last second
+  const now = Date.now();
+  while (_hamqthQpsWindow.length > 0 && now - _hamqthQpsWindow[0] > 1000) {
+    _hamqthQpsWindow.shift();
+  }
+  if (_hamqthQpsWindow.length >= HAMQTH_QPS_MAX) return;
+  _hamqthQpsWindow.push(now);
 
   inflightSet.add(callsign);
 
@@ -428,7 +527,7 @@ function enrichDecode(msg, clientState, gridCache, myCall, callsignCache) {
     time: msg.time?.formatted ?? '',
     timeMs: msg.time?.ms ?? 0,
     snr: msg.snr,
-    dt: msg.deltaTime != null ? msg.deltaTime.toFixed(1) : '0.0',
+    dt: msg.deltaTime ?? 0,
     freq: msg.deltaFreq,
     mode: msg.mode || state.mode || '',
     message: msg.message,
@@ -595,7 +694,7 @@ function enrichWspr(msg) {
     time: msg.time?.formatted ?? '',
     timeMs: msg.time?.ms ?? 0,
     snr: msg.snr,
-    dt: msg.deltaTime != null ? msg.deltaTime.toFixed(1) : '0.0',
+    dt: msg.deltaTime ?? 0,
     frequency: msg.frequency,
     band: msg.frequency ? getBandFromHz(msg.frequency) : '',
     drift: msg.drift,
@@ -625,6 +724,8 @@ module.exports = {
   getBandFromHz,
   createGridCache,
   createCallsignCache,
+  loadCallsignCache,
+  saveCallsignCache,
   parseDecodeMessage,
   enrichDecode,
   enrichStatus,

--- a/rig-bridge/lib/wsjtx-enrich.js
+++ b/rig-bridge/lib/wsjtx-enrich.js
@@ -344,7 +344,7 @@ function parseDecodeMessage(text, gridCache, myCall) {
   //          "CQ DX CALLSIGN GRID"
   //          "CQ POTA N0VIG EM28"
   if (/^CQ\s/i.test(text)) {
-    result.type = 'cq';
+    result.type = 'CQ';
     const tokens = text.split(/\s+/).slice(1); // drop leading "CQ"
 
     // Last token may be a grid square
@@ -373,7 +373,7 @@ function parseDecodeMessage(text, gridCache, myCall) {
   // Exchange examples: grid (EN82), report (+05, -12, R+05, R-12), 73, RR73
   const qsoMatch = text.match(/^([A-Z0-9/<>.]+)\s+([A-Z0-9/<>.]+)\s+(.*)/i);
   if (qsoMatch) {
-    result.type = 'qso';
+    result.type = 'QSO';
     result.dxCall = qsoMatch[1];
     result.deCall = qsoMatch[2];
     result.exchange = qsoMatch[3].trim();

--- a/rig-bridge/lib/wsjtx-enrich.js
+++ b/rig-bridge/lib/wsjtx-enrich.js
@@ -1,0 +1,480 @@
+'use strict';
+/**
+ * wsjtx-enrich.js — WSJT-X message enrichment utilities for rig-bridge plugins
+ *
+ * Provides the intelligence layer that the OHC server applies to raw WSJT-X
+ * messages, now available locally so SSE consumers get enriched events without
+ * needing a server connection.
+ *
+ * Features
+ * ────────
+ *  • FT8/FT4/JT65 message text parsing  — CQ / QSO classification, callsign
+ *    and grid extraction, modifier detection (DX, POTA, NA, …)
+ *  • Maidenhead grid → lat/lon           — pure math, no external dependency
+ *  • Frequency (Hz) → band name          — 160 m … 70 cm + fallback
+ *  • In-message grid cache               — remembers callsign → grid from CQ
+ *    and exchange messages; entries expire after 2 h
+ *
+ * Exported helpers
+ * ────────────────
+ *  gridToLatLon(grid)                    → { lat, lon } | null
+ *  getBandFromHz(freqHz)                 → string  (e.g. '20m')
+ *  createGridCache()                     → { get, set, prune, size }
+ *  parseDecodeMessage(text, cache, myCall) → parsed object
+ *  enrichDecode(msg, clientState, cache, myCall) → enriched decode object
+ *  enrichStatus(msg, prevState, cache)   → enriched status fields
+ *  enrichQso(msg)                        → enriched QSO object
+ *  enrichWspr(msg)                       → enriched WSPR object
+ */
+
+// ──────────────────────────────────────────────────────────────────────────────
+// FT8 token blacklist — look like Maidenhead grids but are QSO protocol tokens
+// ──────────────────────────────────────────────────────────────────────────────
+
+const FT8_TOKENS = new Set(['RR73', 'RR53', 'RR13', 'RR23', 'RR33', 'RR43', 'RR63', 'RR83', 'RR93']);
+
+const GRID_REGEX = /\b([A-R]{2}\d{2}(?:[a-x]{2})?)\b/i;
+
+/**
+ * Return true if `s` is a syntactically valid Maidenhead grid AND not an FT8
+ * protocol token that happens to match the grid pattern (e.g. RR73).
+ */
+function isGrid(s) {
+  if (!s || s.length < 4) return false;
+  const g = s.toUpperCase();
+  if (FT8_TOKENS.has(g)) return false;
+  return /^[A-R]{2}\d{2}(?:[A-Xa-x]{2})?$/.test(s);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Grid → lat/lon
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Convert a Maidenhead grid locator to the centre lat/lon of that square.
+ * Supports 4-char field+square and 6-char +subsquare locators. Case-insensitive.
+ *
+ * Returns null for any invalid input so callers can use `== null` guards without
+ * accidentally treating the equator/prime-meridian (0,0) as absent.
+ *
+ * @param {string} grid
+ * @returns {{ lat: number, lon: number } | null}
+ */
+function gridToLatLon(grid) {
+  if (!grid) return null;
+  const g = String(grid).trim().toUpperCase();
+  if (g.length < 4) return null;
+
+  const A = 'A'.charCodeAt(0);
+  const lonField = g.charCodeAt(0) - A;
+  const latField = g.charCodeAt(1) - A;
+  // Field letters must be A–R (0–17)
+  if (lonField < 0 || lonField > 17 || latField < 0 || latField > 17) return null;
+
+  const lonSquare = parseInt(g[2], 10);
+  const latSquare = parseInt(g[3], 10);
+  if (!Number.isFinite(lonSquare) || !Number.isFinite(latSquare)) return null;
+
+  let lon = -180 + lonField * 20 + lonSquare * 2;
+  let lat = -90 + latField * 10 + latSquare;
+
+  if (g.length >= 6) {
+    const lonSub = g.charCodeAt(4) - A;
+    const latSub = g.charCodeAt(5) - A;
+    if (lonSub < 0 || lonSub > 23 || latSub < 0 || latSub > 23) {
+      // Invalid subsquare — centre the 4-char square instead
+      lon += 1.0;
+      lat += 0.5;
+    } else {
+      lon += lonSub * (2 / 24) + 1 / 24;
+      lat += latSub * (1 / 24) + 0.5 / 24;
+    }
+  } else {
+    lon += 1.0;
+    lat += 0.5;
+  }
+
+  return { lat, lon };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Hz → band name
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Return the amateur radio band name for a dial frequency in Hz.
+ * Returns an empty string for frequencies that do not fall in a known band.
+ *
+ * @param {number} freqHz
+ * @returns {string}
+ */
+function getBandFromHz(freqHz) {
+  if (!freqHz) return '';
+  const mhz = freqHz / 1_000_000;
+  if (mhz >= 1.8 && mhz < 2.0) return '160m';
+  if (mhz >= 3.5 && mhz < 4.0) return '80m';
+  if (mhz >= 5.3 && mhz < 5.4) return '60m';
+  if (mhz >= 7.0 && mhz < 7.3) return '40m';
+  if (mhz >= 10.1 && mhz < 10.15) return '30m';
+  if (mhz >= 14.0 && mhz < 14.35) return '20m';
+  if (mhz >= 18.068 && mhz < 18.168) return '17m';
+  if (mhz >= 21.0 && mhz < 21.45) return '15m';
+  if (mhz >= 24.89 && mhz < 24.99) return '12m';
+  if (mhz >= 28.0 && mhz < 29.7) return '10m';
+  if (mhz >= 40.0 && mhz < 42.0) return '8m';
+  if (mhz >= 50.0 && mhz < 54.0) return '6m';
+  if (mhz >= 70.0 && mhz < 70.5) return '4m';
+  if (mhz >= 144.0 && mhz < 148.0) return '2m';
+  if (mhz >= 420.0 && mhz < 450.0) return '70cm';
+  return '';
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// In-message grid cache
+// ──────────────────────────────────────────────────────────────────────────────
+
+const GRID_CACHE_TTL = 2 * 60 * 60 * 1000; // 2 hours
+
+/**
+ * Create a per-plugin-instance grid cache.
+ *
+ * Maps callsign (uppercase) → { grid, lat, lon, timestamp }.
+ * Populated from CQ and exchange messages observed on the air; entries expire
+ * after 2 hours of not being refreshed.
+ *
+ * @returns {{ get(call): entry|null, set(call, grid, lat, lon): void, prune(): void, size: number }}
+ */
+function createGridCache() {
+  const _map = new Map();
+
+  function set(callsign, grid, lat, lon) {
+    if (!callsign || !grid) return;
+    _map.set(callsign.toUpperCase(), { grid, lat, lon, timestamp: Date.now() });
+  }
+
+  function get(callsign) {
+    if (!callsign) return null;
+    const entry = _map.get(callsign.toUpperCase());
+    if (!entry) return null;
+    if (Date.now() - entry.timestamp > GRID_CACHE_TTL) {
+      _map.delete(callsign.toUpperCase());
+      return null;
+    }
+    return entry;
+  }
+
+  function prune() {
+    const cutoff = Date.now() - GRID_CACHE_TTL;
+    for (const [key, entry] of _map) {
+      if (entry.timestamp < cutoff) _map.delete(key);
+    }
+  }
+
+  return {
+    get,
+    set,
+    prune,
+    get size() {
+      return _map.size;
+    },
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// FT8 message text parser
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Parse FT8/FT4/JT65 decoded message text into structured fields.
+ *
+ * As a side-effect, callsign→grid mappings discovered in CQ and exchange
+ * messages are written into `gridCache` for later resolve-by-callsign lookups.
+ *
+ * @param {string}      text       Raw decoded message (e.g. "CQ DX W1AW FN31")
+ * @param {object}      gridCache  Cache from createGridCache()
+ * @param {string|null} myCall     Operator callsign (for QSO direction detection)
+ * @returns {{ type?: string, caller?: string, modifier?: string,
+ *             dxCall?: string, deCall?: string, exchange?: string,
+ *             grid?: string }}
+ */
+function parseDecodeMessage(text, gridCache, myCall) {
+  if (!text) return {};
+  const result = {};
+
+  // ── CQ messages ──────────────────────────────────────────────────────────
+  // Formats: "CQ CALLSIGN"
+  //          "CQ CALLSIGN GRID"
+  //          "CQ DX CALLSIGN GRID"
+  //          "CQ POTA N0VIG EM28"
+  if (/^CQ\s/i.test(text)) {
+    result.type = 'cq';
+    const tokens = text.split(/\s+/).slice(1); // drop leading "CQ"
+
+    // Last token may be a grid square
+    let grid = null;
+    if (tokens.length >= 2 && isGrid(tokens[tokens.length - 1])) {
+      grid = tokens.pop();
+    }
+
+    // What remains is: [modifier…] CALLSIGN
+    if (tokens.length >= 1) {
+      result.caller = tokens[tokens.length - 1];
+      result.modifier = tokens.length >= 2 ? tokens.slice(0, -1).join(' ') : null;
+    }
+    result.grid = grid ?? null;
+
+    // Populate the grid cache so later QSO exchanges can resolve this station
+    if (result.caller && result.grid) {
+      const coords = gridToLatLon(result.grid);
+      if (coords) gridCache.set(result.caller, result.grid, coords.lat, coords.lon);
+    }
+    return result;
+  }
+
+  // ── Standard QSO exchange ─────────────────────────────────────────────────
+  // Format: "DXCALL DECALL EXCHANGE"
+  // Exchange examples: grid (EN82), report (+05, -12, R+05, R-12), 73, RR73
+  const qsoMatch = text.match(/^([A-Z0-9/<>.]+)\s+([A-Z0-9/<>.]+)\s+(.*)/i);
+  if (qsoMatch) {
+    result.type = 'qso';
+    result.dxCall = qsoMatch[1];
+    result.deCall = qsoMatch[2];
+    result.exchange = qsoMatch[3].trim();
+
+    const gridMatch = result.exchange.match(GRID_REGEX);
+    if (gridMatch && isGrid(gridMatch[1])) {
+      result.grid = gridMatch[1];
+      const coords = gridToLatLon(result.grid);
+      if (coords) {
+        // The grid belongs to whichever station is NOT the operator
+        const mc = (myCall || '').toUpperCase();
+        const cacheCall = mc && result.deCall.toUpperCase() === mc ? result.dxCall : result.deCall;
+        gridCache.set(cacheCall, result.grid, coords.lat, coords.lon);
+      }
+    }
+    return result;
+  }
+
+  return result;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Enrichment helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build an enriched decode object from a raw WSJT-X DECODE message.
+ *
+ * Enrichments over the raw message:
+ *  • content-based `id` for deduplication
+ *  • parsed message fields (type, caller, grid, modifier, dxCall, deCall, …)
+ *  • lat/lon from in-message grid, then grid cache fallback
+ *  • band name from current client status
+ *
+ * @param {object}      msg          Raw DECODE from parseMessage()
+ * @param {object|null} clientState  Current client state { band, dialFrequency, mode }
+ * @param {object}      gridCache    Cache from createGridCache()
+ * @param {string|null} myCall       Operator callsign
+ * @returns {object}
+ */
+function enrichDecode(msg, clientState, gridCache, myCall) {
+  const parsed = parseDecodeMessage(msg.message, gridCache, myCall);
+  const state = clientState ?? {};
+
+  const decode = {
+    // Stable content-based ID for deduplication at SSE consumer level
+    id: `${msg.id}-${(msg.time?.formatted ?? '').replace(/[^0-9]/g, '')}-${msg.deltaFreq ?? 0}-${(msg.message ?? '').replace(/\s+/g, '')}`,
+    clientId: msg.id,
+    isNew: msg.isNew,
+    time: msg.time?.formatted ?? '',
+    timeMs: msg.time?.ms ?? 0,
+    snr: msg.snr,
+    dt: msg.deltaTime != null ? msg.deltaTime.toFixed(1) : '0.0',
+    freq: msg.deltaFreq,
+    mode: msg.mode || state.mode || '',
+    message: msg.message,
+    lowConfidence: msg.lowConfidence,
+    offAir: msg.offAir,
+    dialFrequency: state.dialFrequency ?? 0,
+    band: state.band ?? '',
+    // Spread parsed fields (type, caller, modifier, dxCall, deCall, exchange, grid)
+    ...parsed,
+    timestamp: msg.timestamp,
+  };
+
+  // ── Resolve grid → lat/lon ──────────────────────────────────────────────
+  let lat = null;
+  let lon = null;
+  let gridSource = null;
+
+  if (parsed.grid) {
+    const coords = gridToLatLon(parsed.grid);
+    if (coords) {
+      lat = coords.lat;
+      lon = coords.lon;
+      gridSource = 'message';
+    }
+  }
+
+  // Fall back to grid cache (from a prior CQ/exchange that included this callsign's grid)
+  if (lat == null) {
+    const targetCall = (parsed.caller ?? parsed.deCall ?? parsed.dxCall ?? '').toUpperCase();
+    if (targetCall) {
+      const cached = gridCache.get(targetCall);
+      if (cached) {
+        lat = cached.lat;
+        lon = cached.lon;
+        if (!decode.grid) decode.grid = cached.grid;
+        gridSource = 'cache';
+      }
+    }
+  }
+
+  if (lat != null) decode.lat = lat;
+  if (lon != null) decode.lon = lon;
+  if (gridSource) decode.gridSource = gridSource;
+
+  return decode;
+}
+
+/**
+ * Compute the enriched fields for a STATUS message.
+ *
+ * Derives band name, detects band changes, resolves DX and DE grids to lat/lon.
+ * Does NOT modify `msg` — returns a plain object to spread into the bus event.
+ *
+ * @param {object}      msg        Raw STATUS from parseMessage()
+ * @param {object|null} prevState  Previous enriched state for this client, or null
+ * @param {object}      gridCache  Cache from createGridCache()
+ * @returns {{ band, bandChanged, dxCall, dxGrid, dxLat, dxLon, deLat, deLon }}
+ */
+function enrichStatus(msg, prevState, gridCache) {
+  const band = msg.dialFrequency ? getBandFromHz(msg.dialFrequency) : '';
+  const prevBand = prevState?.band ?? null;
+  const bandChanged = !!(prevBand && band && prevBand !== band);
+
+  const dxCall = (msg.dxCall ?? '').replace(/[<>]/g, '').trim() || null;
+  let dxLat = null;
+  let dxLon = null;
+  let dxGrid = msg.dxGrid ?? null;
+
+  if (dxCall) {
+    // 1. Use dxGrid supplied by WSJT-X in this message
+    if (dxGrid) {
+      const coords = gridToLatLon(dxGrid);
+      if (coords) {
+        dxLat = coords.lat;
+        dxLon = coords.lon;
+      }
+    }
+    // 2. Fall back to what we have heard on air (grid cache)
+    if (dxLat == null) {
+      const cached = gridCache.get(dxCall);
+      if (cached) {
+        dxLat = cached.lat;
+        dxLon = cached.lon;
+        dxGrid = dxGrid ?? cached.grid;
+      }
+    }
+  }
+
+  // Resolve operator grid (deGrid) if present
+  let deLat = null;
+  let deLon = null;
+  if (msg.deGrid) {
+    const coords = gridToLatLon(msg.deGrid);
+    if (coords) {
+      deLat = coords.lat;
+      deLon = coords.lon;
+    }
+  }
+
+  return { band, bandChanged, dxCall, dxGrid, dxLat, dxLon, deLat, deLon };
+}
+
+/**
+ * Build an enriched QSO_LOGGED object.
+ *
+ * Adds band name and resolves dxGrid → lat/lon.
+ *
+ * @param {object} msg  Raw QSO_LOGGED from parseMessage()
+ * @returns {object}
+ */
+function enrichQso(msg) {
+  const band = msg.txFrequency ? getBandFromHz(msg.txFrequency) : '';
+
+  const qso = {
+    clientId: msg.id,
+    dxCall: msg.dxCall,
+    dxGrid: msg.dxGrid,
+    frequency: msg.txFrequency,
+    band,
+    mode: msg.mode,
+    reportSent: msg.reportSent,
+    reportRecv: msg.reportRecv,
+    myCall: msg.myCall,
+    myGrid: msg.myGrid,
+    timestamp: msg.timestamp,
+  };
+
+  if (msg.dxGrid) {
+    const coords = gridToLatLon(msg.dxGrid);
+    if (coords) {
+      qso.lat = coords.lat;
+      qso.lon = coords.lon;
+    }
+  }
+
+  return qso;
+}
+
+/**
+ * Build an enriched WSPR_DECODE object.
+ *
+ * Resolves the WSPR station's grid → lat/lon for map plotting.
+ *
+ * @param {object} msg  Raw WSPR_DECODE from parseMessage()
+ * @returns {object}
+ */
+function enrichWspr(msg) {
+  const wspr = {
+    clientId: msg.id,
+    isNew: msg.isNew,
+    time: msg.time?.formatted ?? '',
+    timeMs: msg.time?.ms ?? 0,
+    snr: msg.snr,
+    dt: msg.deltaTime != null ? msg.deltaTime.toFixed(1) : '0.0',
+    frequency: msg.frequency,
+    band: msg.frequency ? getBandFromHz(msg.frequency) : '',
+    drift: msg.drift,
+    callsign: msg.callsign,
+    grid: msg.grid,
+    power: msg.power,
+    offAir: msg.offAir,
+    timestamp: msg.timestamp,
+  };
+
+  if (msg.grid) {
+    const coords = gridToLatLon(msg.grid);
+    if (coords) {
+      wspr.lat = coords.lat;
+      wspr.lon = coords.lon;
+    }
+  }
+
+  return wspr;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+
+module.exports = {
+  isGrid,
+  gridToLatLon,
+  getBandFromHz,
+  createGridCache,
+  parseDecodeMessage,
+  enrichDecode,
+  enrichStatus,
+  enrichQso,
+  enrichWspr,
+};

--- a/rig-bridge/lib/wsjtx-enrich.js
+++ b/rig-bridge/lib/wsjtx-enrich.js
@@ -14,18 +14,28 @@
  *  • Frequency (Hz) → band name          — 160 m … 70 cm + fallback
  *  • In-message grid cache               — remembers callsign → grid from CQ
  *    and exchange messages; entries expire after 2 h
+ *  • HamQTH callsign lookup (opt-in)     — resolves unknown callsigns to
+ *    country-level lat/lon; results cached 24 h, max 5 concurrent requests
  *
  * Exported helpers
  * ────────────────
- *  gridToLatLon(grid)                    → { lat, lon } | null
- *  getBandFromHz(freqHz)                 → string  (e.g. '20m')
- *  createGridCache()                     → { get, set, prune, size }
- *  parseDecodeMessage(text, cache, myCall) → parsed object
- *  enrichDecode(msg, clientState, cache, myCall) → enriched decode object
- *  enrichStatus(msg, prevState, cache)   → enriched status fields
- *  enrichQso(msg)                        → enriched QSO object
- *  enrichWspr(msg)                       → enriched WSPR object
+ *  gridToLatLon(grid)                         → { lat, lon } | null
+ *  getBandFromHz(freqHz)                      → string  (e.g. '20m')
+ *  createGridCache()                          → { get, set, prune, size }
+ *  createCallsignCache()                      → { get, set, prune, size }
+ *  parseDecodeMessage(text, cache, myCall)    → parsed object
+ *  enrichDecode(msg, clientState, gridCache,
+ *               myCall, callsignCache)        → enriched decode object
+ *  enrichStatus(msg, prevState, cache)        → enriched status fields
+ *  enrichQso(msg)                             → enriched QSO object
+ *  enrichWspr(msg)                            → enriched WSPR object
+ *  triggerHamqthLookup(callsign,
+ *    callsignCache, inflightSet, onResult)    → void  (fire-and-forget)
  */
+
+const https = require('https');
+const http = require('http');
+const { URL } = require('url');
 
 // ──────────────────────────────────────────────────────────────────────────────
 // FT8 token blacklist — look like Maidenhead grids but are QSO protocol tokens
@@ -181,6 +191,133 @@ function createGridCache() {
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
+// HamQTH callsign → lat/lon cache
+// ──────────────────────────────────────────────────────────────────────────────
+
+const CALLSIGN_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
+
+/**
+ * Create a per-plugin-instance callsign lookup cache.
+ *
+ * Stores the results of HamQTH DXCC lookups: callsign → { lat, lon, timestamp }.
+ * Separate from the grid cache because it comes from a different source (remote
+ * DXCC database) and has a longer TTL (24 h vs 2 h).
+ *
+ * @returns {{ get(call): entry|null, set(call, lat, lon): void, prune(): void, size: number }}
+ */
+function createCallsignCache() {
+  const _map = new Map();
+
+  function set(callsign, lat, lon) {
+    if (!callsign || lat == null || lon == null) return;
+    _map.set(callsign.toUpperCase(), { lat, lon, timestamp: Date.now() });
+  }
+
+  function get(callsign) {
+    if (!callsign) return null;
+    const entry = _map.get(callsign.toUpperCase());
+    if (!entry) return null;
+    if (Date.now() - entry.timestamp > CALLSIGN_CACHE_TTL) {
+      _map.delete(callsign.toUpperCase());
+      return null;
+    }
+    return entry;
+  }
+
+  function prune() {
+    const cutoff = Date.now() - CALLSIGN_CACHE_TTL;
+    for (const [key, entry] of _map) {
+      if (entry.timestamp < cutoff) _map.delete(key);
+    }
+  }
+
+  return {
+    get,
+    set,
+    prune,
+    get size() {
+      return _map.size;
+    },
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// HamQTH lookup (fire-and-forget)
+// ──────────────────────────────────────────────────────────────────────────────
+
+const HAMQTH_MAX_CONCURRENT = 5;
+const HAMQTH_TIMEOUT_MS = 5000;
+
+/**
+ * Fire-and-forget background callsign → lat/lon lookup via HamQTH DXCC API.
+ *
+ * Writes the result into `callsignCache` so future decodes from the same
+ * callsign resolve without another network request.  Calls `onResult` with
+ * `{ callsign, lat, lon }` when the lookup succeeds, allowing the caller to
+ * emit a `decode-update` event for already-displayed decodes.
+ *
+ * Concurrency is capped at HAMQTH_MAX_CONCURRENT (5) via `inflightSet`.
+ * All errors are silently swallowed — this is purely a best-effort enrichment.
+ *
+ * @param {string}   callsign      Uppercase base callsign (no portable suffixes)
+ * @param {object}   callsignCache Cache from createCallsignCache()
+ * @param {Set}      inflightSet   Shared Set of in-flight callsigns
+ * @param {function} onResult      Called with { callsign, lat, lon } on success
+ */
+function triggerHamqthLookup(callsign, callsignCache, inflightSet, onResult) {
+  if (!callsign || callsign.length < 3) return;
+  if (inflightSet.has(callsign)) return;
+  if (inflightSet.size >= HAMQTH_MAX_CONCURRENT) return;
+  // Already cached — nothing to do
+  if (callsignCache.get(callsign)) return;
+
+  inflightSet.add(callsign);
+
+  const reqUrl = `https://www.hamqth.com/dxcc.php?callsign=${encodeURIComponent(callsign)}`;
+  let parsed;
+  try {
+    parsed = new URL(reqUrl);
+  } catch {
+    inflightSet.delete(callsign);
+    return;
+  }
+
+  const transport = parsed.protocol === 'https:' ? https : http;
+  const req = transport.request(
+    {
+      hostname: parsed.hostname,
+      path: parsed.pathname + parsed.search,
+      method: 'GET',
+      headers: { 'User-Agent': 'rig-bridge/wsjtx-enrich' },
+      timeout: HAMQTH_TIMEOUT_MS,
+    },
+    (res) => {
+      let body = '';
+      res.on('data', (chunk) => (body += chunk));
+      res.on('end', () => {
+        inflightSet.delete(callsign);
+        if (res.statusCode !== 200) return;
+        const latMatch = body.match(/<lat>([^<]+)<\/lat>/);
+        const lonMatch = body.match(/<lng>([^<]+)<\/lng>/);
+        if (!latMatch || !lonMatch) return;
+        const lat = parseFloat(latMatch[1]);
+        const lon = parseFloat(lonMatch[1]);
+        if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
+        callsignCache.set(callsign, lat, lon);
+        if (onResult) onResult({ callsign, lat, lon });
+      });
+    },
+  );
+
+  req.on('error', () => inflightSet.delete(callsign));
+  req.on('timeout', () => {
+    req.destroy();
+    inflightSet.delete(callsign);
+  });
+  req.end();
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
 // FT8 message text parser
 // ──────────────────────────────────────────────────────────────────────────────
 
@@ -271,13 +408,15 @@ function parseDecodeMessage(text, gridCache, myCall) {
  *  • lat/lon from in-message grid, then grid cache fallback
  *  • band name from current client status
  *
- * @param {object}      msg          Raw DECODE from parseMessage()
- * @param {object|null} clientState  Current client state { band, dialFrequency, mode }
- * @param {object}      gridCache    Cache from createGridCache()
- * @param {string|null} myCall       Operator callsign
+ * @param {object}      msg            Raw DECODE from parseMessage()
+ * @param {object|null} clientState    Current client state { band, dialFrequency, mode }
+ * @param {object}      gridCache      Cache from createGridCache()
+ * @param {string|null} myCall         Operator callsign
+ * @param {object|null} callsignCache  Optional cache from createCallsignCache() for
+ *                                     HamQTH-resolved coordinates (Phase 5)
  * @returns {object}
  */
-function enrichDecode(msg, clientState, gridCache, myCall) {
+function enrichDecode(msg, clientState, gridCache, myCall, callsignCache) {
   const parsed = parseDecodeMessage(msg.message, gridCache, myCall);
   const state = clientState ?? {};
 
@@ -326,6 +465,19 @@ function enrichDecode(msg, clientState, gridCache, myCall) {
         lon = cached.lon;
         if (!decode.grid) decode.grid = cached.grid;
         gridSource = 'cache';
+      }
+    }
+  }
+
+  // Fall back to HamQTH callsign cache (country-level, populated asynchronously)
+  if (lat == null && callsignCache) {
+    const targetCall = (parsed.caller ?? parsed.deCall ?? parsed.dxCall ?? '').toUpperCase();
+    if (targetCall) {
+      const cached = callsignCache.get(targetCall);
+      if (cached) {
+        lat = cached.lat;
+        lon = cached.lon;
+        gridSource = 'hamqth';
       }
     }
   }
@@ -472,9 +624,11 @@ module.exports = {
   gridToLatLon,
   getBandFromHz,
   createGridCache,
+  createCallsignCache,
   parseDecodeMessage,
   enrichDecode,
   enrichStatus,
   enrichQso,
   enrichWspr,
+  triggerHamqthLookup,
 };

--- a/rig-bridge/package.json
+++ b/rig-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhamclock-rig-bridge",
-  "version": "1.2.0",
+  "version": "2.1.0",
   "description": "Universal rig control bridge for OpenHamClock — plugin architecture supporting USB, flrig, rigctld, and more",
   "main": "rig-bridge.js",
   "bin": "rig-bridge.js",

--- a/rig-bridge/plugins/digital-mode-base.js
+++ b/rig-bridge/plugins/digital-mode-base.js
@@ -182,6 +182,8 @@ function createDigitalModePlugin({ id, name, configKey, defaultPort, tag }) {
                 band: enriched.band,
                 dialFrequency: msg.dialFrequency,
                 mode: msg.mode,
+                deCall: msg.deCall ?? null,
+                deGrid: msg.deGrid ?? null,
               };
               lastStatus = { ...msg, ...enriched };
 

--- a/rig-bridge/plugins/digital-mode-base.js
+++ b/rig-bridge/plugins/digital-mode-base.js
@@ -9,9 +9,17 @@
  * Each plugin:
  *   - Listens on a configurable UDP port for incoming messages
  *   - Parses the WSJT-X binary protocol via the shared library
+ *   - Enriches events with band name, grid → lat/lon, and parsed message text
  *   - Tracks the remote app's address/port for bidirectional communication
  *   - Exposes API endpoints for sending commands back to the app
  *   - Does NOT relay to OHC server (that's wsjtx-relay's job)
+ *
+ * Enrichments applied (same subset as wsjtx-relay SSE mode)
+ * ──────────────────────────────────────────────────────────
+ *  decode  — FT8 message text parsed, in-message grid → lat/lon, band name, dedup ID
+ *  status  — band name, band-change detection, DX/DE lat/lon from grids
+ *  qso     — band name, dxGrid → lat/lon
+ *  clear   — forwarded as-is  (new — was not emitted before)
  */
 
 const dgram = require('dgram');
@@ -23,6 +31,7 @@ const {
   buildFreeText,
   buildHighlightCallsign,
 } = require('../lib/wsjtx-protocol');
+const { createGridCache, enrichDecode, enrichStatus, enrichQso } = require('../lib/wsjtx-enrich');
 
 /**
  * Create a digital mode plugin descriptor.
@@ -139,6 +148,15 @@ function createDigitalModePlugin({ id, name, configKey, defaultPort, tag }) {
       let totalDecodes = 0;
       let lastStatus = null;
 
+      // ── Enrichment state ──────────────────────────────────────────────────
+      const gridCache = createGridCache();
+      // Per-client state for decode enrichment (band, freq, mode)
+      const clientStates = Object.create(null);
+      // Content-based deduplication (time + freq + message)
+      const seenDecodeIds = new Set();
+      const SEEN_DECODE_MAX = 2000;
+      let gridPruneInterval = null;
+
       function connect() {
         socket = dgram.createSocket('udp4');
 
@@ -150,26 +168,70 @@ function createDigitalModePlugin({ id, name, configKey, defaultPort, tag }) {
           remotePort = rinfo.port;
           if (msg.id) appId = msg.id;
 
-          if (msg.type === WSJTX_MSG.DECODE && msg.isNew) {
-            totalDecodes++;
-            if (bus) bus.emit('decode', { source: id, ...msg });
-            if (cfg.verbose) {
-              const snr = msg.snr != null ? (msg.snr >= 0 ? `+${msg.snr}` : msg.snr) : '?';
-              console.log(`[${tag}] Decode ${msg.time?.formatted || '??'} ${snr}dB ${msg.deltaFreq}Hz ${msg.message}`);
+          switch (msg.type) {
+            case WSJTX_MSG.HEARTBEAT: {
+              console.log(`[${tag}] Connected: ${msg.version || 'unknown version'} (${appId})`);
+              break;
             }
-          }
 
-          if (msg.type === WSJTX_MSG.STATUS) {
-            lastStatus = msg;
-            if (bus) bus.emit('status', { source: id, ...msg });
-          }
+            case WSJTX_MSG.STATUS: {
+              const prevState = clientStates[msg.id] ?? null;
+              const enriched = enrichStatus(msg, prevState, gridCache);
 
-          if (msg.type === WSJTX_MSG.QSO_LOGGED) {
-            if (bus) bus.emit('qso', { source: id, ...msg });
-          }
+              clientStates[msg.id] = {
+                band: enriched.band,
+                dialFrequency: msg.dialFrequency,
+                mode: msg.mode,
+              };
+              lastStatus = { ...msg, ...enriched };
 
-          if (msg.type === WSJTX_MSG.HEARTBEAT) {
-            console.log(`[${tag}] Connected: ${msg.version || 'unknown version'} (${appId})`);
+              if (bus) bus.emit('status', { source: id, ...msg, ...enriched });
+              break;
+            }
+
+            case WSJTX_MSG.DECODE: {
+              if (!msg.isNew) break;
+              totalDecodes++;
+
+              const clientState = clientStates[msg.id] ?? null;
+              const decode = enrichDecode(msg, clientState, gridCache, cfg.myCall ?? null);
+
+              if (seenDecodeIds.has(decode.id)) break;
+              seenDecodeIds.add(decode.id);
+              if (seenDecodeIds.size > SEEN_DECODE_MAX) {
+                seenDecodeIds.delete(seenDecodeIds.values().next().value);
+              }
+
+              if (bus) bus.emit('decode', { source: id, ...decode });
+
+              if (cfg.verbose) {
+                const snr = decode.snr != null ? (decode.snr >= 0 ? `+${decode.snr}` : decode.snr) : '?';
+                console.log(`[${tag}] Decode ${decode.time} ${snr}dB ${decode.freq}Hz ${decode.message}`);
+              }
+              break;
+            }
+
+            case WSJTX_MSG.CLEAR: {
+              if (bus) bus.emit('clear', { source: id, clientId: msg.id, window: msg.window });
+              // Clear seen IDs for this client so post-clear replays are treated as fresh
+              for (const seenId of seenDecodeIds) {
+                if (seenId.startsWith(`${msg.id}-`)) seenDecodeIds.delete(seenId);
+              }
+              break;
+            }
+
+            case WSJTX_MSG.QSO_LOGGED: {
+              const qso = {
+                ...enrichQso(msg),
+                myCall: msg.myCall || clientStates[msg.id]?.deCall || null,
+                myGrid: msg.myGrid || clientStates[msg.id]?.deGrid || null,
+              };
+              if (bus) bus.emit('qso', { source: id, ...qso });
+              break;
+            }
+
+            default:
+              break;
           }
         });
 
@@ -185,6 +247,7 @@ function createDigitalModePlugin({ id, name, configKey, defaultPort, tag }) {
         socket.on('listening', () => {
           const addr = socket.address();
           console.log(`[${tag}] Listening on UDP ${addr.address}:${addr.port}`);
+          gridPruneInterval = setInterval(() => gridCache.prune(), 5 * 60 * 1000);
         });
 
         const bindAddr = cfg.bindAddress || '127.0.0.1';
@@ -192,6 +255,10 @@ function createDigitalModePlugin({ id, name, configKey, defaultPort, tag }) {
       }
 
       function disconnect() {
+        if (gridPruneInterval) {
+          clearInterval(gridPruneInterval);
+          gridPruneInterval = null;
+        }
         if (socket) {
           try {
             socket.close();
@@ -224,9 +291,11 @@ function createDigitalModePlugin({ id, name, configKey, defaultPort, tag }) {
           appId,
           decodeCount: totalDecodes,
           udpPort,
-          lastFrequency: lastStatus?.dialFrequency || null,
-          lastMode: lastStatus?.mode || null,
-          transmitting: lastStatus?.transmitting || false,
+          gridCacheSize: gridCache.size,
+          lastFrequency: lastStatus?.dialFrequency ?? null,
+          lastBand: lastStatus?.band ?? null,
+          lastMode: lastStatus?.mode ?? null,
+          transmitting: lastStatus?.transmitting ?? false,
         };
       }
 

--- a/rig-bridge/plugins/wsjtx-relay.js
+++ b/rig-bridge/plugins/wsjtx-relay.js
@@ -35,6 +35,7 @@
 const dgram = require('dgram');
 const http = require('http');
 const https = require('https');
+const path = require('path');
 const { URL } = require('url');
 const {
   WSJTX_MSG,
@@ -47,12 +48,15 @@ const {
 const {
   createGridCache,
   createCallsignCache,
+  loadCallsignCache,
+  saveCallsignCache,
   enrichDecode,
   enrichStatus,
   enrichQso,
   enrichWspr,
   triggerHamqthLookup,
 } = require('../lib/wsjtx-enrich');
+const { CONFIG_DIR } = require('../core/config');
 
 const RELAY_VERSION = require('../package.json').version;
 
@@ -189,6 +193,11 @@ const descriptor = {
     // HamQTH callsign lookup cache (only populated when cfg.hamqthLookup is true)
     const callsignCache = createCallsignCache();
     const hamqthInflight = new Set(); // callsigns currently being looked up
+    const hamqthLastAttempted = new Map(); // callsign → timestamp of last attempt (for cooldown)
+    // Persist HamQTH cache to disk so it survives rig-bridge restarts.
+    // Only used when hamqthLookup is enabled; null disables all file I/O.
+    const cacheFilePath = cfg.hamqthLookup ? path.join(CONFIG_DIR, 'hamqth-cache.json') : null;
+    let cacheSaveTimer = null;
     // Per-client state needed for decode enrichment (band, freq, mode)
     const clientStates = Object.create(null); // clientId → { band, dialFrequency, mode }
     // Content-based decode deduplication (time + freq + message text)
@@ -208,6 +217,16 @@ const descriptor = {
       if (consecutiveErrors < 5) return (cfg.batchInterval || 2000) * 2;
       if (consecutiveErrors < 20) return 10000;
       return 30000;
+    }
+
+    // Debounced HamQTH cache save — coalesces rapid resolve bursts into one write.
+    function scheduleCacheSave() {
+      if (!cacheFilePath) return;
+      if (cacheSaveTimer) clearTimeout(cacheSaveTimer);
+      cacheSaveTimer = setTimeout(() => {
+        cacheSaveTimer = null;
+        saveCallsignCache(cacheFilePath, callsignCache);
+      }, 30_000);
     }
 
     function makeRequest(urlStr, method, body, extraHeaders, onDone) {
@@ -394,9 +413,16 @@ const descriptor = {
           if (cfg.hamqthLookup && decode.lat == null) {
             const targetCall = (decode.caller ?? decode.deCall ?? decode.dxCall ?? '').toUpperCase();
             if (targetCall) {
-              triggerHamqthLookup(targetCall, callsignCache, hamqthInflight, ({ callsign, lat, lon }) => {
-                if (bus) bus.emit('decode-update', { source: 'wsjtx-relay', callsign, lat, lon });
-              });
+              triggerHamqthLookup(
+                targetCall,
+                callsignCache,
+                hamqthInflight,
+                ({ callsign, lat, lon }) => {
+                  if (bus) bus.emit('decode-update', { source: 'wsjtx-relay', callsign, lat, lon });
+                  scheduleCacheSave();
+                },
+                hamqthLastAttempted,
+              );
             }
           }
 
@@ -482,6 +508,8 @@ const descriptor = {
           willRelay = false;
         }
       }
+
+      if (cacheFilePath) loadCallsignCache(cacheFilePath, callsignCache);
 
       const udpPort = cfg.udpPort || 2237;
       socket = dgram.createSocket('udp4');
@@ -580,6 +608,13 @@ const descriptor = {
         clearInterval(gridPruneInterval);
         gridPruneInterval = null;
       }
+      // Flush HamQTH cache to disk on clean shutdown (cancel the debounced write
+      // first so we don't fire twice if the save completes quickly).
+      if (cacheSaveTimer) {
+        clearTimeout(cacheSaveTimer);
+        cacheSaveTimer = null;
+      }
+      if (cacheFilePath) saveCallsignCache(cacheFilePath, callsignCache);
       if (socket) {
         if (mcEnabled) {
           try {

--- a/rig-bridge/plugins/wsjtx-relay.js
+++ b/rig-bridge/plugins/wsjtx-relay.js
@@ -357,6 +357,8 @@ const descriptor = {
             band: enriched.band,
             dialFrequency: msg.dialFrequency,
             mode: msg.mode,
+            deCall: msg.deCall ?? null,
+            deGrid: msg.deGrid ?? null,
           };
 
           if (bus) bus.emit('status', { source: 'wsjtx-relay', ...msg, ...enriched });

--- a/rig-bridge/plugins/wsjtx-relay.js
+++ b/rig-bridge/plugins/wsjtx-relay.js
@@ -2,20 +2,34 @@
 /**
  * wsjtx-relay.js — WSJT-X Relay integration plugin
  *
- * Listens for WSJT-X UDP packets on the local machine and forwards decoded
- * messages in batches to an OpenHamClock server via HTTPS.
+ * Listens for WSJT-X UDP packets on the local machine and:
+ *  1. Emits enriched events on the plugin bus for local SSE consumers.
+ *  2. Optionally forwards raw decoded messages in batches to an OpenHamClock
+ *     server via HTTPS.
+ *
+ * Enrichments applied locally (no server required)
+ * ─────────────────────────────────────────────────
+ *  decode   — FT8/FT4 message text parsed (type/caller/modifier/dxCall/deCall),
+ *             in-message grid → lat/lon, grid cache fallback, band name, dedup ID
+ *  status   — band name, band-change detection, DX lat/lon (from dxGrid or cache),
+ *             DE lat/lon (from deGrid)
+ *  qso      — band name, dxGrid → lat/lon, QSO deduplication (60 s window)
+ *  wspr     — band name, grid → lat/lon              (new — was not emitted before)
+ *  clear    — forwarded as-is                         (new — was not emitted before)
  *
  * Configuration (config.wsjtxRelay):
- *   enabled       boolean  Whether the relay is active (default: false)
- *   url           string   OpenHamClock server URL (e.g. https://openhamclock.com)
- *   key           string   Relay authentication key
- *   session       string   Browser session ID for per-user isolation
+ *   enabled            boolean  Whether the relay is active (default: false)
+ *   url                string   OpenHamClock server URL (e.g. https://openhamclock.com)
+ *   key                string   Relay authentication key
+ *   session            string   Browser session ID for per-user isolation
+ *   myCall             string   Operator callsign (improves QSO direction detection)
  *   udpPort            number   UDP port to listen on (default: 2237)
  *   batchInterval      number   Batch send interval in ms (default: 2000)
  *   verbose            boolean  Log all decoded messages (default: false)
  *   multicast          boolean  Join a multicast group (default: false)
  *   multicastGroup     string   Multicast group IP (default: '224.0.0.1')
  *   multicastInterface string   Local NIC IP for multi-homed systems; '' = OS default
+ *   relayToServer      boolean  Forward raw messages to OHC server (default: false)
  */
 
 const dgram = require('dgram');
@@ -30,6 +44,7 @@ const {
   buildFreeText,
   buildHighlightCallsign,
 } = require('../lib/wsjtx-protocol');
+const { createGridCache, enrichDecode, enrichStatus, enrichQso, enrichWspr } = require('../lib/wsjtx-enrich');
 
 const RELAY_VERSION = require('../package.json').version;
 
@@ -141,6 +156,7 @@ const descriptor = {
     const mcGroup = cfg.multicastGroup || '224.0.0.1';
     const mcInterface = cfg.multicastInterface || undefined; // undefined → OS picks NIC
 
+    // ── Server relay state ──────────────────────────────────────────────────
     let socket = null;
     let batchTimer = null;
     let heartbeatInterval = null;
@@ -158,6 +174,23 @@ const descriptor = {
     let remoteAddress = null;
     let remotePort = null;
     let appId = 'WSJT-X'; // Updated from heartbeat/status messages
+
+    // ── Local enrichment state ──────────────────────────────────────────────
+    // Shared grid cache: remembers callsign → grid from CQ/exchange messages
+    const gridCache = createGridCache();
+    // Per-client state needed for decode enrichment (band, freq, mode)
+    const clientStates = Object.create(null); // clientId → { band, dialFrequency, mode }
+    // Content-based decode deduplication (time + freq + message text)
+    const seenDecodeIds = new Set();
+    const SEEN_DECODE_MAX = 2000; // keep at most this many IDs to bound memory
+    // QSO deduplication: track recent logged QSOs (call + freq + mode, 60 s window)
+    const recentQsos = []; // { dxCall, frequency, mode, timestamp }
+    const QSO_DEDUP_MS = 60_000;
+    const QSO_DEDUP_MAX = 200; // max entries to scan
+    // Prune grid cache every 5 minutes
+    let gridPruneInterval = null;
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
 
     function getInterval() {
       if (consecutiveErrors === 0) return cfg.batchInterval || 2000;
@@ -287,6 +320,113 @@ const descriptor = {
       });
     }
 
+    // ── Message handler ─────────────────────────────────────────────────────
+
+    function handleMessage(buf, rinfo) {
+      const msg = parseMessage(buf);
+      if (!msg) return;
+
+      // Track sender for bidirectional communication
+      remoteAddress = rinfo.address;
+      remotePort = rinfo.port;
+      if (msg.id) appId = msg.id;
+
+      // Queue raw message for server relay (unmodified — server does its own enrichment)
+      if (msg.type !== WSJTX_MSG.REPLAY && willRelay) {
+        messageQueue.push(msg);
+      }
+
+      switch (msg.type) {
+        case WSJTX_MSG.STATUS: {
+          const prevState = clientStates[msg.id] ?? null;
+          const enriched = enrichStatus(msg, prevState, gridCache);
+
+          // Update per-client state for decode enrichment
+          clientStates[msg.id] = {
+            band: enriched.band,
+            dialFrequency: msg.dialFrequency,
+            mode: msg.mode,
+          };
+
+          if (bus) bus.emit('status', { source: 'wsjtx-relay', ...msg, ...enriched });
+          break;
+        }
+
+        case WSJTX_MSG.DECODE: {
+          if (!msg.isNew) break;
+          totalDecodes++;
+
+          const clientState = clientStates[msg.id] ?? null;
+          const decode = enrichDecode(msg, clientState, gridCache, cfg.myCall ?? null);
+
+          // Content-based deduplication — skip if we have already emitted this decode
+          if (seenDecodeIds.has(decode.id)) break;
+          seenDecodeIds.add(decode.id);
+          // Bound the set size by evicting the oldest entry when over limit
+          if (seenDecodeIds.size > SEEN_DECODE_MAX) {
+            seenDecodeIds.delete(seenDecodeIds.values().next().value);
+          }
+
+          if (bus) bus.emit('decode', { source: 'wsjtx-relay', ...decode });
+
+          if (cfg.verbose) {
+            const snr = decode.snr != null ? (decode.snr >= 0 ? `+${decode.snr}` : decode.snr) : '?';
+            console.log(`[WsjtxRelay] Decode ${decode.time} ${snr}dB ${decode.freq}Hz ${decode.message}`);
+          }
+          break;
+        }
+
+        case WSJTX_MSG.CLEAR: {
+          // WSJT-X cleared its band activity window — forward so the UI can react
+          if (bus) bus.emit('clear', { source: 'wsjtx-relay', clientId: msg.id, window: msg.window });
+          // Also clear seen-decode IDs for this client so a replay after a manual
+          // clear is treated as fresh decodes
+          for (const id of seenDecodeIds) {
+            if (id.startsWith(`${msg.id}-`)) seenDecodeIds.delete(id);
+          }
+          break;
+        }
+
+        case WSJTX_MSG.QSO_LOGGED: {
+          const qso = {
+            ...enrichQso(msg),
+            // Fill myCall/myGrid from client state when not present in the message
+            myCall: msg.myCall || clientStates[msg.id]?.deCall || null,
+            myGrid: msg.myGrid || clientStates[msg.id]?.deGrid || null,
+          };
+
+          // Deduplicate: same call + frequency + mode within 60 s
+          const now = Date.now();
+          const isDup = recentQsos.some(
+            (q) =>
+              q.dxCall === qso.dxCall &&
+              q.frequency === qso.frequency &&
+              q.mode === qso.mode &&
+              now - q.timestamp < QSO_DEDUP_MS,
+          );
+          if (!isDup) {
+            recentQsos.push({ dxCall: qso.dxCall, frequency: qso.frequency, mode: qso.mode, timestamp: now });
+            if (recentQsos.length > QSO_DEDUP_MAX) recentQsos.shift();
+            if (bus) bus.emit('qso', { source: 'wsjtx-relay', ...qso });
+          }
+          break;
+        }
+
+        case WSJTX_MSG.WSPR_DECODE: {
+          if (!msg.isNew) break;
+          const wspr = enrichWspr(msg);
+          if (bus) bus.emit('wspr', { source: 'wsjtx-relay', ...wspr });
+          break;
+        }
+
+        // HEARTBEAT and CLOSE need no SSE event; REPLAY is filtered above.
+        default:
+          break;
+      }
+    }
+
+    // ── connect / disconnect ─────────────────────────────────────────────────
+
     function connect() {
       // Determine whether server relay is active for this session.
       // relayToServer requires url + key + session to all be set.
@@ -315,29 +455,7 @@ const descriptor = {
       const udpPort = cfg.udpPort || 2237;
       socket = dgram.createSocket('udp4');
 
-      socket.on('message', (buf, rinfo) => {
-        const msg = parseMessage(buf);
-        if (!msg) return;
-        // Track sender for bidirectional communication
-        remoteAddress = rinfo.address;
-        remotePort = rinfo.port;
-        if (msg.id) appId = msg.id;
-        if (msg.type === WSJTX_MSG.DECODE && msg.isNew) {
-          totalDecodes++;
-          if (bus) bus.emit('decode', { source: 'wsjtx-relay', ...msg });
-        }
-        if (msg.type === WSJTX_MSG.STATUS && bus) bus.emit('status', { source: 'wsjtx-relay', ...msg });
-        if (msg.type === WSJTX_MSG.QSO_LOGGED && bus) bus.emit('qso', { source: 'wsjtx-relay', ...msg });
-        if (msg.type !== WSJTX_MSG.REPLAY) {
-          if (willRelay) messageQueue.push(msg);
-          if (cfg.verbose && msg.type === WSJTX_MSG.DECODE) {
-            const snr = msg.snr != null ? (msg.snr >= 0 ? `+${msg.snr}` : msg.snr) : '?';
-            console.log(
-              `[WsjtxRelay] Decode ${msg.time?.formatted || '??'} ${snr}dB ${msg.deltaFreq}Hz ${msg.message}`,
-            );
-          }
-        }
-      });
+      socket.on('message', handleMessage);
 
       socket.on('error', (err) => {
         if (err.code === 'EADDRINUSE') {
@@ -351,7 +469,6 @@ const descriptor = {
       socket.on('listening', () => {
         const addr = socket.address();
         console.log(`[WsjtxRelay] Listening for WSJT-X on UDP ${addr.address}:${addr.port}`);
-        console.log(`[WsjtxRelay] Relaying to ${serverUrl}`);
 
         if (mcEnabled) {
           try {
@@ -366,7 +483,11 @@ const descriptor = {
           }
         }
 
+        // Prune grid cache every 5 minutes to release stale entries
+        gridPruneInterval = setInterval(() => gridCache.prune(), 5 * 60 * 1000);
+
         if (willRelay) {
+          console.log(`[WsjtxRelay] Relaying to ${serverUrl}`);
           scheduleBatch();
 
           // Initial health check then heartbeat
@@ -418,6 +539,10 @@ const descriptor = {
         clearInterval(healthInterval);
         healthInterval = null;
       }
+      if (gridPruneInterval) {
+        clearInterval(gridPruneInterval);
+        gridPruneInterval = null;
+      }
       if (socket) {
         if (mcEnabled) {
           try {
@@ -452,6 +577,7 @@ const descriptor = {
         serverUrl: willRelay ? serverUrl : null,
         multicast: mcEnabled,
         multicastGroup: mcEnabled ? mcGroup : null,
+        gridCacheSize: gridCache.size,
       };
     }
 

--- a/rig-bridge/plugins/wsjtx-relay.js
+++ b/rig-bridge/plugins/wsjtx-relay.js
@@ -44,7 +44,15 @@ const {
   buildFreeText,
   buildHighlightCallsign,
 } = require('../lib/wsjtx-protocol');
-const { createGridCache, enrichDecode, enrichStatus, enrichQso, enrichWspr } = require('../lib/wsjtx-enrich');
+const {
+  createGridCache,
+  createCallsignCache,
+  enrichDecode,
+  enrichStatus,
+  enrichQso,
+  enrichWspr,
+  triggerHamqthLookup,
+} = require('../lib/wsjtx-enrich');
 
 const RELAY_VERSION = require('../package.json').version;
 
@@ -178,6 +186,9 @@ const descriptor = {
     // ── Local enrichment state ──────────────────────────────────────────────
     // Shared grid cache: remembers callsign → grid from CQ/exchange messages
     const gridCache = createGridCache();
+    // HamQTH callsign lookup cache (only populated when cfg.hamqthLookup is true)
+    const callsignCache = createCallsignCache();
+    const hamqthInflight = new Set(); // callsigns currently being looked up
     // Per-client state needed for decode enrichment (band, freq, mode)
     const clientStates = Object.create(null); // clientId → { band, dialFrequency, mode }
     // Content-based decode deduplication (time + freq + message text)
@@ -187,7 +198,7 @@ const descriptor = {
     const recentQsos = []; // { dxCall, frequency, mode, timestamp }
     const QSO_DEDUP_MS = 60_000;
     const QSO_DEDUP_MAX = 200; // max entries to scan
-    // Prune grid cache every 5 minutes
+    // Prune grid and callsign caches every 5 minutes
     let gridPruneInterval = null;
 
     // ── Helpers ─────────────────────────────────────────────────────────────
@@ -357,7 +368,13 @@ const descriptor = {
           totalDecodes++;
 
           const clientState = clientStates[msg.id] ?? null;
-          const decode = enrichDecode(msg, clientState, gridCache, cfg.myCall ?? null);
+          const decode = enrichDecode(
+            msg,
+            clientState,
+            gridCache,
+            cfg.myCall ?? null,
+            cfg.hamqthLookup ? callsignCache : null,
+          );
 
           // Content-based deduplication — skip if we have already emitted this decode
           if (seenDecodeIds.has(decode.id)) break;
@@ -368,6 +385,18 @@ const descriptor = {
           }
 
           if (bus) bus.emit('decode', { source: 'wsjtx-relay', ...decode });
+
+          // Phase 5: if still no coordinates and HamQTH lookup is enabled,
+          // start a background request. When it resolves, emit decode-update so
+          // the frontend can retroactively place the map pin for this decode.
+          if (cfg.hamqthLookup && decode.lat == null) {
+            const targetCall = (decode.caller ?? decode.deCall ?? decode.dxCall ?? '').toUpperCase();
+            if (targetCall) {
+              triggerHamqthLookup(targetCall, callsignCache, hamqthInflight, ({ callsign, lat, lon }) => {
+                if (bus) bus.emit('decode-update', { source: 'wsjtx-relay', callsign, lat, lon });
+              });
+            }
+          }
 
           if (cfg.verbose) {
             const snr = decode.snr != null ? (decode.snr >= 0 ? `+${decode.snr}` : decode.snr) : '?';
@@ -483,8 +512,14 @@ const descriptor = {
           }
         }
 
-        // Prune grid cache every 5 minutes to release stale entries
-        gridPruneInterval = setInterval(() => gridCache.prune(), 5 * 60 * 1000);
+        // Prune grid and callsign caches every 5 minutes to release stale entries
+        gridPruneInterval = setInterval(
+          () => {
+            gridCache.prune();
+            callsignCache.prune();
+          },
+          5 * 60 * 1000,
+        );
 
         if (willRelay) {
           console.log(`[WsjtxRelay] Relaying to ${serverUrl}`);
@@ -578,6 +613,9 @@ const descriptor = {
         multicast: mcEnabled,
         multicastGroup: mcEnabled ? mcGroup : null,
         gridCacheSize: gridCache.size,
+        callsignCacheSize: callsignCache.size,
+        hamqthLookup: !!cfg.hamqthLookup,
+        hamqthInflight: hamqthInflight.size,
       };
     }
 

--- a/rig-bridge/rig-bridge.js
+++ b/rig-bridge/rig-bridge.js
@@ -123,7 +123,6 @@ pluginBus.on('decode', (msg) => {
     timeMs: msg.timeMs,
     mode: msg.mode,
     message: msg.message,
-    type: msg.message.startsWith('CQ') ? 'CQ' : 'QSO',
     dialFrequency: msg.dialFrequency,
     band: msg.band,
     // Parsed FT8 message fields (from wsjtx-enrich, undefined for raw decodes)
@@ -201,7 +200,29 @@ pluginBus.on('clear', (msg) => {
 });
 
 pluginBus.on('wspr', (msg) => {
-  broadcast({ type: 'plugin', event: 'wspr', source: msg.source, data: msg });
+  broadcast({
+    type: 'plugin',
+    event: 'wspr',
+    source: msg.source,
+    data: {
+      clientId: msg.clientId,
+      isNew: msg.isNew,
+      time: msg.time,
+      timeMs: msg.timeMs,
+      snr: msg.snr,
+      dt: msg.dt,
+      frequency: msg.frequency,
+      band: msg.band,
+      drift: msg.drift,
+      callsign: msg.callsign,
+      grid: msg.grid,
+      power: msg.power,
+      offAir: msg.offAir,
+      lat: msg.lat ?? null,
+      lon: msg.lon ?? null,
+      timestamp: msg.timestamp ?? Date.now(),
+    },
+  });
 });
 
 pluginBus.on('decode-update', (msg) => {

--- a/rig-bridge/rig-bridge.js
+++ b/rig-bridge/rig-bridge.js
@@ -19,7 +19,7 @@
 
 'use strict';
 
-const VERSION = '2.0.0';
+const VERSION = '2.1.0';
 
 const { config, loadConfig, applyCliArgs } = require('./core/config');
 const {

--- a/rig-bridge/rig-bridge.js
+++ b/rig-bridge/rig-bridge.js
@@ -103,20 +103,42 @@ registry.registerBuiltins();
 //    mode receive all plugin data (decodes, status, APRS) over the same
 //    connection used for freq/mode/ptt — no separate HTTP POSTs needed.
 pluginBus.on('decode', (msg) => {
-  // Build a trimmed decode object with the fields the UI needs.
-  // id is a stable content key used for client-side deduplication.
+  // Build the decode object forwarded to SSE consumers.
+  // When the decode comes from wsjtx-relay (or any plugin using wsjtx-enrich),
+  // it already carries an enriched content-based id plus lat/lon/band/grid/type/
+  // caller/modifier fields — pass them all through so the UI can use them.
+  // For raw (un-enriched) decodes, synthesise an id from available fields.
+  const rawTime = typeof msg.time === 'object' ? (msg.time?.formatted ?? '') : (msg.time ?? '');
   const d = {
-    id: `${msg.source}-${msg.time?.formatted ?? Date.now()}-${msg.deltaFreq}-${(msg.message ?? '').replace(/\s/g, '')}`,
+    id:
+      msg.id ?? `${msg.source}-${rawTime}-${msg.deltaFreq ?? msg.freq ?? 0}-${(msg.message ?? '').replace(/\s/g, '')}`,
     source: msg.source,
+    clientId: msg.clientId,
     snr: msg.snr,
     deltaTime: msg.deltaTime,
-    deltaFreq: msg.deltaFreq,
-    freq: msg.deltaFreq, // alias used by useWSJTX dedup key
-    time: msg.time?.formatted ?? '',
+    dt: msg.dt,
+    deltaFreq: msg.deltaFreq ?? msg.freq,
+    freq: msg.freq ?? msg.deltaFreq, // alias used by useWSJTX dedup key
+    time: rawTime,
+    timeMs: msg.timeMs,
     mode: msg.mode,
     message: msg.message,
     dialFrequency: msg.dialFrequency,
-    timestamp: Date.now(),
+    band: msg.band,
+    // Parsed FT8 message fields (from wsjtx-enrich, undefined for raw decodes)
+    type: msg.type,
+    caller: msg.caller,
+    modifier: msg.modifier,
+    dxCall: msg.dxCall,
+    deCall: msg.deCall,
+    exchange: msg.exchange,
+    grid: msg.grid,
+    gridSource: msg.gridSource,
+    lat: msg.lat,
+    lon: msg.lon,
+    lowConfidence: msg.lowConfidence,
+    offAir: msg.offAir,
+    timestamp: msg.timestamp ?? Date.now(),
   };
   addToDecodeRingBuffer(d);
   broadcast({ type: 'plugin', event: 'decode', source: msg.source, data: d });
@@ -132,6 +154,12 @@ pluginBus.on('status', (msg) => {
       mode: msg.mode,
       dxCall: msg.dxCall,
       dxGrid: msg.dxGrid,
+      dxLat: msg.dxLat ?? null,
+      dxLon: msg.dxLon ?? null,
+      deLat: msg.deLat ?? null,
+      deLon: msg.deLon ?? null,
+      band: msg.band ?? null,
+      bandChanged: msg.bandChanged ?? false,
       transmitting: msg.transmitting,
       decoding: msg.decoding,
       txEnabled: msg.txEnabled,
@@ -145,14 +173,42 @@ pluginBus.on('qso', (msg) => {
     event: 'qso',
     source: msg.source,
     data: {
+      clientId: msg.clientId,
       dxCall: msg.dxCall,
       dxGrid: msg.dxGrid,
+      lat: msg.lat ?? null,
+      lon: msg.lon ?? null,
       mode: msg.mode,
+      band: msg.band ?? null,
+      frequency: msg.frequency,
       reportSent: msg.reportSent,
-      reportReceived: msg.reportReceived,
-      txFrequency: msg.txFrequency,
-      timestamp: Date.now(),
+      reportRecv: msg.reportRecv,
+      myCall: msg.myCall ?? null,
+      myGrid: msg.myGrid ?? null,
+      timestamp: msg.timestamp ?? Date.now(),
     },
+  });
+});
+
+pluginBus.on('clear', (msg) => {
+  broadcast({
+    type: 'plugin',
+    event: 'clear',
+    source: msg.source,
+    data: { clientId: msg.clientId, window: msg.window },
+  });
+});
+
+pluginBus.on('wspr', (msg) => {
+  broadcast({ type: 'plugin', event: 'wspr', source: msg.source, data: msg });
+});
+
+pluginBus.on('decode-update', (msg) => {
+  broadcast({
+    type: 'plugin',
+    event: 'decode-update',
+    source: msg.source,
+    data: { callsign: msg.callsign, lat: msg.lat, lon: msg.lon },
   });
 });
 

--- a/src/components/PSKReporterPanel.jsx
+++ b/src/components/PSKReporterPanel.jsx
@@ -757,7 +757,7 @@ const PSKReporterPanel = ({
                       <span
                         style={{ color: 'var(--text-muted)', minWidth: '24px', textAlign: 'right', fontSize: '10px' }}
                       >
-                        {d.dt}
+                        {d.dt != null ? `${Number(d.dt) >= 0 ? '+' : ''}${Number(d.dt).toFixed(1)}` : ''}
                       </span>
                       <span
                         style={{
@@ -828,7 +828,9 @@ const PSKReporterPanel = ({
                       >
                         {d.snr != null ? `${d.snr > 0 ? '+' : ''}${d.snr}` : ''}
                       </span>
-                      <span style={{ color: 'var(--text-muted)', minWidth: '28px', fontSize: '10px' }}>{d.dt}</span>
+                      <span style={{ color: 'var(--text-muted)', minWidth: '28px', fontSize: '10px' }}>
+                        {d.dt != null ? `${Number(d.dt) >= 0 ? '+' : ''}${Number(d.dt).toFixed(1)}` : ''}
+                      </span>
                       <span style={{ color: '#22d3ee', fontWeight: '600', minWidth: '65px' }}>
                         <CallsignLink call={d.callsign} color="#22d3ee" fontWeight="600" />
                       </span>

--- a/src/hooks/useWSJTX.js
+++ b/src/hooks/useWSJTX.js
@@ -249,6 +249,10 @@ export function useWSJTX(enabled = true) {
               mode: s.mode,
               dxCall: s.dxCall,
               dxGrid: s.dxGrid,
+              dxLat: s.dxLat ?? null,
+              dxLon: s.dxLon ?? null,
+              band: s.band ?? null,
+              bandChanged: s.bandChanged ?? false,
               transmitting: s.transmitting,
               decoding: s.decoding,
               lastSeen: Date.now(),
@@ -260,6 +264,29 @@ export function useWSJTX(enabled = true) {
           const updated = [msg.data, ...prev.qsos].slice(-200);
           return { ...prev, qsos: updated, stats: { ...prev.stats, totalQsos: updated.length } };
         });
+      } else if (msg.event === 'clear') {
+        // WSJT-X cleared its band activity — remove decodes from that client
+        const clientId = msg.data?.clientId;
+        if (clientId) {
+          setData((prev) => ({ ...prev, decodes: prev.decodes.filter((d) => d.clientId !== clientId) }));
+        }
+      } else if (msg.event === 'wspr') {
+        setData((prev) => {
+          const updated = [msg.data, ...prev.wspr].slice(-100);
+          return { ...prev, wspr: updated, stats: { ...prev.stats, totalWspr: updated.length } };
+        });
+      } else if (msg.event === 'decode-update') {
+        // Async HamQTH result arrived — patch any existing decodes from this callsign
+        const { callsign, lat, lon } = msg.data ?? {};
+        if (callsign && lat != null && lon != null) {
+          setData((prev) => ({
+            ...prev,
+            decodes: prev.decodes.map((d) => {
+              const match = d.caller === callsign || d.dxCall === callsign || d.deCall === callsign;
+              return match && d.lat == null ? { ...d, lat, lon, gridSource: 'hamqth' } : d;
+            }),
+          }));
+        }
       }
     };
     window.addEventListener('rig-plugin-data', handler);
@@ -292,12 +319,16 @@ export function useWSJTX(enabled = true) {
     prevDxCallRef.current = call || null;
 
     // ── Band change detection ──
-    // When the active client's band changes, clear stale decodes from the old band.
-    const currentBand = active.band || null;
-    if (currentBand && prevBandRef.current && currentBand !== prevBandRef.current) {
+    // Use the bandChanged flag emitted by the rig-bridge enrichment layer, which
+    // sets it for exactly one STATUS cycle when a transition is detected.
+    // Fall back to manual tracking for the server/relay path which may not set it.
+    const currentBand = active.band ?? null;
+    const bandJustChanged =
+      active.bandChanged || (currentBand && prevBandRef.current && currentBand !== prevBandRef.current);
+    if (bandJustChanged) {
       setData((prev) => ({
         ...prev,
-        decodes: [], // Clear all decodes on band change — server will fill with new-band decodes
+        decodes: [], // Clear all decodes on band change — new-band decodes will fill in
       }));
     }
     prevBandRef.current = currentBand;

--- a/src/layouts/ModernLayout.jsx
+++ b/src/layouts/ModernLayout.jsx
@@ -364,6 +364,7 @@ export default function ModernLayout(props) {
       wsjtxDecodes={wsjtx.decodes}
       wsjtxClients={wsjtx.clients}
       wsjtxQsos={wsjtx.qsos}
+      wsjtxWspr={wsjtx.wspr}
       wsjtxStats={wsjtx.stats}
       wsjtxLoading={wsjtx.loading}
       wsjtxEnabled={wsjtx.enabled}


### PR DESCRIPTION
## What does this PR do?

## Summary

This PR moves the WSJTX decode enrichment intelligence from the OHC server into the local `rig-bridge` process, so SSE consumers receive fully enriched events even when no server relay is configured.

- **Local enrichment library** (`rig-bridge/lib/wsjtx-enrich.js`): Maidenhead grid → lat/lon, Hz → band name, FT8/FT4 message parser (CQ/QSO type, caller, modifier, embedded grid), per-client grid cache (2 h TTL), and full enrichment helpers for DECODE, STATUS, QSO_LOGGED, and WSPR_DECODE messages.
- **HamQTH callsign lookup** (Phase 5, opt-in): fire-and-forget background resolution of callsign → lat/lon via `hamqth.com/dxcc.php`; 24 h cache, max 5 concurrent requests. On resolution a `decode-update` SSE event is emitted so the frontend can live-patch map pins already on screen. Toggled via a new checkbox in the rig-bridge Integrations tab.
- **End-to-end wiring** (`rig-bridge.js`): decode, status, qso, clear, wspr, and decode-update bus events are now all forwarded to SSE with their full enriched field sets (previously only a trimmed subset was forwarded, silently dropping all enrichment).
- **Frontend** (`useWSJTX.js`): handles new SSE event types — `clear` (per-client filtering), `wspr` (capped ring buffer), `decode-update` (async HamQTH patch). Band-change detection uses the `bandChanged` flag from enriched status; falls back to manual comparison on the server/relay path.
- **Bug fix**: `wsjtx-enrich` was emitting lowercase `'cq'`/`'qso'` type strings; changed to uppercase `'CQ'`/`'QSO'` to match the server convention and fix CQ filter + row colouring in PSKReporterPanel.
- **Bug fix**: `ModernLayout` was not passing `wsjtxWspr` to `PSKReporterPanel` — the WSPR tab now receives data in that layout.
- Enrichment on the **relay path is unchanged** — the rig-bridge relay queue still sends raw messages so the server can do its own enrichment without double-processing.

## Test plan

- [ ] Run rig-bridge in **SSE-only mode** (no server relay): confirm DECODE events in PSKReporterPanel show band, grid, lat/lon, CQ/QSO type and row colour
- [ ] Enable **HamQTH callsign lookup** in the Integrations tab: confirm callsigns without an embedded grid eventually get lat/lon resolved and map pins appear
- [ ] Confirm **WSPR tab** populates in ModernLayout (was broken before this PR)
- [ ] Confirm **CLEAR** from WSJT-X wipes only the correct client's decodes
- [ ] Run rig-bridge with a **server relay configured**: confirm server-side enrichment still works and no fields are duplicated or corrupted
- [ ] Check rig-bridge status endpoint reports `gridCacheSize`, `callsignCacheSize`, and `hamqthLookup` flag correctly
- [ ] Verify **MSHV / JTDX / JS8Call** (`digital-mode-base.js`) receive the same enrichment as WSJT-X

## Checklist

- [x] App loads without console errors
- [x] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included


