### PR TITLE
fix(rbn): restore PORT in ctx destructuring so spotter-mode spots appear on map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Claude Code local config
 .claude/
+CLAUDE.md
 
 # Dependencies
 node_modules/

--- a/server/routes/rbn.js
+++ b/server/routes/rbn.js
@@ -10,6 +10,7 @@ module.exports = function (app, ctx) {
   const {
     fetch,
     CONFIG,
+    PORT,
     logDebug,
     logInfo,
     logWarn,

--- a/src/plugins/layers/useRBN.js
+++ b/src/plugins/layers/useRBN.js
@@ -282,16 +282,22 @@ export function useLayer({
         // Log spot details
         if (mySpots.length > 0) {
           mySpots.forEach((spot, idx) => {
-            console.log(
-              `  ${idx + 1}. Skimmer: ${spot.callsign}, Freq: ${spot.freqMHz} MHz, SNR: ${spot.snr} dB, Band: ${spot.band}, Grid: ${spot.grid || 'MISSING'}, Lat: ${spot.skimmerLat || '?'}, Lon: ${spot.skimmerLon || '?'}`,
-            );
+            if (queryMode === 'spotter') {
+              console.log(
+                `  ${idx + 1}. DX: ${spot.dx}, Skimmer: ${spot.callsign}, Freq: ${spot.freqMHz} MHz, SNR: ${spot.snr} dB, Band: ${spot.band}, dxLat: ${spot.dxLat ?? 'MISSING'}, dxLon: ${spot.dxLon ?? 'MISSING'}, dxGrid: ${spot.dxGrid ?? 'MISSING'}`,
+              );
+            } else {
+              console.log(
+                `  ${idx + 1}. Skimmer: ${spot.callsign}, Freq: ${spot.freqMHz} MHz, SNR: ${spot.snr} dB, Band: ${spot.band}, Grid: ${spot.grid ?? 'MISSING'}, Lat: ${spot.skimmerLat ?? '?'}, Lon: ${spot.skimmerLon ?? '?'}`,
+              );
+            }
           });
         }
 
         // Client-side location fallback for any spots the server couldn't resolve
         const enrichedSpots = await Promise.all(
           mySpots.map(async (spot) => {
-            if (spot.grid && spot.skimmerLat && spot.skimmerLon) return spot;
+            if (spot.grid && spot.skimmerLat != null && spot.skimmerLon != null) return spot;
             try {
               const locationResponse = await fetch(`/api/rbn/location/${spot.callsign}`);
               if (locationResponse.ok) {
@@ -426,7 +432,7 @@ export function useLayer({
     let spotterOrigin = null;
     if (queryMode === 'spotter' && filteredSpots.length > 0) {
       const first = filteredSpots[0];
-      if (first.skimmerLat && first.skimmerLon) {
+      if (first.skimmerLat != null && first.skimmerLon != null) {
         spotterOrigin = { lat: first.skimmerLat, lon: first.skimmerLon };
       } else if (first.grid) {
         spotterOrigin = gridToLatLon(first.grid);
@@ -501,7 +507,7 @@ export function useLayer({
         }
 
         let skimmerLoc;
-        if (spot.skimmerLat && spot.skimmerLon) {
+        if (spot.skimmerLat != null && spot.skimmerLon != null) {
           skimmerLoc = { lat: spot.skimmerLat, lon: spot.skimmerLon };
         } else {
           skimmerLoc = gridToLatLon(skimmerGrid);


### PR DESCRIPTION
## Summary

Fixes #897 — RBN "What does a skimmer hear?" spots show a correct count in the panel but never appear on the map.

- **Root cause:** `PORT` was present in the shared `ctx` object passed to `rbn.js` but was not included in the module's destructuring. Every internal callsign-lookup call (`enrichSpotWithLocation`, `enrichSpotWithDXLocation`, `/api/rbn/location/`) referenced the undeclared variable inside a `try/catch`, so the resulting `ReferenceError` was silently swallowed, a `_failed` marker was cached for 10 minutes, and **no spot ever received coordinates**. The stats counter read from the raw spot count (before enrichment), so it looked correct while the map stayed empty.
- **Fix:** Add `PORT` to the `ctx` destructuring at the top of `server/routes/rbn.js` (one line). This unblocks all three location-lookup paths and allows `enrichSpotWithDXLocation` to resolve DX station coordinates via the `/api/callsign/` endpoint (which itself falls back to prefix estimation, so virtually any valid callsign resolves).
- **Coding compliance:** Three falsy `&&` checks on `skimmerLat`/`skimmerLon` in `useRBN.js` were replaced with `!= null` guards, preventing silent breakage for stations on the equator (lat 0) or prime meridian (lon 0).
- **Debug logging:** Spotter mode now logs `dxLat`/`dxLon`/`dxGrid` per spot instead of the irrelevant skimmer coordinates, making future diagnosis possible without a code change.

## Test plan

- [ ] Add the RBN panel to the map and set mode to **"What does a skimmer hear?"**
- [ ] Enter a known-active skimmer callsign (e.g. `KD2OGR`, `W2NNN`, `WS2C`)
- [ ] Verify the spot count in the panel header matches the number of markers and paths drawn on the map
- [ ] Confirm the **default DX mode** ("who hears me?") also draws skimmer markers and paths correctly
- [ ] Confirm no regression on band/SNR/time-window filtering in both modes
- [ ] Test with a skimmer near lat=0 or lon=0 if possible (equator/prime meridian edge case)

