### PR TITLE
header, temperature metric or US customary

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -8,6 +8,7 @@ import DonateButton from './DonateButton.jsx';
 import { QRZToggle } from './CallsignLink.jsx';
 import { ctyLookup, isCtyLoaded } from '../utils/ctyLookup';
 import { getFlagUrl } from '../utils/countryFlags';
+import { formatTemperature, formatTemperatureBoth } from '../utils/formatWeather.js';
 
 export const Header = ({
   config,
@@ -37,9 +38,6 @@ export const Header = ({
   const clockSize = `${(isMobile ? 16 : 24) * scale}px`;
   const statsSize = `${(isMobile ? 10 : 13) * scale}px`;
   const labelSize = `${(isMobile ? 10 : 13) * scale}px`;
-
-  const allUnits = config.allUnits || {};
-  const isMetricTemp = allUnits.temp === 'metric';
 
   return (
     <div
@@ -179,12 +177,11 @@ export const Header = ({
               const rawC = localWeather.data.rawTempC;
               return (
                 <div
-                  title={`${Math.round(rawC)}°C / ${Math.round((rawC * 9) / 5 + 32)}°F • ${localWeather.data.description} • Wind: ${localWeather.data.windSpeed} ${localWeather.data.windUnit || 'mph'}`}
+                  title={`${formatTemperatureBoth(rawC)} • ${localWeather.data.description} • Wind: ${localWeather.data.windSpeed} ${localWeather.data.windUnit || 'mph'}`}
                 >
                   <span style={{ marginRight: '3px' }}>{localWeather.data.icon}</span>
                   <span style={{ color: 'var(--accent-cyan)', fontWeight: '600' }}>
-                    {isMetricTemp ? Math.round(rawC) : Math.round((rawC * 9) / 5 + 32)}
-                    {isMetricTemp ? '°C' : '°F'}
+                    {formatTemperature(rawC, config?.allUnits)}
                   </span>
                 </div>
               );

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -179,7 +179,7 @@ export const Header = ({
               const rawC = localWeather.data.rawTempC;
               return (
                 <div
-                  title={`${localWeather.data.description} • Wind: ${localWeather.data.windSpeed} ${localWeather.data.windUnit || 'mph'}`}
+                  title={`${Math.round(rawC)}°C / ${Math.round((rawC * 9) / 5 + 32)}°F • ${localWeather.data.description} • Wind: ${localWeather.data.windSpeed} ${localWeather.data.windUnit || 'mph'}`}
                 >
                   <span style={{ marginRight: '3px' }}>{localWeather.data.icon}</span>
                   <span style={{ color: 'var(--accent-cyan)', fontWeight: '600' }}>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -38,6 +38,9 @@ export const Header = ({
   const statsSize = `${(isMobile ? 10 : 13) * scale}px`;
   const labelSize = `${(isMobile ? 10 : 13) * scale}px`;
 
+  const allUnits = config.allUnits || {};
+  const isMetricTemp = allUnits.temp === 'metric';
+
   return (
     <div
       style={{
@@ -180,7 +183,8 @@ export const Header = ({
                 >
                   <span style={{ marginRight: '3px' }}>{localWeather.data.icon}</span>
                   <span style={{ color: 'var(--accent-cyan)', fontWeight: '600' }}>
-                    {Math.round((rawC * 9) / 5 + 32)}°F/{Math.round(rawC)}°C
+                    {isMetricTemp ? Math.round(rawC) : Math.round((rawC * 9) / 5 + 32)}
+                    {isMetricTemp ? '°C' : '°F'}
                   </span>
                 </div>
               );

--- a/src/utils/formatWeather.js
+++ b/src/utils/formatWeather.js
@@ -1,0 +1,22 @@
+// returns formatted Fahrenheit temperature based on celsius argument e.g. "72°F"
+export function formatFahrenheit(rawCelsius) {
+  return `${Math.round((rawCelsius * 9) / 5 + 32)}°F`;
+}
+
+// returns formatted Celsius temperature based on celsius argument e.g. "22°C"
+export function formatCelsius(rawCelsius) {
+  return `${Math.round(rawCelsius)}°C`;
+}
+
+// returns formatted temperature in both Celsius and Fahrenheit based on celsius argument e.g. "22°C / 72°F"
+export function formatTemperatureBoth(rawCelsius) {
+  return `${formatCelsius(rawCelsius)} / ${formatFahrenheit(rawCelsius)}`;
+}
+
+// Returns formatted temperature based on allUnits.temp, e.g. "22°C" or "72°F"
+export function formatTemperature(rawCelsius, allUnits) {
+  if (allUnits?.temp === 'metric') {
+    return formatCelsius(rawCelsius);
+  }
+  return formatFahrenheit(rawCelsius);
+}


### PR DESCRIPTION
## What does this PR do?

uses global temperature units selection to show C or F in header but not both

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [X] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1.
2.
3.

## Checklist

- [X] App loads without console errors
- [X] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

WAS
![was Screenshot 2026-04-12 093034](https://github.com/user-attachments/assets/3e99c061-b8fa-4cce-9f5c-2065a3865222)

BECOMES
![becomes F Screenshot 2026-04-12 093547](https://github.com/user-attachments/assets/fe508a85-40c9-4642-927e-4081fb0d7dfb)

OR
![become celcius Screenshot 2026-04-12 093457](https://github.com/user-attachments/assets/2865259b-3140-40d5-8f50-d3c667115563)
