### PR TITLE
Feature/Show DX spot callsign in the DX panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -234,7 +234,7 @@ const App = () => {
   usePresence({ callsign: config.callsign, locator: config.locator, sharePresence: config.sharePresence !== false });
 
   // Location & map state
-  const { dxLocation, dxLocked, handleToggleDxLock, handleDXChange } = useDXLocation(config.defaultDX);
+  const { dxLocation, dxCallsign, dxLocked, handleToggleDxLock, handleDXChange } = useDXLocation(config.defaultDX);
 
   const {
     mapLayers,
@@ -491,6 +491,7 @@ const App = () => {
     deGrid,
     dxGrid,
     dxLocation,
+    dxCallsign,
     dxLocked,
     handleDXChange,
     handleToggleDxLock,

--- a/src/DockableApp.jsx
+++ b/src/DockableApp.jsx
@@ -64,6 +64,7 @@ export const DockableApp = ({
   deGrid,
   dxGrid,
   dxLocation,
+  dxCallsign,
   deSunTimes,
   dxSunTimes,
   handleDXChange,
@@ -344,12 +345,12 @@ export const DockableApp = ({
       // For DX Cluster spots, we need to find the path data which contains coordinates
       // For POTA/SOTA, the spot object itself has lat/lon
       if (spot.lat != null && spot.lon != null) {
-        handleDXChange({ lat: spot.lat, lon: spot.lon });
+        handleDXChange({ lat: spot.lat, lon: spot.lon, callsign: spot.call ?? null });
       } else if (spot.call) {
         // Try to find in DX Cluster paths
         const path = findDXPathForSpot(dxClusterData.paths || [], spot);
         if (path && path.dxLat != null && path.dxLon != null) {
-          handleDXChange({ lat: path.dxLat, lon: path.dxLon });
+          handleDXChange({ lat: path.dxLat, lon: path.dxLon, callsign: spot.call ?? null });
         }
       }
     },
@@ -532,6 +533,19 @@ export const DockableApp = ({
                   flex: '1 1 auto',
                 }}
               />
+              {dxCallsign && (
+                <span
+                  style={{
+                    fontFamily: 'JetBrains Mono',
+                    fontSize: '22px',
+                    fontWeight: '900',
+                    color: 'var(--accent-amber)',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {dxCallsign}
+                </span>
+              )}
               <DXFavorites dxLocation={dxLocation} dxGrid={dxGrid} onDXChange={handleDXChange} dxLocked={dxLocked} />
               <button
                 type="button"

--- a/src/DockableApp.jsx
+++ b/src/DockableApp.jsx
@@ -521,50 +521,56 @@ export const DockableApp = ({
         </div>
         <div style={{ display: 'flex', alignItems: 'flex-start', gap: '12px' }}>
           <div style={{ fontFamily: 'JetBrains Mono', fontSize: '14px', flex: '1 1 auto', minWidth: 0 }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-              <DXGridInput
-                dxGrid={dxGrid}
-                onDXChange={handleDXChange}
-                dxLocked={dxLocked}
-                style={{
-                  color: 'var(--accent-amber)',
-                  fontSize: '22px',
-                  fontWeight: '700',
-                  flex: '1 1 auto',
-                }}
-              />
-              {dxCallsign && (
-                <span
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 }}>
+                <DXGridInput
+                  dxGrid={dxGrid}
+                  onDXChange={handleDXChange}
+                  dxLocked={dxLocked}
                   style={{
-                    fontFamily: 'JetBrains Mono',
-                    fontSize: '22px',
-                    fontWeight: '900',
                     color: 'var(--accent-amber)',
-                    whiteSpace: 'nowrap',
+                    fontSize: '22px',
+                    fontWeight: '700',
+                    flex: '0 0 auto',
+                  }}
+                />
+                {dxCallsign && (
+                  <span
+                    style={{
+                      fontFamily: 'JetBrains Mono',
+                      fontSize: '22px',
+                      fontWeight: '900',
+                      color: 'var(--accent-amber)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {dxCallsign}
+                  </span>
+                )}
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                <DXFavorites dxLocation={dxLocation} dxGrid={dxGrid} onDXChange={handleDXChange} dxLocked={dxLocked} />
+                <button
+                  type="button"
+                  onClick={() => setShowDxccSelect((prev) => !prev)}
+                  title={t('app.dxLocation.dxccToggleTitle')}
+                  style={{
+                    background: showDxccSelect ? 'var(--accent-amber)' : 'var(--bg-tertiary)',
+                    color: showDxccSelect ? '#000' : 'var(--text-secondary)',
+                    border: '1px solid var(--border-color)',
+                    borderRadius: '4px',
+                    padding: '4px 8px',
+                    fontSize: '12px',
+                    fontFamily: 'JetBrains Mono, monospace',
+                    cursor: 'pointer',
+                    flex: '0 0 auto',
                   }}
                 >
-                  {dxCallsign}
-                </span>
-              )}
-              <DXFavorites dxLocation={dxLocation} dxGrid={dxGrid} onDXChange={handleDXChange} dxLocked={dxLocked} />
-              <button
-                type="button"
-                onClick={() => setShowDxccSelect((prev) => !prev)}
-                title={t('app.dxLocation.dxccToggleTitle')}
-                style={{
-                  background: showDxccSelect ? 'var(--accent-amber)' : 'var(--bg-tertiary)',
-                  color: showDxccSelect ? '#000' : 'var(--text-secondary)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '4px',
-                  padding: '4px 8px',
-                  fontSize: '12px',
-                  fontFamily: 'JetBrains Mono, monospace',
-                  cursor: 'pointer',
-                  flex: '0 0 auto',
-                }}
-              >
-                DXCC
-              </button>
+                  DXCC
+                </button>
+              </div>
             </div>
             {showDxccSelect && (
               <DXCCSelect dxLocked={dxLocked} onDXChange={handleDXChange} style={{ margin: '5px 0 10px 0' }} />

--- a/src/hooks/app/useDXLocation.js
+++ b/src/hooks/app/useDXLocation.js
@@ -30,6 +30,13 @@ export default function useDXLocation(defaultDX) {
     return false;
   });
 
+  const [dxCallsign, setDxCallsign] = useState(() => {
+    try {
+      return localStorage.getItem('openhamclock_dxCallsign') || null;
+    } catch (e) {}
+    return null;
+  });
+
   const dxLockedRef = useRef(dxLocked);
 
   useEffect(() => {
@@ -40,6 +47,16 @@ export default function useDXLocation(defaultDX) {
     } catch (e) {}
   }, [dxLocked]);
 
+  useEffect(() => {
+    try {
+      if (dxCallsign != null) {
+        localStorage.setItem('openhamclock_dxCallsign', dxCallsign);
+      } else {
+        localStorage.removeItem('openhamclock_dxCallsign');
+      }
+    } catch (e) {}
+  }, [dxCallsign]);
+
   const handleToggleDxLock = useCallback(() => {
     setDxLocked((prev) => !prev);
   }, []);
@@ -47,12 +64,16 @@ export default function useDXLocation(defaultDX) {
   const handleDXChange = useCallback((coords) => {
     if (!dxLockedRef.current) {
       setDxLocation({ lat: coords.lat, lon: coords.lon });
+      // Callsign is only set when a spot is clicked; manual grid entry clears it
+      setDxCallsign(coords.callsign !== undefined ? (coords.callsign ?? null) : null);
     }
   }, []);
 
   return {
     dxLocation,
     setDxLocation,
+    dxCallsign,
+    setDxCallsign,
     dxLocked,
     handleToggleDxLock,
     handleDXChange,

--- a/src/layouts/ClassicLayout.jsx
+++ b/src/layouts/ClassicLayout.jsx
@@ -96,6 +96,7 @@ export default function ClassicLayout(props) {
     hoveredSpot,
     setHoveredSpot,
     dxLocation,
+    dxCallsign,
     dxLocked,
     handleDXChange,
     handleToggleDxLock,
@@ -158,7 +159,7 @@ export default function ClassicLayout(props) {
       tuneTo(spot);
       const path = findDXPathForSpot(dxClusterData.paths || [], spot);
       if (path && path.dxLat != null && path.dxLon != null) {
-        handleDXChange({ lat: path.dxLat, lon: path.dxLon });
+        handleDXChange({ lat: path.dxLat, lon: path.dxLon, callsign: spot.call ?? spot.dxCall ?? null });
       }
     },
     [tuneTo, dxClusterData.paths, handleDXChange],
@@ -1699,7 +1700,7 @@ export default function ClassicLayout(props) {
                     tuneTo(spot);
                     const path = findDXPathForSpot(dxClusterData.paths || [], spot);
                     if (path && path.dxLat != null && path.dxLon != null) {
-                      handleDXChange({ lat: path.dxLat, lon: path.dxLon });
+                      handleDXChange({ lat: path.dxLat, lon: path.dxLon, callsign: spot.call ?? spot.dxCall ?? null });
                     }
                   }}
                 >
@@ -2145,6 +2146,18 @@ export default function ClassicLayout(props) {
                 dxLocked={dxLocked}
                 style={{ color: 'var(--text-muted)', fontSize: '14px' }}
               />
+              {dxCallsign && (
+                <span
+                  style={{
+                    color: 'var(--text-muted)',
+                    fontSize: '14px',
+                    fontFamily: 'JetBrains Mono',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {dxCallsign}
+                </span>
+              )}
               <DXFavorites dxLocation={dxLocation} dxGrid={dxGrid} onDXChange={handleDXChange} dxLocked={dxLocked} /> •{' '}
               {dxLocked ? t('app.dxLock.lockedShort') : t('app.dxLock.clickToSet')}
             </span>
@@ -2254,7 +2267,7 @@ export default function ClassicLayout(props) {
                   tuneTo(spot);
                   const path = findDXPathForSpot(dxClusterData.paths || [], spot);
                   if (path && path.dxLat != null && path.dxLon != null) {
-                    handleDXChange({ lat: path.dxLat, lon: path.dxLon });
+                    handleDXChange({ lat: path.dxLat, lon: path.dxLon, callsign: spot.call ?? spot.dxCall ?? null });
                   }
                 }}
               >

--- a/src/layouts/ClassicLayout.jsx
+++ b/src/layouts/ClassicLayout.jsx
@@ -168,6 +168,9 @@ export default function ClassicLayout(props) {
   // Handler for POTA/WWFF/SOTA spot clicks
   const handleParkSpotClick = (spot) => {
     tuneTo(spot);
+    if (spot.lat != null && spot.lon != null) {
+      handleDXChange({ lat: spot.lat, lon: spot.lon, callsign: spot.call ?? null });
+    }
   };
 
   // Kp color coding

--- a/src/layouts/ClassicLayout.jsx
+++ b/src/layouts/ClassicLayout.jsx
@@ -2149,9 +2149,10 @@ export default function ClassicLayout(props) {
               {dxCallsign && (
                 <span
                   style={{
-                    color: 'var(--text-muted)',
+                    color: 'var(--accent-amber)',
                     fontSize: '14px',
                     fontFamily: 'JetBrains Mono',
+                    fontWeight: '900',
                     whiteSpace: 'nowrap',
                   }}
                 >

--- a/src/layouts/ModernLayout.jsx
+++ b/src/layouts/ModernLayout.jsx
@@ -266,7 +266,7 @@ export default function ModernLayout(props) {
             <span
               style={{
                 fontFamily: 'JetBrains Mono',
-                fontSize: '14px',
+                fontSize: '22px',
                 fontWeight: '900',
                 color: 'var(--accent-amber)',
                 whiteSpace: 'nowrap',

--- a/src/layouts/ModernLayout.jsx
+++ b/src/layouts/ModernLayout.jsx
@@ -60,6 +60,7 @@ export default function ModernLayout(props) {
     deGrid,
     dxGrid,
     dxLocation,
+    dxCallsign,
     dxLocked,
     handleDXChange,
     handleToggleDxLock,
@@ -133,7 +134,7 @@ export default function ModernLayout(props) {
     tuneTo(spot);
     const path = findDXPathForSpot(dxClusterData.paths || [], spot);
     if (path && path.dxLat != null && path.dxLon != null) {
-      handleDXChange({ lat: path.dxLat, lon: path.dxLon });
+      handleDXChange({ lat: path.dxLat, lon: path.dxLon, callsign: spot.call ?? spot.dxCall ?? null });
     }
   };
 
@@ -261,6 +262,19 @@ export default function ModernLayout(props) {
               flex: '1 1 auto',
             }}
           />
+          {dxCallsign && (
+            <span
+              style={{
+                fontFamily: 'JetBrains Mono',
+                fontSize: '14px',
+                color: 'var(--accent-green)',
+                opacity: 0.85,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {dxCallsign}
+            </span>
+          )}
           <DXFavorites dxLocation={dxLocation} dxGrid={dxGrid} onDXChange={handleDXChange} dxLocked={dxLocked} />
           <button
             type="button"

--- a/src/layouts/ModernLayout.jsx
+++ b/src/layouts/ModernLayout.jsx
@@ -129,7 +129,12 @@ export default function ModernLayout(props) {
   const isMobile = breakpoint === 'mobile';
   const isTablet = breakpoint === 'tablet';
 
-  const handleParkSpotClick = (spot) => tuneTo(spot);
+  const handleParkSpotClick = (spot) => {
+    tuneTo(spot);
+    if (spot.lat != null && spot.lon != null) {
+      handleDXChange({ lat: spot.lat, lon: spot.lon, callsign: spot.call ?? null });
+    }
+  };
   const handleDXSpotClick = (spot) => {
     tuneTo(spot);
     const path = findDXPathForSpot(dxClusterData.paths || [], spot);

--- a/src/layouts/ModernLayout.jsx
+++ b/src/layouts/ModernLayout.jsx
@@ -267,8 +267,8 @@ export default function ModernLayout(props) {
               style={{
                 fontFamily: 'JetBrains Mono',
                 fontSize: '14px',
-                color: 'var(--accent-green)',
-                opacity: 0.85,
+                fontWeight: '900',
+                color: 'var(--accent-amber)',
                 whiteSpace: 'nowrap',
               }}
             >


### PR DESCRIPTION
## Show DX spot callsign in the DX panel

Requested by https://github.com/accius/openhamclock/issues/899

### Summary

- When any spot is clicked, the activator/DX callsign is now captured alongside the coordinates and displayed to the right of the grid locator in the DX panel.
- Clicking a POTA, SOTA, WWFF, or WWBOTA spot also moves the DX marker — previously these spot types only tuned the radio.
- The callsign is styled to match the header callsign: `var(--accent-amber)`, `font-weight: 900`, same font size as the locator (`22px`).
- Typing a grid square manually clears the callsign display.
- Callsign is persisted to `localStorage` and survives page reloads.
- All three layouts are covered: **ModernLayout**, **ClassicLayout**, and **DockableApp**.

### Changes

| File | What changed |
|---|---|
| `src/hooks/app/useDXLocation.js` | Added `dxCallsign` state with localStorage persistence; extended `handleDXChange` to accept optional `callsign` field — set on spot click, cleared on manual grid entry |
| `src/App.jsx` | Destructures `dxCallsign` from hook and passes it through `layoutProps` |
| `src/layouts/ModernLayout.jsx` | `handleDXSpotClick` passes callsign; `handleParkSpotClick` now calls `handleDXChange` with lat/lon/callsign; callsign `<span>` rendered after `DXGridInput` |
| `src/layouts/ClassicLayout.jsx` | Same — all three inline spot click handlers updated; callsign span added in the bottom bar |
| `src/DockableApp.jsx` | Destructures `dxCallsign`; unified `handleSpotClick` passes callsign for both direct and path-resolved coordinates; callsign span added in `renderDXLocation` |

### Behaviour

| Action | DX marker moves | Callsign shown |
|---|---|---|
| Click DX cluster spot | ✓ (via path lookup) | ✓ |
| Click POTA spot | ✓ | ✓ |
| Click SOTA spot | ✓ (if coordinates resolved) | ✓ |
| Click WWFF spot | ✓ | ✓ |
| Click WWBOTA spot | ✓ | ✓ |
| Type grid manually | ✓ | cleared |
| Click map directly | ✓ | cleared |

### Test plan

- [ ] Click a DX cluster spot — verify DX marker moves and callsign appears next to the locator
- [ ] Click a POTA spot — verify same
- [ ] Click a SOTA spot with resolved coordinates — verify same
- [ ] Type a grid square manually — verify callsign clears
- [ ] Reload page — verify callsign persists from localStorage
- [ ] Verify callsign styling matches header callsign (amber, bold, same size as locator)
- [ ] Verify all three layouts work: ModernLayout, ClassicLayout, DockableApp

### Checks

- [x] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<!-- Before/after screenshots or a quick screen recording help reviewers a lot -->
Before:
<img width="378" height="241" alt="Bildschirmfoto 2026-04-12 um 21 41 17" src="https://github.com/user-attachments/assets/4ca6f1af-65be-4949-9112-b56e48851ce1" />
After:
<img width="366" height="246" alt="Bildschirmfoto 2026-04-12 um 21 42 25" src="https://github.com/user-attachments/assets/5733b5ad-59e2-44fe-9225-4a5fe0676185" />
Dockable layout:
<img width="898" height="940" alt="image" src="https://github.com/user-attachments/assets/0ce4774c-4539-488a-ad91-4ae3d98466e1" />

