### PR TITLE
fix: reject invalid server timezone (e.g. Etc/Unknown) before it reac…

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -26,6 +26,10 @@ LOCATOR=FN20
 TZ=America/New_York
 ```
 
+> **`TZ` is optional** — if omitted, each visitor's browser timezone is used for
+> the local-time display. Setting it is still recommended so that server-side
+> timestamps (logs, cache TTLs, etc.) match your local time.
+
 Restart to apply:
 
 ```bash

--- a/server/routes/config-routes.js
+++ b/server/routes/config-routes.js
@@ -180,9 +180,13 @@ module.exports = function (app, ctx) {
         const tz = process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone || '';
         if (!tz) return '';
         try {
-          Intl.DateTimeFormat('en-US', { timeZone: tz });
+          new Intl.DateTimeFormat(undefined, { timeZone: tz });
           return tz;
         } catch (e) {
+          console.warn(
+            '[config] Invalid resolved timezone "%s" — falling back to empty (client will use browser TZ). Set TZ env var to silence.',
+            tz,
+          );
           return '';
         }
       })(),

--- a/server/routes/config-routes.js
+++ b/server/routes/config-routes.js
@@ -173,8 +173,19 @@ module.exports = function (app, ctx) {
       // Whether config is incomplete (show setup wizard)
       configIncomplete: CONFIG.callsign === 'N0CALL' || !CONFIG.gridSquare,
 
-      // Server timezone (from TZ env var or system)
-      timezone: process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone || '',
+      // Server timezone (from TZ env var or system), validated.
+      // On minimal Linux containers without TZ set, Intl can return "Etc/Unknown"
+      // which browsers reject with RangeError. Validate before sending.
+      timezone: (() => {
+        const tz = process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone || '';
+        if (!tz) return '';
+        try {
+          Intl.DateTimeFormat('en-US', { timeZone: tz });
+          return tz;
+        } catch (e) {
+          return '';
+        }
+      })(),
 
       // Feature availability
       features: {

--- a/src/hooks/app/useTimeState.js
+++ b/src/hooks/app/useTimeState.js
@@ -61,18 +61,24 @@ export default function useTimeState(configLocation, dxLocation, timezone) {
 
   const utcTime = currentTime.toISOString().substr(11, 8);
   const utcDate = currentTime.toISOString().substr(0, 10);
+  // Validate the timezone once per changed value, not on every render.
+  // new Intl.DateTimeFormat throws a RangeError for invalid values such as
+  // "Etc/Unknown" (returned by Node on minimal Linux containers with no TZ set).
+  const safeTimezone = useMemo(() => {
+    if (!timezone) return '';
+    try {
+      new Intl.DateTimeFormat(undefined, { timeZone: timezone });
+      return timezone;
+    } catch {
+      return '';
+    }
+  }, [timezone]);
+
   const localTimeOpts = { hour12: use12Hour };
   const localDateOpts = { weekday: 'short', month: 'short', day: 'numeric' };
-  if (timezone) {
-    try {
-      // Validate before use — an invalid timezone (e.g. "Etc/Unknown" from a
-      // misconfigured Docker container) would throw a RangeError here.
-      Intl.DateTimeFormat('en-US', { timeZone: timezone });
-      localTimeOpts.timeZone = timezone;
-      localDateOpts.timeZone = timezone;
-    } catch (e) {
-      // Fall back to browser timezone
-    }
+  if (safeTimezone) {
+    localTimeOpts.timeZone = safeTimezone;
+    localDateOpts.timeZone = safeTimezone;
   }
   const localTime = currentTime.toLocaleTimeString('en-US', localTimeOpts);
   const localDate = currentTime.toLocaleDateString('en-US', localDateOpts);

--- a/src/hooks/app/useTimeState.js
+++ b/src/hooks/app/useTimeState.js
@@ -64,8 +64,15 @@ export default function useTimeState(configLocation, dxLocation, timezone) {
   const localTimeOpts = { hour12: use12Hour };
   const localDateOpts = { weekday: 'short', month: 'short', day: 'numeric' };
   if (timezone) {
-    localTimeOpts.timeZone = timezone;
-    localDateOpts.timeZone = timezone;
+    try {
+      // Validate before use — an invalid timezone (e.g. "Etc/Unknown" from a
+      // misconfigured Docker container) would throw a RangeError here.
+      Intl.DateTimeFormat('en-US', { timeZone: timezone });
+      localTimeOpts.timeZone = timezone;
+      localDateOpts.timeZone = timezone;
+    } catch (e) {
+      // Fall back to browser timezone
+    }
   }
   const localTime = currentTime.toLocaleTimeString('en-US', localTimeOpts);
   const localDate = currentTime.toLocaleDateString('en-US', localDateOpts);


### PR DESCRIPTION
## What does this PR do?

## Summary

- On minimal Linux Docker containers without a `TZ` environment variable set, Node's `Intl.DateTimeFormat().resolvedOptions().timeZone` returns `"Etc/Unknown"`. This string is accepted by Node but rejected by browsers with `RangeError: invalid time zone: Etc/Unknown`, crashing the entire dashboard.
- **Server fix** (`server/routes/config-routes.js`): validate the resolved timezone with `Intl.DateTimeFormat` in a try/catch before sending it to the client. Any invalid value (including `"Etc/Unknown"`) is replaced with `''`, which tells the client to fall back to the browser's own timezone.
- **Client fix** (`src/hooks/app/useTimeState.js`): apply the same validation guard before passing the timezone to `toLocaleTimeString`/`toLocaleDateString`, so a bad value can never crash the dashboard even if it somehow slips through in the future.

## Reproduction

1. Deploy via Docker/Portainer **without** a `TZ` environment variable set
2. Open the app — dashboard fails immediately with `RangeError: invalid time zone: Etc/Unknown`

## Workaround for existing deployments

Add `TZ=Europe/Berlin` (or your local IANA timezone) to the Portainer stack environment variables. This fix makes that optional rather than required.

## Test plan

- [ ] Deploy via Docker without `TZ` set — dashboard loads, local time shows browser timezone
- [ ] Deploy via Docker with `TZ=America/New_York` — local time reflects that timezone correctly
- [ ] Open Settings → Timezone, manually select a timezone — still works as before
- [ ] Verify no regression on bare-metal / non-Docker deployments


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## Checklist

- [x] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

