### PR TITLE
Pass dxSpots and clusterFilters values to `PropagationPanel`

### DIFF
--- a/src/DockableApp.jsx
+++ b/src/DockableApp.jsx
@@ -817,7 +817,6 @@ export const DockableApp = ({
 
         case 'band-health':
           content = <BandHealthPanel dxSpots={dxClusterData.spots} clusterFilters={dxFilters} />;
-
           break;
 
         case 'dx-cluster':

--- a/src/DockableApp.jsx
+++ b/src/DockableApp.jsx
@@ -770,6 +770,8 @@ export const DockableApp = ({
               bandConditions={bandConditions}
               allUnits={config.allUnits}
               propConfig={config.propagation}
+              dxSpots={dxClusterData.spots}
+              clusterFilters={dxFilters}
             />
           );
           break;
@@ -815,6 +817,7 @@ export const DockableApp = ({
 
         case 'band-health':
           content = <BandHealthPanel dxSpots={dxClusterData.spots} clusterFilters={dxFilters} />;
+
           break;
 
         case 'dx-cluster':


### PR DESCRIPTION
## What does this PR do?

Passes `dxSpots` and `clusterFilters` values to `PropagationPanel` in `Dockable`. Without this, the display of `BandHealthpanel` inside `PropagationPanel` uses an empty array for the Dx Cluster spots.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Go to Band Health in PropagationPanel using Dockable
2. Note that we now have spots being recognised

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [X] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [X] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

Before
<img width="395" height="405" alt="Image" src="https://github.com/user-attachments/assets/874bd84d-c87e-478f-873e-a2eb5d7aa12d" />

After
<img width="352" height="364" alt="Screenshot 2026-04-19 at 3 21 19 pm" src="https://github.com/user-attachments/assets/9a2af10a-ca56-4a72-8d47-c858a32580d1" />
