### PR TITLE
Client side logging cleanup

### DIFF
--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -1704,7 +1704,7 @@ export const WorldMap = ({
 
       // Initialize state ONLY on first mount (when empty)
       if (Object.keys(pluginLayerStates).length === 0) {
-        console.log('Loading saved layer states:', initialStates);
+        console.debug('Loading saved layer states:', initialStates);
         setPluginLayerStates(initialStates);
       }
 

--- a/src/hooks/app/useAppConfig.js
+++ b/src/hooks/app/useAppConfig.js
@@ -65,9 +65,9 @@ export default function useAppConfig() {
     setConfig(newConfig);
     saveConfig(newConfig);
     applyTheme(newConfig.theme || 'dark');
-    console.log('[Config] Saved to localStorage:', newConfig.callsign);
+    console.debug('[Config] Saved to localStorage:', newConfig.callsign);
     if (newConfig.lowMemoryMode) {
-      console.log('[Config] Low Memory Mode ENABLED - reduced spot limits, disabled animations');
+      console.info('[Config] Low Memory Mode ENABLED - reduced spot limits, disabled animations');
     }
     // Sync all settings to server (debounced)
     syncAllSettingsToServer();

--- a/src/hooks/app/useScreenWakeLock.js
+++ b/src/hooks/app/useScreenWakeLock.js
@@ -58,14 +58,14 @@ export default function useScreenWakeLock(config, displaySleeping = false) {
       }
       wakeLockRef.current = await navigator.wakeLock.request('screen');
       setWakeLockStatus({ active: true, reason: null });
-      console.log('[WakeLock] Screen wake lock acquired.');
+      console.debug('[WakeLock] Screen wake lock acquired.');
 
       wakeLockRef.current.addEventListener('release', () => {
         // Only update status if we didn't release intentionally (ref cleared on intentional release)
         if (wakeLockRef.current) {
           setWakeLockStatus({ active: false, reason: 'error' });
         }
-        console.log('[WakeLock] Screen wake lock released.');
+        console.debug('[WakeLock] Screen wake lock released.');
       });
     } catch (e) {
       console.warn('[WakeLock] Could not acquire screen wake lock:', e.message);

--- a/src/hooks/app/useVersionCheck.js
+++ b/src/hooks/app/useVersionCheck.js
@@ -30,7 +30,7 @@ export default function useVersionCheck() {
         }
 
         if (version !== knownVersion.current) {
-          console.log(`[VersionCheck] Update detected: ${knownVersion.current} → ${version}`);
+          console.info(`[VersionCheck] Update detected: ${knownVersion.current} → ${version}`);
           showUpdateToast(knownVersion.current, version);
           // Wait a moment so the user can see the toast, then reload
           setTimeout(() => {

--- a/src/hooks/usePOTASpots.js
+++ b/src/hooks/usePOTASpots.js
@@ -47,7 +47,7 @@ export const usePOTASpots = () => {
         const res = await apiFetch('/api/pota/spots', { cache: 'no-store' });
         if (res?.ok) {
           const spots = await res.json();
-          console.log(`[POTA] Fetched ${Array.isArray(spots) ? spots.length : 0} spots`);
+          console.info(`[POTA] Fetched ${Array.isArray(spots) ? spots.length : 0} spots`);
 
           // Log newest spot time for staleness debugging
           let newestTime = null;
@@ -58,7 +58,6 @@ export const usePOTASpots = () => {
               .sort()
               .reverse();
             newestTime = times[0] || null;
-            if (newestTime) console.log(`[POTA] Newest spot: ${newestTime}`);
           }
 
           // Only mark as "updated" when data content actually changes

--- a/src/hooks/usePSKReporter.js
+++ b/src/hooks/usePSKReporter.js
@@ -127,7 +127,7 @@ export const usePSKReporter = (callsign, options = {}) => {
     setSource('connecting');
 
     const modeLabel = filterMode === 'grid' ? `grid ${upperIdentifier}` : upperIdentifier;
-    console.log(`[PSKReporter SSE] Connecting for ${modeLabel}...`);
+    console.info(`[PSKReporter SSE] Connecting for ${modeLabel}...`);
 
     const typeParam = filterMode === 'grid' ? '?type=grid' : '';
     const url = `/api/pskreporter/stream/${encodeURIComponent(upperIdentifier)}${typeParam}`;
@@ -139,7 +139,7 @@ export const usePSKReporter = (callsign, options = {}) => {
       if (!mountedRef.current) return;
       try {
         const data = JSON.parse(e.data);
-        console.log(
+        console.info(
           `[PSKReporter SSE] Connected! MQTT ${data.mqttConnected ? 'up' : 'pending'}, ${data.recentSpots?.length || 0} recent spots`,
         );
         setConnected(true);
@@ -172,7 +172,7 @@ export const usePSKReporter = (callsign, options = {}) => {
     es.onerror = () => {
       if (!mountedRef.current) return;
       if (es.readyState === EventSource.CLOSED) {
-        console.log('[PSKReporter SSE] Connection closed');
+        console.debug('[PSKReporter SSE] Connection closed');
         setConnected(false);
         setSource('disconnected');
         setError('Stream closed');
@@ -184,7 +184,7 @@ export const usePSKReporter = (callsign, options = {}) => {
     return () => {
       mountedRef.current = false;
       if (es) {
-        console.log('[PSKReporter SSE] Cleaning up...');
+        console.debug('[PSKReporter SSE] Cleaning up...');
         es.close();
       }
     };
@@ -221,7 +221,7 @@ export const usePSKReporter = (callsign, options = {}) => {
 
   // Manual refresh
   const refresh = useCallback(() => {
-    console.log('[PSKReporter] Manual refresh requested');
+    console.debug('[PSKReporter] Manual refresh requested');
 
     if (eventSourceRef.current) {
       eventSourceRef.current.close();
@@ -240,7 +240,7 @@ export const usePSKReporter = (callsign, options = {}) => {
     if (!enabled) return;
     const es = eventSourceRef.current;
     if (!es || es.readyState === EventSource.CLOSED) {
-      console.log('[PSKReporter] Tab visible — reconnecting SSE');
+      console.debug('[PSKReporter] Tab visible — reconnecting SSE');
       refresh();
     }
   }, 5000);

--- a/src/hooks/usePropagation.js
+++ b/src/hooks/usePropagation.js
@@ -21,7 +21,6 @@ export const usePropagation = (deLocation, dxLocation, propagationConfig = {}) =
   const mode = propagationConfig.mode || 'SSB';
   const power = propagationConfig.power || 100;
   const antenna = propagationConfig.antenna || 'isotropic';
-  const [loggedFailure, setLoggedFailure] = useState(false);
 
   useEffect(() => {
     if (!deLocation || !dxLocation) return;
@@ -45,7 +44,7 @@ export const usePropagation = (deLocation, dxLocation, propagationConfig = {}) =
         const response = await fetch(`/api/propagation?${params}`);
         if (response.ok) rest = await response.json();
       } catch (err) {
-        console.error('Propagation error:', err);
+        console.error('[usePropagation] Propagation error:', err);
       }
 
       if (!alive) return;
@@ -66,7 +65,6 @@ export const usePropagation = (deLocation, dxLocation, propagationConfig = {}) =
           ssn: rest?.solarData?.ssn ?? 100,
           signal: wasmAbort.signal,
         });
-        setLoggedFailure(false);
         if (!alive) return;
         // Preserve REST-derived fields the WASM engine doesn't own (solar data,
         // path distance, LUF) so downstream panels don't lose them on swap.
@@ -93,12 +91,8 @@ export const usePropagation = (deLocation, dxLocation, propagationConfig = {}) =
       } catch (err) {
         // Expected when /wasm/p533.mjs is missing (self-hoster) or the 10 MB
         // coefficient download fails — keep the REST data we already rendered.
-        //
-        // loggedFailure ensures we only log this message once, or on a failure
-        //  after a success.
-        if (!wasmAbort.signal.aborted && !loggedFailure) {
+        if (!wasmAbort.signal.aborted) {
           console.debug('[usePropagation] WASM engine skipped:', err.message);
-          setLoggedFailure(true);
         }
       }
     };

--- a/src/hooks/usePropagation.js
+++ b/src/hooks/usePropagation.js
@@ -21,6 +21,7 @@ export const usePropagation = (deLocation, dxLocation, propagationConfig = {}) =
   const mode = propagationConfig.mode || 'SSB';
   const power = propagationConfig.power || 100;
   const antenna = propagationConfig.antenna || 'isotropic';
+  const [loggedFailure, setLoggedFailure] = useState(false);
 
   useEffect(() => {
     if (!deLocation || !dxLocation) return;
@@ -65,6 +66,7 @@ export const usePropagation = (deLocation, dxLocation, propagationConfig = {}) =
           ssn: rest?.solarData?.ssn ?? 100,
           signal: wasmAbort.signal,
         });
+        setLoggedFailure(false);
         if (!alive) return;
         // Preserve REST-derived fields the WASM engine doesn't own (solar data,
         // path distance, LUF) so downstream panels don't lose them on swap.
@@ -91,8 +93,12 @@ export const usePropagation = (deLocation, dxLocation, propagationConfig = {}) =
       } catch (err) {
         // Expected when /wasm/p533.mjs is missing (self-hoster) or the 10 MB
         // coefficient download fails — keep the REST data we already rendered.
-        if (!wasmAbort.signal.aborted) {
+        //
+        // loggedFailure ensures we only log this message once, or on a failure
+        //  after a success.
+        if (!wasmAbort.signal.aborted && !loggedFailure) {
           console.debug('[usePropagation] WASM engine skipped:', err.message);
+          setLoggedFailure(true);
         }
       }
     };

--- a/src/hooks/useSOTASpots.js
+++ b/src/hooks/useSOTASpots.js
@@ -23,7 +23,7 @@ export const useSOTASpots = () => {
         const res = await apiFetch('/api/sota/spots', { cache: 'no-store' });
         if (res?.ok) {
           const spots = await res.json();
-          console.log(`[SOTA] Fetched ${Array.isArray(spots) ? spots.length : 0} spots`);
+          console.info(`[SOTA] Fetched ${Array.isArray(spots) ? spots.length : 0} spots`);
 
           // Only mark as "updated" when data content actually changes
           let newestTime = null;

--- a/src/hooks/useWWBOTASpots.js
+++ b/src/hooks/useWWBOTASpots.js
@@ -43,13 +43,13 @@ export const useWWBOTASpots = () => {
         const url = new URL('https://api.wwbota.org/spots/');
         url.searchParams.set('age', '1'); // Last 1 hour
 
-        console.log(`[WWBOTA] Attempting to connect to: ${url.toString()}`);
+        console.debug(`[WWBOTA] Attempting to connect to: ${url.toString()}`);
 
         const es = new EventSource(url.toString());
 
         // Connection opened successfully
         es.addEventListener('open', () => {
-          console.log('[WWBOTA] SSE connection opened successfully');
+          console.debug('[WWBOTA] SSE connection opened successfully');
           if (isMounted) {
             setLoading(false);
             setConnected(true);
@@ -171,7 +171,7 @@ export const useWWBOTASpots = () => {
 
             // Update lastUpdated when new spot arrives
             setLastUpdated(Date.now());
-            console.log('[WWBOTA] Spot processed and data updated');
+            console.debug('[WWBOTA] Spot processed and data updated');
           } catch (err) {
             console.error('[WWBOTA] Failed to parse spot:', err, 'Raw event data:', event.data);
           }
@@ -186,13 +186,13 @@ export const useWWBOTASpots = () => {
           }
 
           if (es.readyState === EventSource.CLOSED) {
-            console.log('[WWBOTA] SSE connection closed, will reconnect in 5 seconds');
+            console.debug('[WWBOTA] SSE connection closed, will reconnect in 5 seconds');
             es.close();
             if (isMounted) {
               // Reconnect after 5 seconds
               reconnectTimeoutRef.current = setTimeout(() => {
                 if (isMounted) {
-                  console.log('[WWBOTA] Attempting to reconnect...');
+                  console.debug('[WWBOTA] Attempting to reconnect...');
                   connectWWBOTA();
                 }
               }, 5000);
@@ -211,7 +211,7 @@ export const useWWBOTASpots = () => {
         if (isMounted) {
           reconnectTimeoutRef.current = setTimeout(() => {
             if (isMounted) {
-              console.log('[WWBOTA] Retrying connection after error...');
+              console.debug('[WWBOTA] Retrying connection after error...');
               connectWWBOTA();
             }
           }, 5000);

--- a/src/hooks/useWWFFSpots.js
+++ b/src/hooks/useWWFFSpots.js
@@ -24,7 +24,7 @@ export const useWWFFSpots = () => {
         const res = await apiFetch('/api/wwff/spots', { cache: 'no-store' });
         if (res?.ok) {
           const spots = await res.json();
-          console.log(`[WWFF] Fetched ${Array.isArray(spots) ? spots.length : 0} spots`);
+          console.info(`[WWFF] Fetched ${Array.isArray(spots) ? spots.length : 0} spots`);
 
           // Only mark as "updated" when data content actually changes
           let newestTime = null;

--- a/src/hooks/useWeather.js
+++ b/src/hooks/useWeather.js
@@ -232,9 +232,9 @@ export const useWeather = (location, allUnits = { dist: 'imperial', temp: 'imper
         const lat = normalizeLat(location.lat);
         const lon = normalizeLon(location.lon);
 
-        console.log(`[Weather] Fetching for ${lat.toFixed(4)}, ${lon.toFixed(4)}`);
+        console.info(`[Weather] Fetching for ${lat.toFixed(4)}, ${lon.toFixed(4)}`);
         const data = await fetchOpenMeteoDirect(lat, lon);
-        console.log(
+        console.info(
           `[Weather] Result: ${data?.current?.temperature_2m}°C (${Math.round((data?.current?.temperature_2m * 9) / 5 + 32)}°F) from ${data?._source || 'unknown'}`,
         );
         setRawData(data);

--- a/src/plugins/layerRegistry.js
+++ b/src/plugins/layerRegistry.js
@@ -40,7 +40,7 @@ const localPlugins = Object.entries(localPluginModules)
   .filter(Boolean);
 
 if (localPlugins.length > 0) {
-  console.log(
+  console.info(
     `[Plugins] Loaded ${localPlugins.length} local plugin(s):`,
     localPlugins.map((p) => p.metadata.id).join(', '),
   );

--- a/src/plugins/layers/useEarthquakes.js
+++ b/src/plugins/layers/useEarthquakes.js
@@ -45,7 +45,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
           //'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_hour.geojson'
         );
         const data = await response.json();
-        console.log('[Earthquakes] fetched:', data.features?.length || 0, 'quakes');
+        console.info('[Earthquakes] fetched:', data.features?.length || 0, 'quakes');
         // Limit earthquakes in low memory mode
         const quakes = (data.features || []).slice(0, MAX_QUAKES);
         setEarthquakeData(quakes);

--- a/src/plugins/layers/useEarthquakes.js
+++ b/src/plugins/layers/useEarthquakes.js
@@ -45,12 +45,12 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
           //'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_hour.geojson'
         );
         const data = await response.json();
-        console.log('Earthquakes fetched:', data.features?.length || 0, 'quakes');
+        console.log('[Earthquakes] fetched:', data.features?.length || 0, 'quakes');
         // Limit earthquakes in low memory mode
         const quakes = (data.features || []).slice(0, MAX_QUAKES);
         setEarthquakeData(quakes);
       } catch (err) {
-        console.error('Earthquake data fetch error:', err);
+        console.error('[Earthquakes] data fetch error:', err);
       }
     };
 
@@ -75,7 +75,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
     setMarkersRef([]);
 
     if (!enabled || earthquakeData.length === 0) {
-      console.log('[Earthquakes] enabled=', enabled, 'data count=', earthquakeData.length);
+      console.info('[Earthquakes] enabled=', enabled, 'data count=', earthquakeData.length);
       return;
     }
 
@@ -98,7 +98,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
       const quakeId = quake.id;
 
       // Debug logging with detailed info
-      console.log(`🌋 Earthquake ${quakeId}:`, {
+      console.debug(`[Earthquakes] 🌋 ${quakeId}:`, {
         place: props.place,
         mag: mag,
         geojson: `[lon=${coords[0]}, lat=${coords[1]}, depth=${coords[2]}]`,
@@ -164,14 +164,16 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
         popupAnchor: [0, 0], // Popup appears at the marker position (icon center)
       });
 
-      console.log(`📍 Creating marker for ${quakeId}: M${mag.toFixed(1)} at [lat=${lat}, lon=${lon}] - ${props.place}`);
+      console.debug(
+        `[Earthquakes]📍 Creating marker for ${quakeId}: M${mag.toFixed(1)} at [lat=${lat}, lon=${lon}] - ${props.place}`,
+      );
 
       // Use standard Leaflet [latitude, longitude] format
       // The popup was appearing in the correct location, confirming marker position is correct
       // The icon was appearing offset due to CSS position: relative issue (now fixed)
       const markerCoords = [lat, lon]; // CORRECT: [latitude, longitude]
 
-      console.log(`   → Creating L.marker([${markerCoords[0]}, ${markerCoords[1]}]) = [lat, lon]`);
+      console.debug(`[Earthquakes]   → Creating L.marker([${markerCoords[0]}, ${markerCoords[1]}]) = [lat, lon]`);
 
       const circle = L.marker(markerCoords, {
         icon,
@@ -202,7 +204,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
               }
             }
           } catch (e) {
-            console.warn('Could not animate earthquake marker:', e);
+            console.warn('[Earthquakes] Could not animate earthquake marker:', e);
           }
         }, 10);
 
@@ -264,7 +266,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
       isFirstLoad.current = false;
     }
 
-    console.log('Earthquakes: Created', newMarkers.length, 'markers on map');
+    console.debug('[Earthquakes] Created', newMarkers.length, 'markers on map');
     setMarkersRef(newMarkers);
 
     return () => {

--- a/src/plugins/layers/useEarthquakes.js
+++ b/src/plugins/layers/useEarthquakes.js
@@ -75,7 +75,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
     setMarkersRef([]);
 
     if (!enabled || earthquakeData.length === 0) {
-      console.log('Earthquakes: enabled=', enabled, 'data count=', earthquakeData.length);
+      console.log('[Earthquakes] enabled=', enabled, 'data count=', earthquakeData.length);
       return;
     }
 

--- a/src/plugins/layers/useLightning.js
+++ b/src/plugins/layers/useLightning.js
@@ -96,7 +96,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
   // Fetch WebSocket key from Blitzortung (fallback to 111)
   useEffect(() => {
     if (enabled && !wsKey) {
-      console.log('[Lightning] Using WebSocket key 111 (Blitzortung standard)');
+      console.info('[Lightning] Using WebSocket key 111 (Blitzortung standard)');
       setWsKey(111); // Standard Blitzortung key
     }
   }, [enabled, wsKey]);
@@ -117,13 +117,13 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
     const connectWebSocket = () => {
       try {
         const serverUrl = servers[currentServerIndexRef.current];
-        console.log(`[Lightning] Connecting to ${serverUrl} (attempt ${connectionAttemptsRef.current + 1})...`);
+        console.debug(`[Lightning] Connecting to ${serverUrl} (attempt ${connectionAttemptsRef.current + 1})...`);
 
         const ws = new WebSocket(serverUrl);
         wsRef.current = ws;
 
         ws.onopen = () => {
-          console.log(`[Lightning] Connected to ${serverUrl}, sending key:`, wsKey);
+          console.debug(`[Lightning] Connected to ${serverUrl}, sending key:`, wsKey);
           ws.send(JSON.stringify({ a: wsKey }));
           connectionAttemptsRef.current = 0; // Reset attempts on success
         };
@@ -176,7 +176,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
 
           // Try next server if this one fails
           if (connectionAttemptsRef.current >= 3) {
-            console.log(`[Lightning] Failed to connect after 3 attempts, trying next server...`);
+            console.debug(`[Lightning] Failed to connect after 3 attempts, trying next server...`);
             currentServerIndexRef.current = (currentServerIndexRef.current + 1) % servers.length;
             connectionAttemptsRef.current = 0;
           }
@@ -184,7 +184,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
 
         ws.onclose = () => {
           const serverUrl = servers[currentServerIndexRef.current];
-          console.log(`[Lightning] WebSocket closed for ${serverUrl}`);
+          console.debug(`[Lightning] WebSocket closed for ${serverUrl}`);
           wsRef.current = null;
 
           // Increment connection attempts
@@ -192,14 +192,14 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
 
           // Try next server if too many failed attempts on current server
           if (connectionAttemptsRef.current >= 3) {
-            console.log(`[Lightning] Too many failures on ${serverUrl}, rotating to next server...`);
+            console.debug(`[Lightning] Too many failures on ${serverUrl}, rotating to next server...`);
             currentServerIndexRef.current = (currentServerIndexRef.current + 1) % servers.length;
             connectionAttemptsRef.current = 0;
           }
 
           // Reconnect after 5 seconds if still enabled
           if (enabled) {
-            console.log(`[Lightning] Reconnecting to ${servers[currentServerIndexRef.current]} in 5s...`);
+            console.debug(`[Lightning] Reconnecting to ${servers[currentServerIndexRef.current]} in 5s...`);
             setTimeout(connectWebSocket, 5000);
           }
         };
@@ -209,7 +209,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
 
         // Try next server on connection error
         if (connectionAttemptsRef.current >= 3) {
-          console.log(`[Lightning] Too many connection errors, trying next server...`);
+          console.debug(`[Lightning] Too many connection errors, trying next server...`);
           currentServerIndexRef.current = (currentServerIndexRef.current + 1) % servers.length;
           connectionAttemptsRef.current = 0;
         }
@@ -225,7 +225,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
 
     return () => {
       if (wsRef.current) {
-        console.log('[Lightning] Closing WebSocket connection');
+        console.debug('[Lightning] Closing WebSocket connection');
         wsRef.current.close();
         wsRef.current = null;
       }
@@ -503,7 +503,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
           contentClassName: 'lightning-panel-content',
           buttonClassName: 'lightning-minimize-btn',
         });
-        console.log('[Lightning] Stats panel is now draggable with minimize toggle');
+        console.debug('[Lightning] Stats panel is now draggable with minimize toggle');
       } else {
         console.error('[Lightning] Could not find .lightning-stats container');
       }
@@ -784,7 +784,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
           contentClassName: 'lightning-panel-content',
           buttonClassName: 'lightning-minimize-btn',
         });
-        console.log('[Lightning] Proximity: Panel is now draggable and minimizable');
+        console.ldebugog('[Lightning] Proximity: Panel is now draggable and minimizable');
 
         // IMPORTANT: Set ref AFTER setup is complete
         proximityControlRef.current = control;

--- a/src/plugins/layers/useLightning.js
+++ b/src/plugins/layers/useLightning.js
@@ -437,24 +437,24 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
   // Create stats panel control
   useEffect(() => {
     if (!map || typeof L === 'undefined') {
-      console.log('[Lightning] Cannot create stats panel - map or Leaflet not available');
+      console.debug('[Lightning] Cannot create stats panel - map or Leaflet not available');
       return;
     }
     if (!enabled) {
-      console.log('[Lightning] Stats panel not created - plugin not enabled');
+      console.debug('[Lightning] Stats panel not created - plugin not enabled');
       return;
     }
     if (statsControl) {
-      console.log('[Lightning] Stats panel already created');
+      console.debug('[Lightning] Stats panel already created');
       return; // Already created
     }
 
-    console.log('[Lightning] Creating stats panel control...');
+    console.info('[Lightning] Creating stats panel control...');
 
     const StatsControl = L.Control.extend({
       options: { position: 'topright' },
       onAdd: function () {
-        console.log('[Lightning] StatsControl onAdd called');
+        console.debug('[Lightning] StatsControl onAdd called');
         const panelWrapper = L.DomUtil.create('div', 'panel-wrapper');
         const div = L.DomUtil.create('div', 'lightning-stats', panelWrapper);
 
@@ -467,21 +467,21 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
         L.DomEvent.disableClickPropagation(div);
         L.DomEvent.disableScrollPropagation(div);
 
-        console.log('[Lightning] Stats panel div created');
+        console.debug('[Lightning] Stats panel div created');
         return panelWrapper;
       },
     });
 
     const control = new StatsControl();
     map.addControl(control);
-    console.log('[Lightning] Stats control added to map');
+    console.debug('[Lightning] Stats control added to map');
     setStatsControl(control);
 
     // Make draggable and add minimize toggle after a short delay
     setTimeout(() => {
       const container = document.querySelector('.lightning-stats');
       if (container) {
-        console.log('[Lightning] Found stats panel container, making draggable...');
+        console.debug('[Lightning] Found stats panel container, making draggable...');
         // Apply saved position IMMEDIATELY before making draggable
         const saved = localStorage.getItem('lightning-stats-position');
         if (saved) {
@@ -492,7 +492,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
             container.style.left = left + 'px';
             container.style.right = 'auto';
             container.style.bottom = 'auto';
-            console.log('[Lightning] Applied saved position:', { top, left });
+            console.debug('[Lightning] Applied saved position:', { top, left });
           } catch (e) {
             console.error('[Lightning] Error applying saved position:', e);
           }
@@ -512,7 +512,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
     return () => {
       if (control && map) {
         try {
-          console.log('[Lightning] Removing stats control from map');
+          console.debug('[Lightning] Removing stats control from map');
           map.removeControl(control);
         } catch (e) {
           console.warn('[Lightning] Error removing stats control:', e);
@@ -544,7 +544,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
     const positiveStrikes = lightningData.filter((s) => s.polarity === 'positive').length;
     const negativeStrikes = total - positiveStrikes;
 
-    console.log('[Lightning] Stats panel updated:', { fresh, recent, total });
+    console.debug('[Lightning] Stats panel updated:', { fresh, recent, total });
 
     const contentHTML = `
       <table style="width: 100%; font-size: 11px;">
@@ -633,7 +633,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
 
   // Create proximity panel control (within radius of PROXIMITY_RADIUS_KM)
   useEffect(() => {
-    console.log(
+    console.debug(
       '[Lightning] Proximity effect triggered - enabled:',
       enabled,
       'map:',
@@ -643,19 +643,19 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
     );
 
     if (!map || typeof L === 'undefined') {
-      console.log('[Lightning] Proximity: No map or Leaflet');
+      console.debug('[Lightning] Proximity: No map or Leaflet');
       return;
     }
     if (!enabled) {
-      console.log('[Lightning] Proximity: Not enabled');
+      console.debug('[Lightning] Proximity: Not enabled');
       return;
     }
     if (proximityControlRef.current) {
-      console.log('[Lightning] Proximity: Already exists, skipping');
+      console.debug('[Lightning] Proximity: Already exists, skipping');
       return; // Already created
     }
 
-    console.log('[Lightning] Proximity: Getting station config from localStorage...');
+    console.debug('[Lightning] Proximity: Getting station config from localStorage...');
 
     // Get config from localStorage directly (more reliable than window.hamclockConfig)
     let config;
@@ -663,11 +663,11 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
       const stored = localStorage.getItem('openhamclock_config');
       if (stored) {
         config = JSON.parse(stored);
-        console.log('[Lightning] Proximity: Config loaded from localStorage');
+        console.info('[Lightning] Proximity: Config loaded from localStorage');
       } else {
-        console.log('[Lightning] Proximity: No config in localStorage, setting retry timer');
+        console.debug('[Lightning] Proximity: No config in localStorage, setting retry timer');
         const retryTimer = setTimeout(() => {
-          console.log('[Lightning] Proximity: Retry timer fired, triggering re-render');
+          console.debug('[Lightning] Proximity: Retry timer fired, triggering re-render');
           setLightningData((prev) => [...prev]); // Trigger re-render
         }, 2000);
         return () => clearTimeout(retryTimer);
@@ -680,14 +680,14 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
     const stationLat = config.location?.lat ?? config.latitude;
     const stationLon = config.location?.lon ?? config.longitude;
 
-    console.log('[Lightning] Proximity: Station location:', { stationLat, stationLon });
+    console.debug('[Lightning] Proximity: Station location:', { stationLat, stationLon });
 
     if (!Number.isFinite(stationLat) || !Number.isFinite(stationLon)) {
-      console.log('[Lightning] Proximity: No station location - aborting');
+      console.warn('[Lightning] Proximity: No station location - aborting');
       return;
     }
 
-    console.log('[Lightning] Proximity: ALL CHECKS PASSED - Creating panel now!');
+    console.debug('[Lightning] Proximity: ALL CHECKS PASSED - Creating panel now!');
 
     const ProximityControl = L.Control.extend({
       options: { position: 'bottomright' },
@@ -708,22 +708,22 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
     });
 
     const control = new ProximityControl();
-    console.log('[Lightning] Proximity: ProximityControl instance created');
+    console.debug('[Lightning] Proximity: ProximityControl instance created');
     map.addControl(control);
-    console.log('[Lightning] Proximity: Control added to map');
+    console.debug('[Lightning] Proximity: Control added to map');
 
     // Make draggable and add minimize toggle - retry until found
     let retries = 0;
     const maxRetries = 20; // Try for up to 2 seconds
     const retryInterval = setInterval(() => {
       retries++;
-      console.log(
+      console.debug(
         `[Lightning] Proximity: Looking for .lightning-proximity container... (attempt ${retries}/${maxRetries})`,
       );
       const container = document.querySelector('.lightning-proximity');
       if (container) {
         clearInterval(retryInterval);
-        console.log('[Lightning] Proximity: Container found! Making draggable...');
+        console.debug('[Lightning] Proximity: Container found! Making draggable...');
 
         // Default to CENTER of screen (not corner!)
         container.style.position = 'fixed';
@@ -733,7 +733,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
         container.style.bottom = 'auto';
         container.style.zIndex = '1001'; // Ensure it's on top
 
-        console.log('[Lightning] Proximity: Panel positioned at center of screen');
+        console.debug('[Lightning] Proximity: Panel positioned at center of screen');
 
         // Try to load saved position (but validate it's on-screen)
         const saved = localStorage.getItem('lightning-proximity-position');
@@ -749,7 +749,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
               container.style.left = data.leftPercent + '%';
               container.style.transform = 'none';
               positionLoaded = true;
-              console.log('[Lightning] Proximity: Applied saved position (percentage):', {
+              console.debug('[Lightning] Proximity: Applied saved position (percentage):', {
                 topPercent: data.topPercent,
                 leftPercent: data.leftPercent,
               });
@@ -767,9 +767,9 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
                 container.style.left = leftPercent + '%';
                 container.style.transform = 'none';
                 positionLoaded = true;
-                console.log('[Lightning] Proximity: Converted pixel to percentage:', { topPercent, leftPercent });
+                console.debug('[Lightning] Proximity: Converted pixel to percentage:', { topPercent, leftPercent });
               } else {
-                console.log('[Lightning] Proximity: Saved pixel position off-screen, using default');
+                console.debug('[Lightning] Proximity: Saved pixel position off-screen, using default');
                 localStorage.removeItem('lightning-proximity-position');
               }
             }
@@ -788,7 +788,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
 
         // IMPORTANT: Set ref AFTER setup is complete
         proximityControlRef.current = control;
-        console.log('[Lightning] Proximity: Ref updated with control');
+        console.debug('[Lightning] Proximity: Ref updated with control');
       } else if (retries >= maxRetries) {
         clearInterval(retryInterval);
         console.error('[Lightning] Proximity: Container NOT FOUND after 20 retries!');

--- a/src/plugins/layers/useRBN.js
+++ b/src/plugins/layers/useRBN.js
@@ -254,9 +254,9 @@ export function useLayer({
 
     if (!queryCallsign || queryCallsign === 'N0CALL') {
       if (queryMode === 'spotter') {
-        console.log('[RBN] Spotter mode: enter a skimmer callsign');
+        console.debug('[RBN] Spotter mode: enter a skimmer callsign');
       } else {
-        console.log('[RBN] No valid callsign configured');
+        console.debug('[RBN] No valid callsign configured');
       }
       return;
     }
@@ -277,17 +277,17 @@ export function useLayer({
       if (data && data.spots && Array.isArray(data.spots)) {
         const mySpots = data.spots;
 
-        console.log(`[RBN] Received ${mySpots.length} spots for ${callsign}`);
+        console.info(`[RBN] Received ${mySpots.length} spots for ${callsign}`);
 
         // Log spot details
         if (mySpots.length > 0) {
           mySpots.forEach((spot, idx) => {
             if (queryMode === 'spotter') {
-              console.log(
+              console.debug(
                 `  ${idx + 1}. DX: ${spot.dx}, Skimmer: ${spot.callsign}, Freq: ${spot.freqMHz} MHz, SNR: ${spot.snr} dB, Band: ${spot.band}, dxLat: ${spot.dxLat ?? 'MISSING'}, dxLon: ${spot.dxLon ?? 'MISSING'}, dxGrid: ${spot.dxGrid ?? 'MISSING'}`,
               );
             } else {
-              console.log(
+              console.debug(
                 `  ${idx + 1}. Skimmer: ${spot.callsign}, Freq: ${spot.freqMHz} MHz, SNR: ${spot.snr} dB, Band: ${spot.band}, Grid: ${spot.grid ?? 'MISSING'}, Lat: ${spot.skimmerLat ?? '?'}, Lon: ${spot.skimmerLon ?? '?'}`,
               );
             }
@@ -424,7 +424,7 @@ export function useLayer({
       return true;
     });
 
-    console.log(
+    console.debug(
       `[RBN] Rendering ${filteredSpots.length} spots (within ${timeWindow < 1 ? (timeWindow * 60).toFixed(0) + 's' : timeWindow.toFixed(1) + 'min'} window)`,
     );
 

--- a/src/plugins/layers/useWSPR.js
+++ b/src/plugins/layers/useWSPR.js
@@ -256,14 +256,14 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
     const fetchWSPR = async () => {
       try {
         const timestamp = new Date().toLocaleTimeString();
-        console.log(`[WSPR] Fetching data at ${timestamp}...`);
+        console.debug(`[WSPR] Fetching data at ${timestamp}...`);
         const response = await fetch(`/api/wspr/heatmap?minutes=${timeWindow}&band=${bandFilter}`);
         if (response.ok) {
           const data = await response.json();
 
           // Handle new aggregated format
           if (data.format === 'aggregated' && data.grids) {
-            console.log(
+            console.info(
               `[WSPR Plugin] Loaded aggregated data: ${data.uniqueGrids} grids, ${data.paths?.length || 0} paths from ${data.totalSpots} spots`,
             );
 
@@ -338,7 +338,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
           // Filter by callsign ONLY if grid filter is OFF
           if (!filterByGrid && callsign && callsign !== 'N0CALL') {
             const baseCall = stripCallsign(callsign);
-            console.log(`[WSPR] Filtering for callsign: ${baseCall} (grid filter OFF)`);
+            console.debug(`[WSPR] Filtering for callsign: ${baseCall} (grid filter OFF)`);
 
             spots = spots.filter((spot) => {
               // Show spots where I'm TX or RX
@@ -347,9 +347,9 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
               return isTX || isRX;
             });
 
-            console.log(`[WSPR] Found ${spots.length} spots for ${baseCall} (TX or RX)`);
+            console.debug(`[WSPR] Found ${spots.length} spots for ${baseCall} (TX or RX)`);
           } else if (filterByGrid) {
-            console.log(`[WSPR] Grid filter ON - fetching ALL spots (${spots.length} total)`);
+            console.debug(`[WSPR] Grid filter ON - fetching ALL spots (${spots.length} total)`);
           }
 
           // Convert grid squares to lat/lon if coordinates are missing
@@ -378,7 +378,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
           });
 
           setWsprData(spots);
-          console.log(`[WSPR Plugin] Loaded ${spots.length} raw spots (${timeWindow}min, band: ${bandFilter})`);
+          console.info(`[WSPR Plugin] Loaded ${spots.length} raw spots (${timeWindow}min, band: ${bandFilter})`);
         }
       } catch (err) {
         console.error('WSPR data fetch error:', err);
@@ -563,20 +563,20 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
       if (animCheck) animCheck.addEventListener('change', (e) => setShowAnimation(e.target.checked));
       if (heatCheck)
         heatCheck.addEventListener('change', (e) => {
-          console.log('[WSPR] Heatmap toggle:', e.target.checked);
+          console.debug('[WSPR] Heatmap toggle:', e.target.checked);
           setShowHeatmap(e.target.checked);
         });
       if (gridFilterCheck)
         gridFilterCheck.addEventListener('change', (e) => {
           setFilterByGrid(e.target.checked);
-          console.log('[WSPR] Grid filter toggle:', e.target.checked);
+          console.debug('[WSPR] Grid filter toggle:', e.target.checked);
         });
       if (gridInput) {
         gridInput.addEventListener('input', (e) => {
           const value = e.target.value.toUpperCase().substring(0, 6);
           e.target.value = value;
           setGridFilter(value);
-          console.log('[WSPR] Grid filter value:', value);
+          console.debug('[WSPR] Grid filter value:', value);
         });
       }
     }, 100);
@@ -738,7 +738,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
       }
     }, 150);
 
-    console.log('[WSPR] All controls created once');
+    console.debug('[WSPR] All controls created once');
   }, [enabled, map]);
 
   // Render WSPR paths and markers
@@ -811,7 +811,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
       return true;
     });
 
-    console.log(
+    console.debug(
       `[WSPR Paths] Filtering: filterByGrid=${filterByGrid}, gridFilter="${gridFilter}", callsign="${callsign}", input=${wsprData.length}, output=${filteredData.length}`,
     );
 
@@ -827,7 +827,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
         if (spot.senderGrid) grids.add(spot.senderGrid.substring(0, 4));
         if (spot.receiverGrid) grids.add(spot.receiverGrid.substring(0, 4));
       });
-      console.log(
+      console.debug(
         `[WSPR Grid] Filtering for ${gridFilter}, found ${filteredData.length} spots with grids:`,
         Array.from(grids).join(', '),
       );
@@ -838,7 +838,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
         if (spot.senderGrid) availableGrids.add(spot.senderGrid.substring(0, 4));
         if (spot.receiverGrid) availableGrids.add(spot.receiverGrid.substring(0, 4));
       });
-      console.log(
+      console.debug(
         `[WSPR Grid] No matches for ${gridFilter}. Available grids in data:`,
         Array.from(availableGrids).join(', '),
       );
@@ -1166,7 +1166,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
       }
     }, 50);
 
-    console.log(
+    console.debug(
       `[WSPR Plugin] Rendered ${newPaths.length} paths, ${newMarkers.length} markers, ${bestPaths.length} best DX`,
     );
 
@@ -1209,7 +1209,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
 
     if (!enabled || !showHeatmap || wsprData.length === 0) return;
 
-    console.log('[WSPR] Rendering heatmap with', wsprData.length, 'spots');
+    console.debug('[WSPR] Rendering heatmap with', wsprData.length, 'spots');
 
     // Create heatmap circles for all TX and RX stations
     const heatPoints = [];
@@ -1260,7 +1260,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
       return true;
     });
 
-    console.log(
+    console.debug(
       `[WSPR Heatmap] Filtering: filterByGrid=${filterByGrid}, gridFilter="${gridFilter}", input=${wsprData.length}, output=${filteredData.length}`,
     );
 
@@ -1290,7 +1290,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
           });
         }
       });
-      console.log(`[WSPR Heatmap] Using aggregated data: ${heatPoints.length} grid squares`);
+      console.debug(`[WSPR Heatmap] Using aggregated data: ${heatPoints.length} grid squares`);
     } else {
       // Legacy: count activity from individual spots
       filteredData.forEach((spot) => {
@@ -1401,7 +1401,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
     const heatGroup = L.layerGroup(heatCircles);
     setHeatmapLayer(heatGroup);
 
-    console.log(`[WSPR] Heatmap rendered with ${Object.keys(uniquePoints).length} hot spots`);
+    console.debug(`[WSPR] Heatmap rendered with ${Object.keys(uniquePoints).length} hot spots`);
 
     return () => {
       heatCircles.forEach((circle) => {
@@ -1434,13 +1434,13 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
         return; // Nothing to clean up
       }
 
-      console.log('[WSPR] Plugin disabled - cleaning up all controls and layers');
+      console.debug('[WSPR] Plugin disabled - cleaning up all controls and layers');
 
       // Remove filter control
       if (filterControlRef.current) {
         try {
           map.removeControl(filterControlRef.current);
-          console.log('[WSPR] Removed filter control');
+          console.debug('[WSPR] Removed filter control');
         } catch (e) {
           console.error('[WSPR] Error removing filter control:', e);
         }
@@ -1452,7 +1452,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
       if (legendControlRef.current) {
         try {
           map.removeControl(legendControlRef.current);
-          console.log('[WSPR] Removed legend control');
+          console.debug('[WSPR] Removed legend control');
         } catch (e) {
           console.error('[WSPR] Error removing legend control:', e);
         }
@@ -1464,7 +1464,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
       if (statsControlRef.current) {
         try {
           map.removeControl(statsControlRef.current);
-          console.log('[WSPR] Removed stats control');
+          console.debug('[WSPR] Removed stats control');
         } catch (e) {
           console.error('[WSPR] Error removing stats control:', e);
         }
@@ -1476,7 +1476,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
       if (chartControlRef.current) {
         try {
           map.removeControl(chartControlRef.current);
-          console.log('[WSPR] Removed chart control');
+          console.debug('[WSPR] Removed chart control');
         } catch (e) {
           console.error('[WSPR] Error removing chart control:', e);
         }
@@ -1488,7 +1488,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
       if (heatmapLayer) {
         try {
           map.removeLayer(heatmapLayer);
-          console.log('[WSPR] Removed heatmap layer');
+          console.debug('[WSPR] Removed heatmap layer');
         } catch (e) {
           console.error('[WSPR] Error removing heatmap layer:', e);
         }

--- a/src/server/ctydat.js
+++ b/src/server/ctydat.js
@@ -201,7 +201,7 @@ async function fetchAndParse() {
     const exactCount = Object.keys(parsed.exact).length;
     const entityCount = parsed.entities.length;
 
-    console.log(`[CTY] Loaded ${entityCount} entities, ${prefixCount} prefixes, ${exactCount} exact calls`);
+    console.info(`[CTY] Loaded ${entityCount} entities, ${prefixCount} prefixes, ${exactCount} exact calls`);
 
     ctyCache = parsed;
     return true;

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -85,7 +85,7 @@ export const fetchServerConfig = async () => {
       serverConfig = await response.json();
       // Only log if server has real config (not defaults)
       if (serverConfig.callsign && serverConfig.callsign !== 'N0CALL') {
-        console.log('[Config] Server config:', serverConfig.callsign, '@', serverConfig.locator);
+        console.info('[Config] Server config:', serverConfig.callsign, '@', serverConfig.locator);
       }
       return serverConfig;
     }
@@ -142,7 +142,7 @@ export const loadConfig = () => {
     const saved = localStorage.getItem('openhamclock_config');
     if (saved) {
       localConfig = JSON.parse(saved);
-      console.log('[Config] Loaded from localStorage:', localConfig.callsign);
+      console.debug('[Config] Loaded from localStorage:', localConfig.callsign);
     }
   } catch (e) {
     console.error('Error loading config from localStorage:', e);
@@ -179,7 +179,7 @@ export const loadConfig = () => {
 export const saveConfig = (config) => {
   try {
     localStorage.setItem('openhamclock_config', JSON.stringify(config));
-    console.log('[Config] Saved to localStorage');
+    console.debug('[Config] Saved to localStorage');
     // Notify plugins of config change (storage events don't fire in the same tab)
     window.dispatchEvent(new CustomEvent('openhamclock-config-change', { detail: config }));
   } catch (e) {
@@ -249,7 +249,7 @@ export const fetchServerSettings = async () => {
     }
 
     if (applied > 0) {
-      console.log(`[Config] Synced ${applied} settings from server`);
+      console.debug(`[Config] Synced ${applied} settings from server`);
     }
     return applied > 0;
   } catch (e) {
@@ -293,7 +293,7 @@ export const syncAllSettingsToServer = () => {
 
       if (response.ok) {
         const result = await response.json();
-        console.log(`[Config] Synced ${result.keys} settings to server`);
+        console.debug(`[Config] Synced ${result.keys} settings to server`);
       }
     } catch (e) {
       // Silent fail — server sync is best-effort

--- a/src/utils/ctyLookup.js
+++ b/src/utils/ctyLookup.js
@@ -40,7 +40,7 @@ export async function initCtyLookup() {
       exact = data.exact;
       entities = Array.isArray(data.entities) ? data.entities : [];
       loaded = true;
-      console.log(`[CTY] Loaded: ${Object.keys(prefixes).length} prefixes, ${Object.keys(exact).length} exact calls`);
+      console.info(`[CTY] Loaded: ${Object.keys(prefixes).length} prefixes, ${Object.keys(exact).length} exact calls`);
       window.dispatchEvent(new CustomEvent('openhamclock-cty-loaded'));
     }
   } catch (err) {


### PR DESCRIPTION
## What does this PR do?

Tidies up some client side logging. Moving a lot of messaging out of `console.log()` into levels such as `console.warn()`, `console.info()` and `console.debug()`.

Removed an unnecessary debug from `usePOTA`.

Made the messaging in `useEarthquake` and `usePropagation`  use similar formatting to everything else.


## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [X] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

Load the web site with varying degrees of log level.

## Checklist

- [ ] App loads without console errors
It was kind of the point that we see console messages from this change
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

