### PR TITLE
[util] geo.js extends maidenhead grid support

### DIFF
--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -99,7 +99,7 @@ export const maidenheadToBoundingBox = (grid) => {
  * @param precision Precision (character length) of the grid locator returned, can be 2, 4, 6, or 8. (default if not specified is 6)
  * @returns Maidenhead grid locator
  */
-export const LatLonToMaidenhead = ({ lat, lon }, precision = 6) => {
+export const latLonToMaidenhead = ({ lat, lon }, precision = 6) => {
   if (lat < -90 || lat > 90) throw new Error('invalid latitude, it should be between -90 and 90');
   if (lon < -180 || lon > 180) throw new Error('invalid longitude, it should be between -180 and 180');
 
@@ -149,10 +149,10 @@ export const parseGridSquare = (grid) => {
 
 /**
  * Calculate Maidenhead grid square (size 6) from coordinates.
- * Deprecated, use LatLonToMaidenhead({lat, lon}) which defaults to size 6.
+ * Deprecated, use latLonToMaidenhead({lat, lon}) which defaults to size 6.
  */
 export const calculateGridSquare = (lat, lon) => {
-  return LatLonToMaidenhead({ lat, lon }, 6);
+  return latLonToMaidenhead({ lat, lon }, 6);
 };
 
 /**
@@ -553,7 +553,7 @@ export const classifyTwilight = (solarElevationDeg) => {
 export default {
   validateGridLocator,
   maidenheadToLatLon,
-  LatLonToMaidenhead,
+  latLonToMaidenhead,
   maidenheadToBoundingBox,
   parseGridSquare,
   calculateGridSquare,

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -142,16 +142,16 @@ export const LatLonToMaidenhead = ({ lat, lon }, precision = 6) => {
  * Parse a Maidenhead grid square string into lat/lon coordinates.
  * Supports 4-character (e.g. "JN58") and 6-character (e.g. "JN58sm") locators.
  * Returns { lat, lon } of the grid square center, or null if input is invalid.
+ * Deprecated, use maidenheadToLatLon(grid)
  */
-// Function provided for legacy support.
 export const parseGridSquare = (grid) => {
   return maidenheadToLatLon(grid);
 };
 
 /**
- * Calculate Maidenhead grid square (size 6) from coordinates
+ * Calculate Maidenhead grid square (size 6) from coordinates.
+ * Deprecated, use LatLonToMaidenhead({lat, lon}) which defaults to size 6.
  */
-// Function provided for legacy support.
 export const calculateGridSquare = (lat, lon) => {
   return LatLonToMaidenhead({ lat, lon }, 6);
 };

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -93,11 +93,10 @@ export const maidenheadToBoundingBox = (grid) => {
   ];
 };
 
-// Convert lat/lon to Maidenhead grid at given precision
 /**
- * Convert latitude/longitude coordinates to Maidenhead grid locator at specified precision (2, 4, or 6 characters)
- * @param {lat, lon} Latitude and longitude coordinates
- * @param precision Precision of the grid locator, can be 2, 4, or 6 characters long (default is 6)
+ * Convert latitude/longitude coordinates to Maidenhead grid locator of specified precision (character length)
+ * @param Latitude and longitude coordinates
+ * @param precision Precision (character length) of the grid locator returned, can be 2, 4, 6, or 8. (default if not specified is 6)
  * @returns Maidenhead grid locator
  */
 export const LatLonToMaidenhead = ({ lat, lon }, precision = 6) => {

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -4,55 +4,156 @@
  */
 
 /**
- * Parse a Maidenhead grid square string into lat/lon coordinates.
- * Supports 4-character (e.g. "JN58") and 6-character (e.g. "JN58sm") locators.
- * Returns { lat, lon } of the grid square center, or null if input is invalid.
+ * Validate Maidenhead grid locator, can be 2, 4, 6, or 8 characters long, e.g. DM, DM12, DM12kv, or DM12kv99 are all valid locators.
+ * @param gridLocator Maidenhead grid locator
+ * @returns true if the grid locator is valid, else false
  */
-export const parseGridSquare = (grid) => {
-  const g = grid.toUpperCase();
-  // Must be exactly 4 (field + square) or 6 (+ subsquare) characters
-  if (g.length !== 4 && g.length !== 6) return null;
+export const validateGridLocator = (gridLocator) => {
+  if (!gridLocator || typeof gridLocator !== 'string') return false;
+  if (gridLocator.length < 2 || gridLocator.length > 8) return false;
+  if (gridLocator.length % 2 !== 0) return false;
+  const regex = /^[A-R]{2}([0-9]{2}([A-Xa-x]{2}([0-9]{2})?)?)?$/;
+  return regex.test(gridLocator);
+};
 
-  // Field letters: A–R (18 fields, covering 360° lon / 180° lat)
-  const f0 = g.charCodeAt(0) - 65;
-  const f1 = g.charCodeAt(1) - 65;
-  if (f0 < 0 || f0 > 17 || f1 < 0 || f1 > 17) return null;
-
-  const lon1 = f0 * 20 - 180;
-  const lat1 = f1 * 10 - 90;
-
-  const lon2 = parseInt(g[2]) * 2;
-  const lat2 = parseInt(g[3]);
-  if (isNaN(lon2) || isNaN(lat2)) return null;
-
-  let lon = lon1 + lon2 + 1;
-  let lat = lat1 + lat2 + 0.5;
-
-  if (g.length === 6) {
-    // Subsquare letters: A–X (24 divisions per axis)
-    const s0 = g.charCodeAt(4) - 65;
-    const s1 = g.charCodeAt(5) - 65;
-    if (s0 < 0 || s0 > 23 || s1 < 0 || s1 > 23) return null;
-    lon = lon1 + lon2 + s0 * (2 / 24) + 1 / 24;
-    lat = lat1 + lat2 + s1 * (1 / 24) + 1 / 48;
-  }
-
+/**
+ * Convert Maidenhead grid locator to latitude/longitude coordinates
+ * @param grid Maidenhead grid locator
+ * @returns Latitude and longitude coordinates
+ */
+export const maidenheadToLatLon = (grid) => {
+  const bbox = maidenheadToBoundingBox(grid);
+  if (!bbox || bbox.length !== 2 || bbox[0].length !== 2 || bbox[1].length !== 2) return null;
+  const lat = (bbox[0][0] + bbox[1][0]) / 2;
+  const lon = (bbox[0][1] + bbox[1][1]) / 2;
   return { lat, lon };
 };
 
 /**
- * Calculate Maidenhead grid square from coordinates
+ * Convert Maidenhead grid square to lat/lon bounding box coordinates, [SW, NE] corners
+ * @param grid Maidenhead grid locator
+ * @returns A two-dimensional array containing two diagonal coordinates of bounds
  */
-export const calculateGridSquare = (lat, lon) => {
-  const lonNorm = lon + 180;
+export const maidenheadToBoundingBox = (grid) => {
+  if (!grid || !validateGridLocator(grid)) return null;
+
+  const gridUpper = grid.toUpperCase();
+  let minLat = -90;
+  let maxLat = 90;
+  let minLon = -180;
+  let maxLon = 180;
+
+  // Field (2 chars): 20° lon x 10° lat
+  if (gridUpper.length >= 2) {
+    const fieldLat = gridUpper.charCodeAt(1) - 65; // A-R
+    const fieldLon = gridUpper.charCodeAt(0) - 65; // A-R
+
+    minLat += fieldLat * 10;
+    maxLat = minLat + 10;
+    minLon += fieldLon * 20;
+    maxLon = minLon + 20;
+  }
+
+  // Square (2 digits): 2° lon x 1° lat
+  if (gridUpper.length >= 4) {
+    const sqLon = parseInt(gridUpper[2]);
+    const sqLat = parseInt(gridUpper[3]);
+
+    minLon += sqLon * 2;
+    maxLon = minLon + 2;
+    minLat += sqLat * 1;
+    maxLat = minLat + 1;
+  }
+
+  // Subsquare (2 chars): 5' lon x 2.5' lat
+  if (gridUpper.length >= 6) {
+    const subLat = gridUpper.charCodeAt(5) - 65; // A thru X
+    const subLon = gridUpper.charCodeAt(4) - 65; // A thru X
+
+    minLat += (subLat * 2.5) / 60;
+    maxLat = minLat + 2.5 / 60;
+    minLon += (subLon * 5) / 60;
+    maxLon = minLon + 5 / 60;
+  }
+
+  // Extended square (2 digits): 0.5' lon x 0.25' lat
+  if (gridUpper.length >= 8) {
+    const subLat = parseInt(gridUpper[7]);
+    const subLon = parseInt(gridUpper[6]);
+
+    minLat += (subLat * 0.25) / 60;
+    maxLat = minLat + 0.25 / 60;
+    minLon += (subLon * 0.5) / 60;
+    maxLon = minLon + 0.5 / 60;
+  }
+
+  return [
+    [minLat, minLon],
+    [maxLat, maxLon],
+  ];
+};
+
+// Convert lat/lon to Maidenhead grid at given precision
+/**
+ * Convert latitude/longitude coordinates to Maidenhead grid locator at specified precision (2, 4, or 6 characters)
+ * @param {lat, lon} Latitude and longitude coordinates
+ * @param precision Precision of the grid locator, can be 2, 4, or 6 characters long (default is 6)
+ * @returns Maidenhead grid locator
+ */
+export const LatLonToMaidenhead = ({ lat, lon }, precision = 6) => {
+  if (lat < -90 || lat > 90) throw new Error('invalid latitude, it should be between -90 and 90');
+  if (lon < -180 || lon > 180) throw new Error('invalid longitude, it should be between -180 and 180');
+
   const latNorm = lat + 90;
-  const field1 = String.fromCharCode(65 + Math.floor(lonNorm / 20));
-  const field2 = String.fromCharCode(65 + Math.floor(latNorm / 10));
-  const square1 = Math.floor((lonNorm % 20) / 2);
-  const square2 = Math.floor(latNorm % 10);
-  const subsq1 = String.fromCharCode(97 + Math.floor((lonNorm % 2) * 12));
-  const subsq2 = String.fromCharCode(97 + Math.floor((latNorm % 1) * 24));
-  return `${field1}${field2}${square1}${square2}${subsq1}${subsq2}`;
+  const lonNorm = lon + 180;
+
+  // Field (2 chars): 20° lon x 10° lat
+  const field1 = String.fromCharCode(65 + Math.floor(lonNorm / 20)); // A-R
+  const field2 = String.fromCharCode(65 + Math.floor(latNorm / 10)); // A-R
+
+  if (precision === 2) {
+    return `${field1}${field2}`;
+  } else {
+    // Square (2 digits): 2° lon x 1° lat
+    const square1 = Math.floor((lonNorm % 20) / 2);
+    const square2 = Math.floor((latNorm % 10) / 1);
+
+    if (precision === 4) {
+      return `${field1}${field2}${square1}${square2}`;
+    } else {
+      // Subsquare (2 chars): 5' lon x 2.5' lat
+      const subsq1 = String.fromCharCode(97 + Math.floor(((lonNorm % 2) * 60) / 5)); // a-x
+      const subsq2 = String.fromCharCode(97 + Math.floor(((latNorm % 1) * 60) / 2.5)); // a-x
+
+      if (precision === 6) {
+        return `${field1}${field2}${square1}${square2}${subsq1}${subsq2}`;
+      } else if (precision === 8) {
+        // Extended square (2 digits): 0.5' lon x 0.25' lat
+        const extSq1 = Math.floor((((lonNorm % 2) * 60) % 5) / 0.5);
+        const extSq2 = Math.floor((((latNorm % 1) * 60) % 2.5) / 0.25);
+
+        return `${field1}${field2}${square1}${square2}${subsq1}${subsq2}${extSq1}${extSq2}`;
+      } else return null; // Invalid precision
+    }
+  }
+};
+
+/**
+ * Parse a Maidenhead grid square string into lat/lon coordinates.
+ * Supports 4-character (e.g. "JN58") and 6-character (e.g. "JN58sm") locators.
+ * Returns { lat, lon } of the grid square center, or null if input is invalid.
+ */
+// Function provided for legacy support.
+export const parseGridSquare = (grid) => {
+  return maidenheadToLatLon(grid);
+};
+
+/**
+ * Calculate Maidenhead grid square (size 6) from coordinates
+ */
+// Function provided for legacy support.
+export const calculateGridSquare = (lat, lon) => {
+  return LatLonToMaidenhead({ lat, lon }, 6);
 };
 
 /**
@@ -451,6 +552,10 @@ export const classifyTwilight = (solarElevationDeg) => {
 };
 
 export default {
+  validateGridLocator,
+  maidenheadToLatLon,
+  LatLonToMaidenhead,
+  maidenheadToBoundingBox,
   parseGridSquare,
   calculateGridSquare,
   calculateBearing,

--- a/src/utils/geo.test.js
+++ b/src/utils/geo.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseGridSquare, calculateGridSquare } from './geo.js';
-import { validateGridLocator, LatLonToMaidenhead, maidenheadToLatLon, maidenheadToBoundingBox } from './geo.js';
+import { validateGridLocator, latLonToMaidenhead, maidenheadToLatLon, maidenheadToBoundingBox } from './geo.js';
 
 describe('Maidenhead Grid tests', () => {
   const gridCases = [
@@ -52,13 +52,13 @@ describe('Maidenhead Grid tests', () => {
 
     for (const size of sizes) {
       it('should convert Lat/Lon to Maidenhead Grid of requested size ' + size, () => {
-        const result = LatLonToMaidenhead(actualLatLon, size);
+        const result = latLonToMaidenhead(actualLatLon, size);
         expect(result.toUpperCase()).toBe(grid.substring(0, size).toUpperCase());
       });
     }
 
     it('should convert Lat/Lon to Maidenhead Grid with default size 6 when no size is specified', () => {
-      const result = LatLonToMaidenhead(actualLatLon);
+      const result = latLonToMaidenhead(actualLatLon);
       expect(result.toUpperCase()).toBe(grid.substring(0, defaultSize).toUpperCase());
     });
 

--- a/src/utils/geo.test.js
+++ b/src/utils/geo.test.js
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { parseGridSquare, calculateGridSquare } from './geo.js';
+import { validateGridLocator, LatLonToMaidenhead, maidenheadToLatLon, maidenheadToBoundingBox } from './geo.js';
+
+describe('Maidenhead Grid tests', () => {
+  const gridCases = [
+    // location in San Diego, CA, USA
+    {
+      grid: 'DM12kv99',
+      actualLatLon: { lat: 32.91254, lon: -117.08409 },
+      latLonSWCornerGrid6: [32.875, -117.167],
+      latLonNECornerGrid6: [32.917, -117.083],
+    },
+
+    // location in Sydney, Australia
+    {
+      grid: 'QF56od55',
+      actualLatLon: { lat: -33.8519, lon: 151.210886 },
+      latLonSWCornerGrid6: [-33.875, 151.1667],
+      latLonNECornerGrid6: [-33.8333, 151.25],
+    },
+  ];
+
+  it('should invalidate empty grid locator', () => {
+    expect(validateGridLocator('')).toBe(false);
+  });
+
+  it('should invalidate grid locator with invalid length', () => {
+    expect(validateGridLocator('DM1')).toBe(false);
+  });
+
+  it('should invalidate grid locator with invalid characters', () => {
+    expect(validateGridLocator('DM12zz')).toBe(false);
+  });
+
+  for (const { grid, actualLatLon, latLonSWCornerGrid6, latLonNECornerGrid6 } of gridCases) {
+    it(
+      ('should validate test case grid locator has size 8',
+      () => {
+        expect(grid.length).toEqual(8);
+      }),
+    );
+
+    const defaultSize = 6;
+    const sizes = [2, 4, 6, 8];
+    for (const size of sizes) {
+      it("should validate grid locator '" + grid.substring(0, size) + "'", () => {
+        const subGrid = grid.substring(0, size);
+        expect(validateGridLocator(subGrid)).toBe(true);
+      });
+    }
+
+    for (const size of sizes) {
+      it('should convert Lat/Lon to Maidenhead Grid of requested size ' + size, () => {
+        const result = LatLonToMaidenhead(actualLatLon, size);
+        expect(result.toUpperCase()).toBe(grid.substring(0, size).toUpperCase());
+      });
+    }
+
+    it('should convert Lat/Lon to Maidenhead Grid with default size 6 when no size is specified', () => {
+      const result = LatLonToMaidenhead(actualLatLon);
+      expect(result.toUpperCase()).toBe(grid.substring(0, defaultSize).toUpperCase());
+    });
+
+    for (const size of sizes) {
+      it("should convert Maidenhead Grid '" + grid.substring(0, size) + "' to Lat/Lon", () => {
+        const { lat, lon } = maidenheadToLatLon(grid.substring(0, size));
+        const { lat: expectedLat, lon: expectedLon } = actualLatLon;
+        let latBucketSize, lonBucketSize, latBucketStart, latBucketEnd, lonBucketStart, lonBucketEnd;
+
+        switch (size) {
+          case 2:
+            latBucketSize = 10; // degrees
+            latBucketStart = Math.floor(expectedLat / latBucketSize) * latBucketSize;
+            latBucketEnd = latBucketStart + latBucketSize;
+
+            lonBucketSize = 20; // degrees
+            lonBucketStart = Math.floor(expectedLon / lonBucketSize) * lonBucketSize;
+            lonBucketEnd = lonBucketStart + lonBucketSize;
+            break;
+
+          case 4:
+            latBucketSize = 1; // degrees
+            latBucketStart = Math.floor(expectedLat / latBucketSize) * latBucketSize;
+            latBucketEnd = latBucketStart + latBucketSize;
+
+            lonBucketSize = 2; // degrees
+            lonBucketStart = Math.floor(expectedLon / lonBucketSize) * lonBucketSize;
+            lonBucketEnd = lonBucketStart + lonBucketSize;
+            break;
+
+          case 6:
+            latBucketSize = 2.5; // minutes
+            latBucketStart = (Math.floor((60 * expectedLat) / latBucketSize) * latBucketSize) / 60;
+            latBucketEnd = latBucketStart + latBucketSize / 60;
+
+            lonBucketSize = 5; // minutes
+            lonBucketStart = (Math.floor((60 * expectedLon) / lonBucketSize) * lonBucketSize) / 60;
+            lonBucketEnd = lonBucketStart + lonBucketSize / 60;
+            break;
+
+          case 8:
+            latBucketSize = 0.25; // minutes
+            latBucketStart = (Math.floor((10 * 60 * expectedLat) / latBucketSize) * latBucketSize) / 60 / 10;
+            latBucketEnd = latBucketStart + latBucketSize / 60;
+
+            lonBucketSize = 0.5; // minutes
+            lonBucketStart = (Math.floor((60 * expectedLon) / lonBucketSize) * lonBucketSize) / 60;
+            lonBucketEnd = lonBucketStart + lonBucketSize / 60;
+            break;
+
+          default:
+            throw new Error('invalid size');
+        }
+
+        expect(lat).toBeGreaterThanOrEqual(latBucketStart);
+        expect(lat).toBeLessThan(latBucketEnd);
+        expect(lon).toBeGreaterThanOrEqual(lonBucketStart);
+        expect(lon).toBeLessThan(lonBucketEnd);
+      });
+    }
+
+    it(
+      "should convert Maidenhead Grid '" + grid.substring(0, defaultSize) + "' to Lat/Lon bounding box coordinates",
+      () => {
+        const result = maidenheadToBoundingBox(grid.substring(0, defaultSize));
+        expect(result).toHaveLength(2);
+        expect(result[0]).toHaveLength(2);
+        expect(result[1]).toHaveLength(2);
+
+        expect(result[0][0]).toBeCloseTo(latLonSWCornerGrid6[0], 3);
+        expect(result[0][1]).toBeCloseTo(latLonSWCornerGrid6[1], 3);
+        expect(result[1][0]).toBeCloseTo(latLonNECornerGrid6[0], 3);
+        expect(result[1][1]).toBeCloseTo(latLonNECornerGrid6[1], 3);
+      },
+    );
+  }
+});
+
+describe('Maidenhead Grid tests - legacy functions', () => {
+  // legacy functions
+  // export const parseGridSquare = (grid) => { return { lat, lon }; }
+  // export const calculateGridSquare = (lat, lon) => { return string; }
+
+  const gridCases = [
+    {
+      grid2: 'DM',
+      grid4: 'DM12',
+      grid6: 'DM12kv',
+      actualLatLon: [32.91254, -117.08409],
+      latlonCenter: [32.896, -117.125],
+      latlonSWCorner: [32.875, -117.167],
+      latlonNECorner: [32.917, -117.083],
+    },
+  ];
+
+  for (const { grid2, grid4, grid6, actualLatLon, latlonCenter, latlonSWCorner, latlonNECorner } of gridCases) {
+    it('should convert Lat/Lon to Maidenhead precision 6', () => {
+      const result = calculateGridSquare(actualLatLon[0], actualLatLon[1]);
+      expect(result).toBe(grid6);
+    });
+
+    it('should convert Maidenhead to Lat/Lon', () => {
+      const { lat, lon } = parseGridSquare(grid6);
+      expect(lat).toBeCloseTo(actualLatLon[0], 1);
+      expect(lon).toBeCloseTo(actualLatLon[1], 1);
+    });
+  }
+});

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -20,7 +20,7 @@ export {
 // Geographic calculations
 export {
   validateGridLocator,
-  LatLonToMaidenhead,
+  latLonToMaidenhead,
   maidenheadToLatLon,
   maidenheadToBoundingBox,
   parseGridSquare,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -19,6 +19,11 @@ export {
 
 // Geographic calculations
 export {
+  validateGridLocator,
+  LatLonToMaidenhead,
+  maidenheadToLatLon,
+  maidenheadToBoundingBox,
+  parseGridSquare,
   calculateGridSquare,
   calculateBearing,
   calculateDistance,


### PR DESCRIPTION
## What does this PR do?

- Extends Maidenhead grid locator functionality in `src/utils/geo.js`
- Adds size 2, 4, (6), 8 Maidenhead grid locator support, e.g. DM / DM12 / DM12KV / DM12KV99
- Code is based on the library already imported into OHC, `@hamset/maidenhead-locator` [link](https://github.com/HoshinoSuzumi/lib-maidenhead-locator), however this library only supports size 6. 
- In making this change it was noted that duplicate versions exist and that they should probably all use the common `geo.js` code, see below.
- Adds `geo.test.js` with unit test for Maidenhead grid locator functionality.

Why? I was trying to create a map layer that revealed size two or size three grid squares and needed the bounding-box coordinates. No other code appears to **fully** support the Maidenhead standard.

### noted that,

- ### The following are functionally the same,
  - `parseGridSquare` from `geo.js`
  - `maidenheadToLatLon` from `@hamset/maidenhead-locator` (`package.json`)
  - coded function `maidenheadToLatLon` (exported) from `server\routes\callsign.js`

- components using `parseGridSquare` from `geo.js`
  - `src\components\DXFavorites.jsx` imported but not used
  - `src\components\DXGridInput.jsx`
  - `src\components\SettingsPanel.jsx`
  - `src\layouts\EmcommLayout.jsx`
  - `src\plugins\layers\useWinlinkGateways.js`

- components that define function `maidenheadToLatLon` and export it 
  - `server\routes\callsign.js`

- components that import `maidenheadToLatLon` but uncertain if it is coming from `server\routes\callsign.js` or `@hamset/maidenhead-locator`
  - `server\routes\dxcluster.js`
  - `server\routes\n1mm.js`
  - `server\routes\rbn.js`
  - `server\routes\wsjtx.js`

- components that import `maidenheadToLatLon` but don't use it
  - `server\routes\propagation.js`
  - `server\routes\pskreporter.js`

- components that use `maidenheadToLatLon` but it appears not imported? possibly code not functional?
  - `src\plugins\layers\useN3FJPLoggedQSOs.js`

- ### The following are functionally the same,
  - `calculateGridSquare` or `latLonToMaidenhead` from `./geo.js`
  - `WGS84ToMaidenhead` from `@hamset/maidenhead-locator`

- components using `WGS84ToMaidenhead` from `@hamset/maidenhead-locator`;
  - `src\hooks\usePOTASpots.js`
  - `src\hooks\useSOTASpots.js`
  - `src\hooks\useWWBOTASpots.js`
  - `src\hooks\useWWFFSpots.js`

- components using `calculateGridSquare` from `geo.js`
  - `src\components\AzimuthalMap.jsx`
  - `src\components\DXFavorites.jsx`
  - `src\components\LocationPanel.jsx`
  - `src\components\SettingsPanel.jsx`
  - `src\components\WorldMap.jsx`
  - `src\hooks\app\useTimeState.js`

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [X] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## Checklist

- [X] App loads without console errors
- [X] Tested in **Dark**, **Light**, and **Retro** themes
- [X] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [X] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [X] No `.bak`, `.old`, `console.log` debug lines, or test scripts included
