### PR TITLE
[fix] Validate that `imageUrl` parses as `https://*.nasa.gov` before fetching.

### DIFF
--- a/server/routes/space-weather.js
+++ b/server/routes/space-weather.js
@@ -473,8 +473,26 @@ module.exports = function (app, ctx) {
       timestamp: Date.now(),
     };
 
+    const isValidNasaImageUrl = (url) => {
+      if (!url) return false;
+
+      let parsed;
+      try {
+        parsed = new URL(url);
+      } catch {
+        return false; // not a valid URL at all
+      }
+
+      if (parsed.protocol !== 'https:') return false;
+      if (!parsed.hostname.endsWith('.nasa.gov')) return false;
+      return true;
+    };
+
     const imageUrl = meta?.image?.url;
     if (!imageUrl) throw new Error('No image URL in Dial-A-Moon response');
+    if (!isValidNasaImageUrl(imageUrl)) {
+      throw new Error('Rejected non‑NASA URL:', imageUrl);
+    }
 
     const imgResponse = await fetch(imageUrl);
     if (!imgResponse.ok) throw new Error(`Moon image fetch returned ${imgResponse.status}`);


### PR DESCRIPTION
fixes reported security/resource audit issue:

## 🟡 Medium — slower bleed, still worth fixing

  - **`fetchDialAMoon` follows upstream-supplied URL** — `server/routes/space-weather.js:476-482`. Validate that `imageUrl` parses as `https://*.nasa.gov` before fetching. 
                                                                                                                                                                                                                