### PR TITLE
[fix] add periodic purges to emcomm.js caches

### DIFF
--- a/server/routes/emcomm.js
+++ b/server/routes/emcomm.js
@@ -6,10 +6,48 @@
 module.exports = function (app, ctx) {
   const { fetch, logDebug, logErrorOnce } = ctx;
 
+  const maintainCache = (cache, ttlMs, maxEntries, label = 'Cache') => {
+    const now = Date.now();
+    let purged = 0;
+
+    // Remove stale entries
+    for (const key of Object.keys(cache)) {
+      if (now - cache[key].timestamp > ttlMs * 2) {
+        delete cache[key];
+        purged++;
+      }
+    }
+
+    // Enforce max size by evicting oldest
+    const remaining = Object.keys(cache);
+    if (remaining.length > maxEntries) {
+      remaining
+        .sort((a, b) => cache[a].timestamp - cache[b].timestamp)
+        .slice(0, remaining.length - maxEntries)
+        .forEach((key) => {
+          delete cache[key];
+          purged++;
+        });
+    }
+
+    if (purged > 0) {
+      logDebug(`[${label}] purged ${purged} stale entries, ${Object.keys(cache).length} remaining`);
+    }
+  };
+
   // --- NWS Alerts ---
   // Cache keyed on rounded lat/lon, 3 minute TTL
   const alertsCache = {};
   const ALERTS_CACHE_TTL = 3 * 60 * 1000;
+  const ALERTS_CACHE_MAX_ENTRIES = 200; // Hard cap on cache entries
+
+  // Periodic cleanup: purge expired cache entries every 10 minutes
+  setInterval(
+    () => {
+      maintainCache(alertsCache, ALERTS_CACHE_TTL, ALERTS_CACHE_MAX_ENTRIES, 'Alerts cache');
+    },
+    10 * 60 * 1000,
+  );
 
   app.get('/api/emcomm/alerts', async (req, res) => {
     try {
@@ -66,6 +104,15 @@ module.exports = function (app, ctx) {
   // --- FEMA Open Shelters ---
   const sheltersCache = {};
   const SHELTERS_CACHE_TTL = 10 * 60 * 1000;
+  const SHELTERS_MAX_ENTRIES = 200; // Hard cap on cache entries
+
+  // Periodic cleanup: purge expired cache entries every 10 minutes
+  setInterval(
+    () => {
+      maintainCache(sheltersCache, SHELTERS_CACHE_TTL, SHELTERS_MAX_ENTRIES, 'Shelters cache');
+    },
+    10 * 60 * 1000,
+  );
 
   app.get('/api/emcomm/shelters', async (req, res) => {
     try {
@@ -136,6 +183,15 @@ module.exports = function (app, ctx) {
   // --- FEMA Disaster Declarations ---
   const disastersCache = {};
   const DISASTERS_CACHE_TTL = 30 * 60 * 1000;
+  const DISASTERS_MAX_ENTRIES = 200; // Hard cap on cache entries
+
+  // Periodic cleanup: purge expired cache entries every 10 minutes
+  setInterval(
+    () => {
+      maintainCache(disastersCache, DISASTERS_CACHE_TTL, DISASTERS_MAX_ENTRIES, 'Disasters cache');
+    },
+    10 * 60 * 1000,
+  );
 
   app.get('/api/emcomm/disasters', async (req, res) => {
     try {


### PR DESCRIPTION
fixes reported security/resource audit issue:

  ## 🔴 Critical — pick this up first 

  **5. Unbounded EmComm caches keyed on user lat/lon** — `server/routes/emcomm.js:11, 67, 137`                                                                                                                                                                               
  `alertsCache`, `sheltersCache`, `disastersCache` are plain objects with no eviction. Keys are `lat,lon` rounded to 1–2 decimals → up to ~64k unique keys per endpoint, each holding multi-KB GeoJSON. **Fix:** convert to `Map` + LRU + TTL purge — copy the pattern from  `propagation.js:605` or `callsign.js:30`. 

## details,
- added periodic purge of `alertsCache`, `sheltersCache`, and `disastersCache` caches
- subtle difference between `propagation.js` and `emcomm.js` is use of `ts' vs. `timestamp` for the .timestamp key in the `.map`.
- not determined if the maximum sizes of the various caches is sufficient
- noted that the disasters uses a state identifier, the alerts and shelters use lat/lon
- basic testing of each of them was successful
                                                                                                                                                                                                                