### PR TITLE
fix(security): harden rig-bridge relay and status endpoints

### DIFF
--- a/rig-bridge/package.json
+++ b/rig-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhamclock-rig-bridge",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Universal rig control bridge for OpenHamClock — plugin architecture supporting USB, flrig, rigctld, and more",
   "main": "rig-bridge.js",
   "bin": "rig-bridge.js",

--- a/rig-bridge/package.json
+++ b/rig-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhamclock-rig-bridge",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Universal rig control bridge for OpenHamClock — plugin architecture supporting USB, flrig, rigctld, and more",
   "main": "rig-bridge.js",
   "bin": "rig-bridge.js",

--- a/rig-bridge/plugins/cloud-relay.js
+++ b/rig-bridge/plugins/cloud-relay.js
@@ -144,7 +144,7 @@ const descriptor = {
         payload.aprsPackets = pendingAprs.splice(0, 50);
       }
 
-      makeRequest(`${serverUrl}/api/rig-bridge/relay/state`, 'POST', payload, (err, status) => {
+      makeRequest(`${serverUrl}/api/rig-bridge/relay/state`, 'POST', payload, (err, status, data) => {
         if (err) {
           if (serverReachable) console.error(`[CloudRelay] Push error: ${err.message}`);
           serverReachable = false;

--- a/rig-bridge/plugins/cloud-relay.js
+++ b/rig-bridge/plugins/cloud-relay.js
@@ -135,7 +135,7 @@ const descriptor = {
       lastState = { ...currentState };
 
       // Include batched data in the push
-      const payload = { ...currentState };
+      const payload = { ...currentState, session };
       if (hasDecodes) {
         payload.decodes = pendingDecodes.splice(0, 50);
         totalDecodes += payload.decodes.length;
@@ -162,7 +162,12 @@ const descriptor = {
             console.log(`[CloudRelay] Pushed state (${currentState.freq} Hz ${currentState.mode}${decodeInfo})`);
           }
         } else if (status === 401 || status === 403) {
-          console.error(`[CloudRelay] Authentication failed (${status}) — check relay API key`);
+          try {
+            const msg = JSON.parse(data)?.error || data;
+            console.error(`[CloudRelay] Authentication failed (${status}): ${msg}`);
+          } catch {
+            console.error(`[CloudRelay] Authentication failed (${status}) — check relay API key and session`);
+          }
         }
       });
     }
@@ -264,8 +269,8 @@ const descriptor = {
     }
 
     function connect() {
-      if (!serverUrl || !apiKey) {
-        console.error('[CloudRelay] Cannot start: url and apiKey are required');
+      if (!serverUrl || !apiKey || !session) {
+        console.error('[CloudRelay] Cannot start: url, apiKey, and session are required');
         return;
       }
 

--- a/rig-bridge/plugins/cloud-relay.js
+++ b/rig-bridge/plugins/cloud-relay.js
@@ -209,56 +209,50 @@ const descriptor = {
     }
 
     // Execute a command received from the cloud
+    // Uses https when rig-bridge TLS is enabled, http otherwise.
+    // All requests have an error handler to prevent unhandled-error crashes.
     function executeCommand(cmd) {
       totalCommands++;
       if (cfg.verbose) console.log(`[CloudRelay] Command: ${cmd.type} ${JSON.stringify(cmd.payload || {})}`);
 
+      const localMod = config.tls?.enabled ? https : http;
+      const localOptions = (path, body) => ({
+        hostname: '127.0.0.1',
+        port: config.port || 5555,
+        path,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-RigBridge-Token': config.apiToken || '' },
+        // Skip cert verification for loopback self-signed cert
+        rejectUnauthorized: false,
+      });
+
       switch (cmd.type) {
         case 'setFreq':
           if (cmd.payload?.freq) {
-            // Dispatch through the local rig-bridge HTTP API
-            const freqReq = http.request(
-              {
-                hostname: '127.0.0.1',
-                port: config.port || 5555,
-                path: '/freq',
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'X-RigBridge-Token': config.apiToken || '' },
-              },
-              () => {},
-            );
+            const freqReq = localMod.request(localOptions('/freq'), () => {});
+            freqReq.on('error', (err) => {
+              if (cfg.verbose) console.error(`[CloudRelay] setFreq dispatch error: ${err.message}`);
+            });
             freqReq.write(JSON.stringify({ freq: cmd.payload.freq }));
             freqReq.end();
           }
           break;
         case 'setMode':
           if (cmd.payload?.mode) {
-            const modeReq = http.request(
-              {
-                hostname: '127.0.0.1',
-                port: config.port || 5555,
-                path: '/mode',
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'X-RigBridge-Token': config.apiToken || '' },
-              },
-              () => {},
-            );
+            const modeReq = localMod.request(localOptions('/mode'), () => {});
+            modeReq.on('error', (err) => {
+              if (cfg.verbose) console.error(`[CloudRelay] setMode dispatch error: ${err.message}`);
+            });
             modeReq.write(JSON.stringify({ mode: cmd.payload.mode }));
             modeReq.end();
           }
           break;
         case 'setPTT':
           if (cmd.payload != null) {
-            const pttReq = http.request(
-              {
-                hostname: '127.0.0.1',
-                port: config.port || 5555,
-                path: '/ptt',
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'X-RigBridge-Token': config.apiToken || '' },
-              },
-              () => {},
-            );
+            const pttReq = localMod.request(localOptions('/ptt'), () => {});
+            pttReq.on('error', (err) => {
+              if (cfg.verbose) console.error(`[CloudRelay] setPTT dispatch error: ${err.message}`);
+            });
             pttReq.write(JSON.stringify({ ptt: !!cmd.payload.ptt }));
             pttReq.end();
           }

--- a/rig-bridge/rig-bridge.js
+++ b/rig-bridge/rig-bridge.js
@@ -19,7 +19,7 @@
 
 'use strict';
 
-const VERSION = '2.1.1';
+const VERSION = '2.1.2';
 
 const { config, loadConfig, applyCliArgs } = require('./core/config');
 const {

--- a/rig-bridge/rig-bridge.js
+++ b/rig-bridge/rig-bridge.js
@@ -19,7 +19,7 @@
 
 'use strict';
 
-const VERSION = '2.1.2';
+const VERSION = '2.1.3';
 
 const { config, loadConfig, applyCliArgs } = require('./core/config');
 const {

--- a/server/routes/dxcluster.js
+++ b/server/routes/dxcluster.js
@@ -3,11 +3,11 @@
  * Lines ~2936-4193 of original server.js
  */
 
-const dns = require('dns');
 const dgram = require('dgram');
 const net = require('net');
 const { gridToLatLon, getBandFromKHz } = require('../utils/grid');
 const { areDXPathsDuplicate } = require('../utils/dxClusterPathIdentity');
+const { isPrivateIP, validateCustomHost } = require('../utils/ssrf');
 
 module.exports = function (app, ctx) {
   const {
@@ -1247,79 +1247,6 @@ module.exports = function (app, ctx) {
       }
     }
   }, 60 * 1000);
-
-  /**
-   * SSRF protection: resolve hostname to IP and reject private/reserved addresses.
-   * Returns the resolved IP so callers can connect to the IP directly, preventing
-   * DNS rebinding (TOCTOU) attacks where the record changes between validation and connect.
-   */
-  function isPrivateIP(ip) {
-    // Normalize IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1 → 127.0.0.1)
-    const normalized = ip.replace(/^::ffff:/i, '');
-
-    // IPv4 private/reserved ranges
-    const parts = normalized.split('.').map(Number);
-    if (parts.length === 4 && parts.every((n) => n >= 0 && n <= 255)) {
-      if (parts[0] === 127) return true; // loopback
-      if (parts[0] === 10) return true; // 10.0.0.0/8
-      if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true; // 172.16.0.0/12
-      if (parts[0] === 192 && parts[1] === 168) return true; // 192.168.0.0/16
-      if (parts[0] === 169 && parts[1] === 254) return true; // link-local
-      if (parts[0] === 0) return true; // 0.0.0.0/8
-      if (parts[0] >= 224) return true; // multicast + reserved
-    }
-    // IPv6 private/reserved
-    const lower = normalized.toLowerCase();
-    if (
-      lower === '::1' ||
-      lower === '::' ||
-      lower.startsWith('fe80:') ||
-      lower.startsWith('fc00:') ||
-      lower.startsWith('fd00:') ||
-      lower.startsWith('ff00:') ||
-      lower.startsWith('::ffff:')
-    ) {
-      // Catch any remaining IPv4-mapped forms that weren't normalized above
-      return true;
-    }
-    return false;
-  }
-
-  async function validateCustomHost(host) {
-    // Allow localhost and IP-literal private addresses directly — OpenHamClock is
-    // self-hosted software and users commonly run local DX cluster servers (CC Cluster,
-    // DXSpider on a Pi, etc.).  SSRF is only a concern for multi-user cloud deployments.
-    if (/^localhost$/i.test(host)) return { ok: true, resolvedIP: '127.0.0.1' };
-
-    // If the host is already an IP address, allow it directly (including private ranges)
-    const ipParts = host.split('.').map(Number);
-    if (ipParts.length === 4 && ipParts.every((n) => n >= 0 && n <= 255)) {
-      return { ok: true, resolvedIP: host };
-    }
-
-    // Resolve hostname to IPv4 addresses.
-    // Try resolve4 first (direct DNS), then fall back to lookup (OS resolver)
-    // which handles /etc/hosts, search domains, and alternate resolvers.
-    let addresses;
-    try {
-      addresses = await dns.promises.resolve4(host);
-    } catch {
-      try {
-        const result = await dns.promises.lookup(host, { family: 4 });
-        if (result?.address) addresses = [result.address];
-      } catch {
-        return { ok: false, reason: 'Host could not be resolved (IPv4 required for custom DX clusters)' };
-      }
-    }
-
-    if (!addresses || addresses.length === 0) {
-      return { ok: false, reason: 'Host did not resolve to any IPv4 address' };
-    }
-
-    // Return the first resolved IP so callers connect to the validated IP, not the hostname.
-    // This prevents DNS rebinding (TOCTOU) where the record changes between validation and connect.
-    return { ok: true, resolvedIP: addresses[0] };
-  }
 
   app.get('/api/dxcluster/paths', async (req, res) => {
     // Parse query parameters for custom cluster settings

--- a/server/routes/rig-bridge.js
+++ b/server/routes/rig-bridge.js
@@ -65,15 +65,22 @@ module.exports = function (app, ctx) {
   const MAX_LONG_POLL_PER_IP = 10;
   const relayPollCountByIP = new Map(); // ip → count
 
-  // Issued relay tokens — sessionId → random token returned by relay/configure or relay/credentials.
+  // Issued relay tokens — sessionId → { token, lastUsed }.
   // Simple server-side lookup avoids any dependency on RIG_BRIDGE_RELAY_KEY being stable across
   // restarts or deployments (the HMAC approach broke when the key changed between issue and verify).
   // Tokens are persisted to RELAY_TOKENS_FILE so they survive server restarts.
-  const relayIssuedTokens = new Map(); // sessionId → token
+  // Entries not used for RELAY_TOKEN_MAX_AGE are pruned on startup (background, non-blocking).
+  const RELAY_TOKEN_MAX_AGE = 30 * 24 * 60 * 60 * 1000; // 30 days
+  const relayIssuedTokens = new Map(); // sessionId → { token, lastUsed }
   try {
     const raw = fs.readFileSync(RELAY_TOKENS_FILE, 'utf8');
     const obj = JSON.parse(raw);
-    for (const [k, v] of Object.entries(obj)) relayIssuedTokens.set(k, v);
+    const now = Date.now();
+    for (const [k, v] of Object.entries(obj)) {
+      // Migrate old plain-string format — treat as freshly used so it isn't immediately pruned
+      if (typeof v === 'string') relayIssuedTokens.set(k, { token: v, lastUsed: now });
+      else if (v?.token) relayIssuedTokens.set(k, { token: v.token, lastUsed: v.lastUsed ?? now });
+    }
     logInfo(`[RigBridge] Loaded ${relayIssuedTokens.size} relay token(s) from ${RELAY_TOKENS_FILE}`);
   } catch {
     /* file absent on first run — normal */
@@ -86,6 +93,26 @@ module.exports = function (app, ctx) {
       logWarn(`[RigBridge] Could not persist relay tokens: ${err.message}`);
     }
   }
+
+  // Flush updated lastUsed timestamps to disk once per hour so they survive restarts
+  setInterval(saveRelayTokens, 3600000);
+
+  // Background startup cleanup — runs 15 s after boot so it never delays request handling.
+  // Removes tokens unused for RELAY_TOKEN_MAX_AGE and persists the trimmed file.
+  setTimeout(() => {
+    const cutoff = Date.now() - RELAY_TOKEN_MAX_AGE;
+    let removed = 0;
+    for (const [k, v] of relayIssuedTokens) {
+      if ((v.lastUsed ?? 0) < cutoff) {
+        relayIssuedTokens.delete(k);
+        removed++;
+      }
+    }
+    if (removed > 0) {
+      saveRelayTokens();
+      logInfo(`[RigBridge] Pruned ${removed} stale relay token(s) (unused > 30 days)`);
+    }
+  }, 15000);
 
   function notifyCommandWaiters(sessionId) {
     const waiters = relayCommandWaiters.get(sessionId);
@@ -168,17 +195,18 @@ module.exports = function (app, ctx) {
     }
     const sessionId = req.headers['x-relay-session'] || req.query.session || req.body?.session;
     const token = (req.headers.authorization || '').replace(/^Bearer\s+/i, '');
-    const issuedToken = sessionId ? relayIssuedTokens.get(sessionId) : undefined;
-    if (!sessionId || !token || !issuedToken || token !== issuedToken) {
+    const entry = sessionId ? relayIssuedTokens.get(sessionId) : undefined;
+    if (!sessionId || !token || !entry || token !== entry.token) {
       logWarn(
         `[RigBridge] relay auth failed — sessionId: ${sessionId ? sessionId.slice(0, 8) + '…' : '(none)'}, ` +
-          `token ${token ? 'present' : 'missing'}, issued token ${issuedToken ? 'found' : 'not found in store'}`,
+          `token ${token ? 'present' : 'missing'}, issued token ${entry ? 'found' : 'not found in store'}`,
       );
       return res.status(401).json({
         error:
           'Invalid relay credentials — re-run Connect Cloud Relay in OHC Settings → Rig Bridge to generate fresh credentials',
       });
     }
+    entry.lastUsed = Date.now();
     next();
   }
 
@@ -190,7 +218,7 @@ module.exports = function (app, ctx) {
       }
       const sessionId = req.query.session || crypto.randomBytes(8).toString('hex');
       const token = crypto.randomBytes(32).toString('hex');
-      relayIssuedTokens.set(sessionId, token);
+      relayIssuedTokens.set(sessionId, { token, lastUsed: Date.now() });
       saveRelayTokens();
       res.json({
         relayKey: token,
@@ -494,7 +522,7 @@ module.exports = function (app, ctx) {
       const sessionId = crypto.randomBytes(8).toString('hex');
       const serverUrl = `${req.protocol}://${req.get('host')}`;
       const token = crypto.randomBytes(32).toString('hex');
-      relayIssuedTokens.set(sessionId, token);
+      relayIssuedTokens.set(sessionId, { token, lastUsed: Date.now() });
       saveRelayTokens();
       res.json({
         ok: true,

--- a/server/routes/rig-bridge.js
+++ b/server/routes/rig-bridge.js
@@ -43,6 +43,11 @@ module.exports = function (app, ctx) {
   const MAX_LONG_POLL_PER_IP = 10;
   const relayPollCountByIP = new Map(); // ip → count
 
+  // Issued relay tokens — sessionId → random token returned by relay/configure or relay/credentials.
+  // Simple server-side lookup avoids any dependency on RIG_BRIDGE_RELAY_KEY being stable across
+  // restarts or deployments (the HMAC approach broke when the key changed between issue and verify).
+  const relayIssuedTokens = new Map(); // sessionId → token
+
   function notifyCommandWaiters(sessionId) {
     const waiters = relayCommandWaiters.get(sessionId);
     if (!waiters || waiters.size === 0) return;
@@ -111,29 +116,23 @@ module.exports = function (app, ctx) {
           }
           relayStreamClients.delete(k);
         }
+        relayIssuedTokens.delete(k);
       }
     }
   }, 300000); // Every 5 minutes
 
   // ─── Relay Auth ───────────────────────────────────────────────────────
-  // Session tokens are HMAC(masterKey, sessionId) so the master key never
-  // leaves the server. A leaked session token is scoped to that one session
-  // and cannot be used to create new sessions or impersonate other relays.
-  function sessionToken(sessionId) {
-    return crypto.createHmac('sha256', RIG_BRIDGE_RELAY_KEY).update(sessionId).digest('hex');
-  }
-
   function requireRelayAuth(req, res, next) {
     if (!RIG_BRIDGE_RELAY_KEY) {
       return res.status(503).json({ error: 'Cloud relay not configured — set RIG_BRIDGE_RELAY_KEY in .env' });
     }
     const sessionId = req.headers['x-relay-session'] || req.query.session || req.body?.session;
     const token = (req.headers.authorization || '').replace(/^Bearer\s+/i, '');
-    if (!sessionId || !token || token !== sessionToken(sessionId)) {
+    const issuedToken = sessionId ? relayIssuedTokens.get(sessionId) : undefined;
+    if (!sessionId || !token || !issuedToken || token !== issuedToken) {
       logWarn(
         `[RigBridge] relay auth failed — sessionId: ${sessionId ? sessionId.slice(0, 8) + '…' : '(none)'}, ` +
-          `token: ${token ? token.slice(0, 8) + '…' : '(none)'}, ` +
-          `expected: ${sessionId ? sessionToken(sessionId).slice(0, 8) + '…' : '(n/a)'}`,
+          `token ${token ? 'present' : 'missing'}, issued token ${issuedToken ? 'found' : 'not found in store'}`,
       );
       return res.status(401).json({
         error:
@@ -150,8 +149,10 @@ module.exports = function (app, ctx) {
         return res.json({ error: 'Cloud relay not configured', configured: false });
       }
       const sessionId = req.query.session || crypto.randomBytes(8).toString('hex');
+      const token = crypto.randomBytes(32).toString('hex');
+      relayIssuedTokens.set(sessionId, token);
       res.json({
-        relayKey: sessionToken(sessionId),
+        relayKey: token,
         session: sessionId,
         serverUrl: `${req.protocol}://${req.get('host')}`,
       });
@@ -451,7 +452,8 @@ module.exports = function (app, ctx) {
       }
       const sessionId = crypto.randomBytes(8).toString('hex');
       const serverUrl = `${req.protocol}://${req.get('host')}`;
-      const token = sessionToken(sessionId);
+      const token = crypto.randomBytes(32).toString('hex');
+      relayIssuedTokens.set(sessionId, token);
       res.json({
         ok: true,
         session: sessionId,

--- a/server/routes/rig-bridge.js
+++ b/server/routes/rig-bridge.js
@@ -24,6 +24,28 @@ module.exports = function (app, ctx) {
   const RIG_BRIDGE_DIR = path.join(ROOT_DIR, 'rig-bridge');
   const RIG_BRIDGE_ENTRY = path.join(RIG_BRIDGE_DIR, 'rig-bridge.js');
 
+  // ─── Relay Token Persistence ──────────────────────────────────────────
+  // Resolve a writable path for relay-tokens.json using the same waterfall
+  // as data/settings.json so tokens survive server restarts.
+  const RELAY_TOKENS_FILE = (() => {
+    const candidates = [
+      process.env.RELAY_TOKENS_FILE,
+      '/data/relay-tokens.json',
+      path.join(ROOT_DIR, 'data', 'relay-tokens.json'),
+      '/tmp/openhamclock-relay-tokens.json',
+    ];
+    for (const p of candidates) {
+      if (!p) continue;
+      try {
+        fs.mkdirSync(path.dirname(p), { recursive: true });
+        return p;
+      } catch {
+        continue;
+      }
+    }
+    return '/tmp/openhamclock-relay-tokens.json';
+  })();
+
   // ─── Cloud Relay State Store ──────────────────────────────────────────
   // Per-session relay state and command queues.
   // Session = unique browser tab / user connection.
@@ -46,7 +68,24 @@ module.exports = function (app, ctx) {
   // Issued relay tokens — sessionId → random token returned by relay/configure or relay/credentials.
   // Simple server-side lookup avoids any dependency on RIG_BRIDGE_RELAY_KEY being stable across
   // restarts or deployments (the HMAC approach broke when the key changed between issue and verify).
+  // Tokens are persisted to RELAY_TOKENS_FILE so they survive server restarts.
   const relayIssuedTokens = new Map(); // sessionId → token
+  try {
+    const raw = fs.readFileSync(RELAY_TOKENS_FILE, 'utf8');
+    const obj = JSON.parse(raw);
+    for (const [k, v] of Object.entries(obj)) relayIssuedTokens.set(k, v);
+    logInfo(`[RigBridge] Loaded ${relayIssuedTokens.size} relay token(s) from ${RELAY_TOKENS_FILE}`);
+  } catch {
+    /* file absent on first run — normal */
+  }
+
+  function saveRelayTokens() {
+    try {
+      fs.writeFileSync(RELAY_TOKENS_FILE, JSON.stringify(Object.fromEntries(relayIssuedTokens), null, 2), 'utf8');
+    } catch (err) {
+      logWarn(`[RigBridge] Could not persist relay tokens: ${err.message}`);
+    }
+  }
 
   function notifyCommandWaiters(sessionId) {
     const waiters = relayCommandWaiters.get(sessionId);
@@ -116,7 +155,8 @@ module.exports = function (app, ctx) {
           }
           relayStreamClients.delete(k);
         }
-        relayIssuedTokens.delete(k);
+        // Tokens are NOT deleted here — they survive session expiry so rig-bridge
+        // can reconnect after a server restart without re-authenticating.
       }
     }
   }, 300000); // Every 5 minutes
@@ -151,6 +191,7 @@ module.exports = function (app, ctx) {
       const sessionId = req.query.session || crypto.randomBytes(8).toString('hex');
       const token = crypto.randomBytes(32).toString('hex');
       relayIssuedTokens.set(sessionId, token);
+      saveRelayTokens();
       res.json({
         relayKey: token,
         session: sessionId,
@@ -454,6 +495,7 @@ module.exports = function (app, ctx) {
       const serverUrl = `${req.protocol}://${req.get('host')}`;
       const token = crypto.randomBytes(32).toString('hex');
       relayIssuedTokens.set(sessionId, token);
+      saveRelayTokens();
       res.json({
         ok: true,
         session: sessionId,
@@ -472,6 +514,21 @@ module.exports = function (app, ctx) {
       logWarn(`[RigBridge] relay/configure error: ${err.message}`);
       if (!res.headersSent) res.json({ ok: false, error: 'Internal error' });
     }
+  });
+
+  // ─── Cloud Relay: Revoke credentials ──────────────────────────────────
+  // Invalidates a relay token immediately. Requires OHC write auth.
+  // After revocation the rig-bridge must run Connect Cloud Relay again to get new credentials.
+  app.delete('/api/rig-bridge/relay/revoke/:sessionId', requireWriteAuth, (req, res) => {
+    const { sessionId } = req.params;
+    if (!relayIssuedTokens.has(sessionId)) {
+      return res.status(404).json({ error: 'Session not found' });
+    }
+    relayIssuedTokens.delete(sessionId);
+    relaySessions.delete(sessionId);
+    saveRelayTokens();
+    logInfo(`[RigBridge] Relay token revoked for session ${sessionId.slice(0, 8)}…`);
+    res.json({ ok: true });
   });
 
   // ─── Downloads: Platform-specific installer scripts ────────────────────

--- a/server/routes/rig-bridge.js
+++ b/server/routes/rig-bridge.js
@@ -130,7 +130,10 @@ module.exports = function (app, ctx) {
     const sessionId = req.headers['x-relay-session'] || req.query.session || req.body?.session;
     const token = (req.headers.authorization || '').replace(/^Bearer\s+/i, '');
     if (!sessionId || !token || token !== sessionToken(sessionId)) {
-      return res.status(401).json({ error: 'Invalid relay credentials' });
+      return res.status(401).json({
+        error:
+          'Invalid relay credentials — re-run Connect Cloud Relay in OHC Settings → Rig Bridge to generate fresh credentials',
+      });
     }
     next();
   }

--- a/server/routes/rig-bridge.js
+++ b/server/routes/rig-bridge.js
@@ -14,6 +14,7 @@ const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
+const { validateCustomHost } = require('../utils/ssrf');
 
 module.exports = function (app, ctx) {
   const { ROOT_DIR, logInfo, logWarn, requireWriteAuth, RIG_BRIDGE_RELAY_KEY } = ctx;
@@ -37,6 +38,10 @@ module.exports = function (app, ctx) {
   // When a browser POSTs a command, any waiting rig-bridge poll is resolved
   // immediately instead of waiting up to 250 ms for the next poll tick.
   const relayCommandWaiters = new Map(); // sessionId → Set<{ resolve, timer }>
+
+  // Per-IP long-poll connection counter — caps concurrent waiters to bound resource use.
+  const MAX_LONG_POLL_PER_IP = 10;
+  const relayPollCountByIP = new Map(); // ip → count
 
   function notifyCommandWaiters(sessionId) {
     const waiters = relayCommandWaiters.get(sessionId);
@@ -111,13 +116,21 @@ module.exports = function (app, ctx) {
   }, 300000); // Every 5 minutes
 
   // ─── Relay Auth ───────────────────────────────────────────────────────
+  // Session tokens are HMAC(masterKey, sessionId) so the master key never
+  // leaves the server. A leaked session token is scoped to that one session
+  // and cannot be used to create new sessions or impersonate other relays.
+  function sessionToken(sessionId) {
+    return crypto.createHmac('sha256', RIG_BRIDGE_RELAY_KEY).update(sessionId).digest('hex');
+  }
+
   function requireRelayAuth(req, res, next) {
     if (!RIG_BRIDGE_RELAY_KEY) {
       return res.status(503).json({ error: 'Cloud relay not configured — set RIG_BRIDGE_RELAY_KEY in .env' });
     }
+    const sessionId = req.headers['x-relay-session'] || req.query.session || req.body?.session;
     const token = (req.headers.authorization || '').replace(/^Bearer\s+/i, '');
-    if (token !== RIG_BRIDGE_RELAY_KEY) {
-      return res.status(401).json({ error: 'Invalid relay key' });
+    if (!sessionId || !token || token !== sessionToken(sessionId)) {
+      return res.status(401).json({ error: 'Invalid relay credentials' });
     }
     next();
   }
@@ -130,7 +143,7 @@ module.exports = function (app, ctx) {
       }
       const sessionId = req.query.session || crypto.randomBytes(8).toString('hex');
       res.json({
-        relayKey: RIG_BRIDGE_RELAY_KEY,
+        relayKey: sessionToken(sessionId),
         session: sessionId,
         serverUrl: `${req.protocol}://${req.get('host')}`,
       });
@@ -365,16 +378,32 @@ module.exports = function (app, ctx) {
         return res.json({ commands: [] });
       }
 
+      const clientIP = req.ip || req.socket?.remoteAddress || 'unknown';
+      const ipCount = relayPollCountByIP.get(clientIP) ?? 0;
+      if (ipCount >= MAX_LONG_POLL_PER_IP) {
+        return res.status(429).json({ error: 'Too many concurrent long-polls from this IP' });
+      }
+      relayPollCountByIP.set(clientIP, ipCount + 1);
+
       if (!relayCommandWaiters.has(sessionId)) {
         relayCommandWaiters.set(sessionId, new Set());
       }
       const waiterSet = relayCommandWaiters.get(sessionId);
       let resolved = false;
 
+      function releaseIPSlot() {
+        const n = relayPollCountByIP.get(clientIP);
+        if (n != null) {
+          if (n <= 1) relayPollCountByIP.delete(clientIP);
+          else relayPollCountByIP.set(clientIP, n - 1);
+        }
+      }
+
       const waiter = {
         resolve(commands) {
           if (resolved) return;
           resolved = true;
+          releaseIPSlot();
           try {
             res.json({ commands });
           } catch (e) {
@@ -397,6 +426,7 @@ module.exports = function (app, ctx) {
           clearTimeout(waiter.timer);
           waiterSet.delete(waiter);
           if (waiterSet.size === 0) relayCommandWaiters.delete(sessionId);
+          releaseIPSlot();
         }
       });
     } catch (err) {
@@ -413,16 +443,17 @@ module.exports = function (app, ctx) {
       }
       const sessionId = crypto.randomBytes(8).toString('hex');
       const serverUrl = `${req.protocol}://${req.get('host')}`;
+      const token = sessionToken(sessionId);
       res.json({
         ok: true,
         session: sessionId,
         serverUrl,
-        relayKey: RIG_BRIDGE_RELAY_KEY,
+        relayKey: token,
         configPayload: {
           cloudRelay: {
             enabled: true,
             url: serverUrl,
-            apiKey: RIG_BRIDGE_RELAY_KEY,
+            apiKey: token,
             session: sessionId,
           },
         },
@@ -443,6 +474,11 @@ module.exports = function (app, ctx) {
     const proto = req.headers['x-forwarded-proto'] || req.protocol || 'http';
     const host = req.headers['x-forwarded-host'] || req.headers.host;
     const serverURL = (proto + '://' + host).replace(/[^a-zA-Z0-9._\-:\/\@]/g, '');
+    try {
+      new URL(serverURL);
+    } catch {
+      return res.status(400).json({ error: 'Invalid server URL derived from request headers' });
+    }
 
     if (platform === 'windows') {
       const script = [
@@ -753,15 +789,24 @@ module.exports = function (app, ctx) {
     }
   });
 
-  app.get('/api/rig-bridge/status', async (req, res) => {
-    const host = req.query.host || 'http://localhost';
+  app.get('/api/rig-bridge/status', requireWriteAuth, async (req, res) => {
+    const rawHost = (req.query.host || 'localhost').replace(/^https?:\/\//i, '');
+    const proto = (req.query.host || '').startsWith('https') ? 'https' : 'http';
     const port = req.query.port || '5555';
-    const url = `${host}:${port}/health`;
 
+    const validation = await validateCustomHost(rawHost);
+    if (!validation.ok) {
+      return res.status(400).json({ reachable: false, error: `Invalid host: ${validation.reason}` });
+    }
+
+    const url = `${proto}://${validation.resolvedIP}:${port}/health`;
     try {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 3000);
-      const response = await ctx.fetch(url, { signal: controller.signal });
+      const response = await ctx.fetch(url, {
+        signal: controller.signal,
+        headers: { Host: rawHost },
+      });
       clearTimeout(timeout);
       if (!response.ok) {
         return res.json({ reachable: false, error: `HTTP ${response.status}` });

--- a/server/routes/rig-bridge.js
+++ b/server/routes/rig-bridge.js
@@ -130,6 +130,11 @@ module.exports = function (app, ctx) {
     const sessionId = req.headers['x-relay-session'] || req.query.session || req.body?.session;
     const token = (req.headers.authorization || '').replace(/^Bearer\s+/i, '');
     if (!sessionId || !token || token !== sessionToken(sessionId)) {
+      logWarn(
+        `[RigBridge] relay auth failed — sessionId: ${sessionId ? sessionId.slice(0, 8) + '…' : '(none)'}, ` +
+          `token: ${token ? token.slice(0, 8) + '…' : '(none)'}, ` +
+          `expected: ${sessionId ? sessionToken(sessionId).slice(0, 8) + '…' : '(n/a)'}`,
+      );
       return res.status(401).json({
         error:
           'Invalid relay credentials — re-run Connect Cloud Relay in OHC Settings → Rig Bridge to generate fresh credentials',

--- a/server/utils/ssrf.js
+++ b/server/utils/ssrf.js
@@ -1,0 +1,83 @@
+'use strict';
+/**
+ * SSRF helpers — shared between route modules that make outbound HTTP/TCP connections
+ * based on caller-supplied hostnames (DX cluster, rig-bridge status, etc.).
+ *
+ * validateCustomHost resolves a hostname to its first IPv4 address and returns it so
+ * callers connect to the resolved IP directly, preventing DNS-rebinding TOCTOU attacks
+ * where the DNS record changes between validation and the actual connection.
+ */
+
+const dns = require('dns');
+
+function isPrivateIP(ip) {
+  // Normalize IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1 → 127.0.0.1)
+  const normalized = ip.replace(/^::ffff:/i, '');
+
+  const parts = normalized.split('.').map(Number);
+  if (parts.length === 4 && parts.every((n) => n >= 0 && n <= 255)) {
+    if (parts[0] === 127) return true; // loopback
+    if (parts[0] === 10) return true; // 10.0.0.0/8
+    if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true; // 172.16.0.0/12
+    if (parts[0] === 192 && parts[1] === 168) return true; // 192.168.0.0/16
+    if (parts[0] === 169 && parts[1] === 254) return true; // link-local
+    if (parts[0] === 0) return true; // 0.0.0.0/8
+    if (parts[0] >= 224) return true; // multicast + reserved
+  }
+
+  const lower = normalized.toLowerCase();
+  if (
+    lower === '::1' ||
+    lower === '::' ||
+    lower.startsWith('fe80:') ||
+    lower.startsWith('fc00:') ||
+    lower.startsWith('fd00:') ||
+    lower.startsWith('ff00:') ||
+    lower.startsWith('::ffff:')
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Validate a caller-supplied hostname for outbound connections.
+ *
+ * Localhost and bare IP literals (including RFC-1918 ranges) are always allowed —
+ * OHC is self-hosted software where connecting to local services is the norm.
+ * SSRF is a concern only for arbitrary DNS names that could resolve to internal infra
+ * on multi-user cloud deployments.
+ *
+ * Returns { ok: true, resolvedIP } or { ok: false, reason }.
+ */
+async function validateCustomHost(host) {
+  if (/^localhost$/i.test(host)) return { ok: true, resolvedIP: '127.0.0.1' };
+
+  // Bare IPv4 literal — allow directly without DNS lookup
+  const ipParts = host.split('.').map(Number);
+  if (ipParts.length === 4 && ipParts.every((n) => n >= 0 && n <= 255)) {
+    return { ok: true, resolvedIP: host };
+  }
+
+  // Resolve hostname → IPv4. Try resolve4 first (pure DNS), fall back to OS resolver
+  // which also handles /etc/hosts and search domains.
+  let addresses;
+  try {
+    addresses = await dns.promises.resolve4(host);
+  } catch {
+    try {
+      const result = await dns.promises.lookup(host, { family: 4 });
+      if (result?.address) addresses = [result.address];
+    } catch {
+      return { ok: false, reason: 'Host could not be resolved (IPv4 required)' };
+    }
+  }
+
+  if (!addresses || addresses.length === 0) {
+    return { ok: false, reason: 'Host did not resolve to any IPv4 address' };
+  }
+
+  return { ok: true, resolvedIP: addresses[0] };
+}
+
+module.exports = { isPrivateIP, validateCustomHost };


### PR DESCRIPTION
## Summary

### Security fixes

- **SSRF in \`/api/rig-bridge/status\`:** endpoint now validates the caller-supplied \`host\` via \`validateCustomHost\`, connects to the resolved IP (preventing DNS-rebinding TOCTOU), and is gated behind \`requireWriteAuth\`
- **Relay key leak:** \`RIG_BRIDGE_RELAY_KEY\` no longer leaves the server — \`relay/credentials\` and \`relay/configure\` now return a random 256-bit per-session token; \`requireRelayAuth\` validates against a server-side Map, so a leaked token is useless without a matching server-side entry
- **Long-poll DoS:** \`relay/commands\` now caps concurrent long-poll waiters at 10 per IP (returns 429 on excess)
- **URL injection in download scripts:** \`new URL()\` validation added after the regex sanitisation in the installer script builder
- **SSRF utility extracted:** \`isPrivateIP\` / \`validateCustomHost\` moved from \`dxcluster.js\` into new shared \`server/utils/ssrf.js\`, removing the duplicate

### Auth evolution: HMAC → server-side token store

Initial implementation used HMAC-SHA256(masterKey, sessionId) as a stateless token. In practice this broke whenever \`RIG_BRIDGE_RELAY_KEY\` differed between the issuing and validating process (restarts, env changes). Replaced with a server-side Map keyed by sessionId storing a random token issued at credential-setup time.

### Persistent relay credentials (survive server restarts)

Relay tokens are now written to \`data/relay-tokens.json\` (same path waterfall as \`settings.json\`: \`/data\` → \`ROOT_DIR/data\` → \`/tmp\`) on every issuance and loaded back at startup. rig-bridge authenticates once; credentials remain valid indefinitely across server restarts and deploys without any user action.

Tokens are **not** deleted on relay-session expiry — only when explicitly revoked or pruned (see below).

New endpoint: \`DELETE /api/rig-bridge/relay/revoke/:sessionId\` (behind \`requireWriteAuth\`) for manual credential invalidation.

### Stale token cleanup

Token entries now store \`{ token, lastUsed }\` instead of a bare string. \`lastUsed\` is updated in memory on every successful auth and flushed to \`relay-tokens.json\` hourly so the timestamp survives restarts.

On each server startup a background job fires 15 seconds after boot, removes any token whose \`lastUsed\` is older than 30 days, and persists the trimmed file — startup latency is unaffected. Old plain-string entries in existing \`relay-tokens.json\` files are migrated automatically (\`lastUsed\` set to now) so nothing is pruned unexpectedly on first upgrade.

### cloud-relay plugin fixes (rig-bridge 2.1.3)

- **Crash fix:** the three fire-and-forget \`http.request\` calls in \`executeCommand\` (setFreq / setMode / setPTT) had no \`.on('error', ...)\` handler. When rig-bridge TLS is enabled the loopback connection returns a TLS handshake instead of plain HTTP, triggering an unhandled \`'error'\` event that crashed the process. Error handlers added; protocol now selected from \`config.tls?.enabled\` with \`rejectUnauthorized: false\` for the self-signed loopback cert.
- **Fixed silent auth-error messages:** \`pushState\`'s \`makeRequest\` callback was declared as \`(err, status)\` but referenced a third \`data\` parameter that was never in scope. In strict mode this threw a ReferenceError caught by the catch block, so 401/403 responses always showed the hardcoded fallback instead of the server's error message. Fixed by adding \`data\` as the third callback parameter.
- **Session in push payload:** \`session\` field now included in the state-push POST body so the server can identify the session from the body when the header is absent.
- **connect() validation:** \`session\` is now checked alongside \`url\` and \`apiKey\` — missing session ID is caught at startup rather than failing silently on first push.

## ⚠️ Breaking change for existing Cloud Relay users

Any rig-bridge that was configured before this change has the raw \`RIG_BRIDGE_RELAY_KEY\` stored as its \`apiKey\`. After deploy the server will reject it with a 401 and the error message reads:

> *Invalid relay credentials — re-run Connect Cloud Relay in OHC Settings → Rig Bridge to generate fresh credentials*

**Recovery:** open OHC Settings → Rig Bridge → click **Connect Cloud Relay**, copy the new config payload into rig-bridge's Cloud Relay plugin, restart rig-bridge. After that, credentials persist across all future server restarts.

## Test plan

- [ ] Local rig-bridge status check (`/api/rig-bridge/status?host=localhost&port=5555`) still returns reachable state
- [ ] `relay/configure` returns a session-scoped random token (64-char hex), not the raw `RIG_BRIDGE_RELAY_KEY` value
- [ ] rig-bridge cloud-relay plugin authenticates successfully after re-running setup
- [ ] Stale credentials return HTTP 401 with the recovery hint message
- [ ] After server restart, rig-bridge reconnects without re-running setup (token loaded from `relay-tokens.json`)
- [ ] `relay/commands` long-poll returns 429 after 10 concurrent connections from the same IP
- [ ] Download installer scripts return 400 for a malformed `Host` header
- [ ] Clicking a DX cluster entry to tune no longer crashes rig-bridge when TLS is enabled
- [ ] `DELETE /api/rig-bridge/relay/revoke/:sessionId` invalidates the token and subsequent pushes receive 401
- [ ] Tokens unused for 30+ days are removed from `relay-tokens.json` after server restart (check log: `Pruned N stale relay token(s)`)
- [ ] Active tokens are not pruned; `lastUsed` is updated on each successful auth and written to disk within the hour
- [ ] Existing `relay-tokens.json` with old plain-string format is migrated without data loss