### PR TITLE
fix(ambient-weather): correct typo isMeticPress -> isMetricPress

### DIFF
--- a/src/hooks/useAmbientWeather.js
+++ b/src/hooks/useAmbientWeather.js
@@ -142,7 +142,7 @@ export const useAmbientWeather = (allUnits = { dist: 'imperial', temp: 'imperial
     const convPressure = (inHg) => {
       const n = safeNum(inHg);
       if (n == null) return null;
-      return isMeticPress ? inHgToHpa(n).toFixed(1) : n.toFixed(3);
+      return isMetricPress ? inHgToHpa(n).toFixed(1) : n.toFixed(3);
     };
 
     return {


### PR DESCRIPTION
## Summary

- Fixes a one-character typo on line 145 of `src/hooks/useAmbientWeather.js`: `isMeticPress` → `isMetricPress`
- The undefined variable caused a `ReferenceError` that crashed the Ambient Weather panel with "Error rendering component" in the Dockable layout

Closes #937

## Test plan

- [ ] Add valid Ambient Weather application key and API key to `.env`
- [ ] Open Dockable layout and scroll to the Ambient Weather panel
- [ ] Verify weather data renders without error
- [ ] Toggle pressure unit between metric (hPa) and imperial (inHg) and confirm values convert correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)