### PR TITLE
[fix] lockout frequent POST to /api/presence

### DIFF
--- a/server/routes/presence.js
+++ b/server/routes/presence.js
@@ -22,7 +22,7 @@ module.exports = function (app, ctx) {
 
   // map of POST operation IP remote addresses, with periodic cleanup
   const remoteAddresses = new Map();
-  const remoteAddress_TTL = 1 * 60 * 1000; // 1 minute
+  const remoteAddress_TTL = 60 * 60 * 1000; // 60 minutes
   setInterval(() => {
     const cutoff = Date.now() - remoteAddress_TTL;
     for (const [key, remoteAddress] of remoteAddresses)
@@ -33,10 +33,11 @@ module.exports = function (app, ctx) {
   app.post('/api/presence', (req, res) => {
     const { callsign, lat, lon, grid } = req.body || {};
 
-    // POST remote address, lockout if repeat activity within remoteAddress_TTL period
+    // POST remote address, lockout if repeat activity within remoteAddress_lockout_period
+    const remoteAddress_lockout_period = 1 * 60 * 1000; // 1 minute
     const remoteAddress = req.socket.remoteAddress || {};
     let remoteAddressLockout = remoteAddresses.has(remoteAddress)
-      ? Date.now() < remoteAddresses.get(remoteAddress).createTime + remoteAddress_TTL
+      ? Date.now() < remoteAddresses.get(remoteAddress).createTime + remoteAddress_lockout_period
       : false;
     if (remoteAddressLockout) return res.status(400).json({ error: 'IP Address lockout until timeout' });
 
@@ -50,9 +51,16 @@ module.exports = function (app, ctx) {
     const call = callsign.toUpperCase().replace(/[^A-Z0-9/\-]/g, '');
     if (call.length < 3) return res.status(400).json({ error: 'Invalid callsign' });
 
+    // if remote address has been used previously but with another callsign then purge that other callsign
+    if (remoteAddresses.has(remoteAddress)) {
+      const callOnRecord = remoteAddresses.get(remoteAddress).call;
+      if (callOnRecord != call && activeUsers.has(callOnRecord)) activeUsers.delete(callOnRecord);
+    }
+
     remoteAddresses.set(remoteAddress, {
       remoteAddress,
       createTime: Date.now(),
+      call, // callsign related to remote address
     });
 
     activeUsers.set(call, {
@@ -61,6 +69,7 @@ module.exports = function (app, ctx) {
       lon: Math.round(lon * 100) / 100,
       grid: (grid || '').substring(0, 6).toUpperCase(),
       lastSeen: Date.now(),
+      remoteAddress, // remote address related to this callsign
     });
 
     // Prune if over limit (keep most recent)

--- a/server/routes/presence.js
+++ b/server/routes/presence.js
@@ -20,9 +20,26 @@ module.exports = function (app, ctx) {
     }
   }, 60000);
 
+  // map of POST operation IP remote addresses, with periodic cleanup
+  const remoteAddresses = new Map();
+  const remoteAddress_TTL = 1 * 60 * 1000; // 1 minute
+  setInterval(() => {
+    const cutoff = Date.now() - remoteAddress_TTL;
+    for (const [key, remoteAddress] of remoteAddresses)
+      if (Date.now() >= remoteAddress.createTime + remoteAddress_TTL) remoteAddresses.delete(key);
+  }, 10000); // every ten minutes
+
   // POST /api/presence — heartbeat from a user
   app.post('/api/presence', (req, res) => {
     const { callsign, lat, lon, grid } = req.body || {};
+
+    // POST remote address, lockout if repeat activity within remoteAddress_TTL period
+    const remoteAddress = req.socket.remoteAddress || {};
+    let remoteAddressLockout = remoteAddresses.has(remoteAddress)
+      ? Date.now() < remoteAddresses.get(remoteAddress).createTime + remoteAddress_TTL
+      : false;
+    if (remoteAddressLockout) return res.status(400).json({ error: 'IP Address lockout until timeout' });
+
     if (!callsign || typeof callsign !== 'string' || callsign.length < 3 || callsign.length > 12) {
       return res.status(400).json({ error: 'Valid callsign required' });
     }
@@ -32,6 +49,11 @@ module.exports = function (app, ctx) {
 
     const call = callsign.toUpperCase().replace(/[^A-Z0-9/\-]/g, '');
     if (call.length < 3) return res.status(400).json({ error: 'Invalid callsign' });
+
+    remoteAddresses.set(remoteAddress, {
+      remoteAddress,
+      createTime: Date.now(),
+    });
 
     activeUsers.set(call, {
       call,


### PR DESCRIPTION
fixes reported security/resource audit issue:

  ## 🔴 Critical — pick this up first 

  **2. `/api/presence` — anyone can spoof any callsign** — `server/routes/presence.js:24-54`
  No auth, no per-IP limit. A POST with `{callsign:"K1JT", lat, lon}` pins that callsign on the Active Users layer for everyone. **Fix:** at minimum bind callsign↔IP, rate-limit to 1 update/60s/IP. 

## details,
- POST operation IP remote address `req.socket.remoteAddress` stored
- lookup prevents same remote address being used within 60s
- if detected that remote address is already associated with another callsign then that other callsign is deleted
- remote address purge occurs every ten mins, addresses purged after sixty minutes

<img width="1098" height="131" alt="image" src="https://github.com/user-attachments/assets/371d2948-940a-42bd-998e-99b590dc9f47" />
