### PR TITLE
[fix] errorLogState periodic purge

### DIFF
--- a/server/utils/logging.js
+++ b/server/utils/logging.js
@@ -20,6 +20,19 @@ function logWarn(...args) {
 const errorLogState = {};
 const ERROR_LOG_INTERVAL = 5 * 60 * 1000;
 
+// Periodic cleanup: purge expired cache entries
+setInterval(() => {
+  const now = Date.now();
+  const cutoff = 2 * ERROR_LOG_INTERVAL;
+
+  for (const key of Object.keys(errorLogState)) {
+    const ts = errorLogState[key];
+    if (now - ts > cutoff) {
+      delete errorLogState[key];
+    }
+  }
+}, ERROR_LOG_INTERVAL);
+
 function logErrorOnce(category, message) {
   if (message && (message.includes('aborted') || message.includes('AbortError'))) return false;
   const key = `${category}:${message}`;


### PR DESCRIPTION
fixes reported security/resource audit issue:

  ## 🟡 Medium — slower bleed, still worth fixing                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                             
  - **`logErrorOnce` map never pruned** — `server/utils/logging.js:20-34`. Keys include `err.message`, which varies per host/port/URL → slow leak over weeks. Add a periodic prune older than `2 × ERROR_LOG_INTERVAL`.

## details,
- purges errorLogState with time cutoff `const cutoff = 2 * ERROR_LOG_INTERVAL;`
- repeats at `ERROR_LOG_INTERVAL`





