### PR TITLE
[fix] fixes issue#950 non-NASA imageUrl report in throw

### DIFF
--- a/server/routes/space-weather.js
+++ b/server/routes/space-weather.js
@@ -491,7 +491,7 @@ module.exports = function (app, ctx) {
     const imageUrl = meta?.image?.url;
     if (!imageUrl) throw new Error('No image URL in Dial-A-Moon response');
     if (!isValidNasaImageUrl(imageUrl)) {
-      throw new Error('Rejected non‑NASA URL:', imageUrl);
+      throw new Error(`Rejected non-NASA URL: \'${imageUrl}\'`);
     }
 
     const imgResponse = await fetch(imageUrl);


### PR DESCRIPTION
## What does this PR do?

- fixes https://github.com/accius/openhamclock/issues/950
- single line change reports imageUrl as part of throw, previously missing

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included
