### PR TITLE
[fix/refactor] fixes issue#949, cleanup lockout frequent POST to /api/presence

### DIFF
--- a/server/routes/presence.js
+++ b/server/routes/presence.js
@@ -42,7 +42,7 @@ module.exports = function (app, ctx) {
     let remoteAddressLockout = remoteAddresses.has(remoteAddress)
       ? Date.now() < remoteAddresses.get(remoteAddress).createTime + remoteAddress_lockout_period
       : false;
-    if (remoteAddressLockout) return res.status(400).json({ error: 'IP Address lockout until timeout' });
+    if (remoteAddressLockout) return res.status(429).json({ error: 'IP Address lockout until timeout' });
 
     if (!callsign || typeof callsign !== 'string' || callsign.length < 3 || callsign.length > 12) {
       return res.status(400).json({ error: 'Valid callsign required' });

--- a/server/routes/presence.js
+++ b/server/routes/presence.js
@@ -38,7 +38,7 @@ module.exports = function (app, ctx) {
 
     // POST remote address, lockout if repeat activity within remoteAddress_lockout_period
     const remoteAddress_lockout_period = 1 * 60 * 1000; // 1 minute
-    const remoteAddress = req.socket.remoteAddress || {};
+    const remoteAddress = req.ip || {};
     let remoteAddressLockout = remoteAddresses.has(remoteAddress)
       ? Date.now() < remoteAddresses.get(remoteAddress).createTime + remoteAddress_lockout_period
       : false;

--- a/server/routes/presence.js
+++ b/server/routes/presence.js
@@ -23,11 +23,14 @@ module.exports = function (app, ctx) {
   // map of POST operation IP remote addresses, with periodic cleanup
   const remoteAddresses = new Map();
   const remoteAddress_TTL = 60 * 60 * 1000; // 60 minutes
-  setInterval(() => {
-    const cutoff = Date.now() - remoteAddress_TTL;
-    for (const [key, remoteAddress] of remoteAddresses)
-      if (Date.now() >= remoteAddress.createTime + remoteAddress_TTL) remoteAddresses.delete(key);
-  }, 10000); // every ten minutes
+  setInterval(
+    () => {
+      const cutoff = Date.now() - remoteAddress_TTL;
+      for (const [key, remoteAddress] of remoteAddresses)
+        if (Date.now() >= remoteAddress.createTime + remoteAddress_TTL) remoteAddresses.delete(key);
+    },
+    10 * 60 * 1000,
+  ); // every ten minutes
 
   // POST /api/presence — heartbeat from a user
   app.post('/api/presence', (req, res) => {

--- a/server/routes/presence.js
+++ b/server/routes/presence.js
@@ -18,7 +18,7 @@ module.exports = function (app, ctx) {
     for (const [key, user] of activeUsers) {
       if (user.lastSeen < cutoff) activeUsers.delete(key);
     }
-  }, 60000);
+  }, 60 * 1000); // every minute
 
   // map of POST operation IP remote addresses, with periodic cleanup
   const remoteAddresses = new Map();


### PR DESCRIPTION
## What does this PR do?

- fixes https://github.com/accius/openhamclock/issues/949
  - remoteAddresses cache cleanup interval set to 10min, was 10s.
  - remote client IP address change req.socket.remoteAddress to req.ip
  - change HTTP status code returned from 400 to 429 i.e. 'Too Many Requests' (but actual message returned 'IP Address lockout until timeout' not modified).

- tested using
  - `http://localhost:3001/api/presence`
  - `curl -X POST http://localhost:3001/api/presence -H "Content-Type: application/json" -d '{ "callsign": "K6MRW", "lat": 32.0, "lon": -117.0 }'`
  - `curl -X POST http://localhost:3001/api/presence -H "Content-Type: application/json" -d '{ "callsign": "zK6MRW", "lat": 32.0, "lon": -117.0 }'`

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [X] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

