### PR TITLE
[refactor] Issue#947, create server/utils/cache.js with maintainCache

### DIFF
--- a/server.js
+++ b/server.js
@@ -98,6 +98,9 @@ const { endpointStats, writeLimiter, requireWriteAuth } = applyMiddleware(app, {
   CORS_ORIGINS,
 });
 
+// ── Utilities ──
+const { maintainCache } = require('./server/utils/cache');
+
 // ── Build shared context object ──
 const ctx = {
   // Core
@@ -144,6 +147,7 @@ const ctx = {
   requireWriteAuth,
   writeLimiter,
   endpointStats,
+  maintainCache,
 };
 
 // ── Visitor stats service ──

--- a/server/routes/dxpeditions.js
+++ b/server/routes/dxpeditions.js
@@ -19,11 +19,11 @@ module.exports = function (app, ctx) {
   const sourceCaches = new Map();
 
   async function cachedFetch(name, fetcher) {
-    const entry = sourceCaches.get(name) || { data: null, ts: 0 };
-    if (entry.data && Date.now() - entry.ts < SOURCE_TTL) return entry.data;
+    const entry = sourceCaches.get(name) || { data: null, timestamp: 0 };
+    if (entry.data && Date.now() - entry.timestamp < SOURCE_TTL) return entry.data;
     try {
       const fresh = await fetcher();
-      sourceCaches.set(name, { data: fresh, ts: Date.now() });
+      sourceCaches.set(name, { data: fresh, timestamp: Date.now() });
       return fresh;
     } catch (e) {
       logErrorOnce(`dxnews:${name}`, e?.message || 'fetch failed');

--- a/server/routes/emcomm.js
+++ b/server/routes/emcomm.js
@@ -4,36 +4,7 @@
  */
 
 module.exports = function (app, ctx) {
-  const { fetch, logDebug, logErrorOnce } = ctx;
-
-  const maintainCache = (cache, ttlMs, maxEntries, label = 'Cache') => {
-    const now = Date.now();
-    let purged = 0;
-
-    // Remove stale entries
-    for (const key of Object.keys(cache)) {
-      if (now - cache[key].timestamp > ttlMs * 2) {
-        delete cache[key];
-        purged++;
-      }
-    }
-
-    // Enforce max size by evicting oldest
-    const remaining = Object.keys(cache);
-    if (remaining.length > maxEntries) {
-      remaining
-        .sort((a, b) => cache[a].timestamp - cache[b].timestamp)
-        .slice(0, remaining.length - maxEntries)
-        .forEach((key) => {
-          delete cache[key];
-          purged++;
-        });
-    }
-
-    if (purged > 0) {
-      logDebug(`[${label}] purged ${purged} stale entries, ${Object.keys(cache).length} remaining`);
-    }
-  };
+  const { fetch, logDebug, logErrorOnce, maintainCache } = ctx;
 
   // --- NWS Alerts ---
   // Cache keyed on rounded lat/lon, 3 minute TTL

--- a/server/routes/propagation.js
+++ b/server/routes/propagation.js
@@ -16,6 +16,7 @@ module.exports = function (app, ctx) {
     upstream,
     maidenheadToLatLon,
     n0nbhCache,
+    maintainCache,
   } = ctx;
 
   const {
@@ -596,35 +597,6 @@ module.exports = function (app, ctx) {
     solarCache = { sfi, ssn, kIndex, timestamp: now };
     return { sfi, ssn, kIndex };
   }
-
-  const maintainCache = (cache, ttlMs, maxEntries, label = 'Cache') => {
-    const now = Date.now();
-    let purged = 0;
-
-    // Remove stale entries
-    for (const key of Object.keys(cache)) {
-      if (now - cache[key].timestamp > ttlMs * 2) {
-        delete cache[key];
-        purged++;
-      }
-    }
-
-    // Enforce max size by evicting oldest
-    const remaining = Object.keys(cache);
-    if (remaining.length > maxEntries) {
-      remaining
-        .sort((a, b) => cache[a].timestamp - cache[b].timestamp)
-        .slice(0, remaining.length - maxEntries)
-        .forEach((key) => {
-          delete cache[key];
-          purged++;
-        });
-    }
-
-    if (purged > 0) {
-      logDebug(`[${label}] purged ${purged} stale entries, ${Object.keys(cache).length} remaining`);
-    }
-  };
 
   const PROP_HEATMAP_CACHE = {};
   const PROP_HEATMAP_TTL = 15 * 60 * 1000; // 15 minutes — propagation changes slowly

--- a/server/routes/propagation.js
+++ b/server/routes/propagation.js
@@ -46,22 +46,22 @@ module.exports = function (app, ctx) {
 
   // Multi-entry LRU cache for ITURHFProp results — different DE/DX paths
   // don't evict each other. Keyed by rounded coordinates + solar params.
-  const iturhfpropSingleCache = new Map(); // key → { data, ts }
-  const iturhfpropHourlyMap = new Map(); // key → { data, ts }
+  const iturhfpropSingleCache = new Map(); // key → { data, timestamp }
+  const iturhfpropHourlyMap = new Map(); // key → { data, timestamp }
   const ITUCACHE_TTL = 30 * 60 * 1000; // 30 min — predictions don't change fast
   const ITUCACHE_MAX = 200; // max entries per cache
 
   function ituCacheGet(cache, key) {
     const entry = cache.get(key);
     if (!entry) return null;
-    if (Date.now() - entry.ts > ITUCACHE_TTL) {
+    if (Date.now() - entry.timestamp > ITUCACHE_TTL) {
       cache.delete(key);
       return null;
     }
     return entry.data;
   }
   function ituCacheSet(cache, key, data) {
-    cache.set(key, { data, ts: Date.now() });
+    cache.set(key, { data, timestamp: Date.now() });
     // LRU eviction
     if (cache.size > ITUCACHE_MAX) {
       const oldest = cache.keys().next().value;
@@ -552,12 +552,12 @@ module.exports = function (app, ctx) {
 
   // Solar data cache — shared across all heatmap requests so band/mode/power
   // changes don't each trigger a slow NOAA fetch
-  let solarCache = { sfi: 150, ssn: 100, kIndex: 2, ts: 0 };
+  let solarCache = { sfi: 150, ssn: 100, kIndex: 2, timestamp: 0 };
   const SOLAR_CACHE_TTL = 15 * 60 * 1000; // 15 minutes
 
   async function getSolarData() {
     const now = Date.now();
-    if (now - solarCache.ts < SOLAR_CACHE_TTL) {
+    if (now - solarCache.timestamp < SOLAR_CACHE_TTL) {
       return { sfi: solarCache.sfi, ssn: solarCache.ssn, kIndex: solarCache.kIndex };
     }
     let sfi = 150,
@@ -593,7 +593,7 @@ module.exports = function (app, ctx) {
     } catch (e) {
       logDebug('[PropHeatmap] Using cached/default solar values');
     }
-    solarCache = { sfi, ssn, kIndex, ts: now };
+    solarCache = { sfi, ssn, kIndex, timestamp: now };
     return { sfi, ssn, kIndex };
   }
 
@@ -603,7 +603,7 @@ module.exports = function (app, ctx) {
 
     // Remove stale entries
     for (const key of Object.keys(cache)) {
-      if (now - cache[key].ts > ttlMs * 2) {
+      if (now - cache[key].timestamp > ttlMs * 2) {
         delete cache[key];
         purged++;
       }
@@ -613,7 +613,7 @@ module.exports = function (app, ctx) {
     const remaining = Object.keys(cache);
     if (remaining.length > maxEntries) {
       remaining
-        .sort((a, b) => cache[a].ts - cache[b].ts)
+        .sort((a, b) => cache[a].timestamp - cache[b].timestamp)
         .slice(0, remaining.length - maxEntries)
         .forEach((key) => {
           delete cache[key];
@@ -654,7 +654,7 @@ module.exports = function (app, ctx) {
     const cacheKey = `${deLat.toFixed(0)}:${deLon.toFixed(0)}:${freq}:${gridSize}:${txMode}:${txPower}:${antennaKey}`;
     const now = Date.now();
 
-    if (PROP_HEATMAP_CACHE[cacheKey] && now - PROP_HEATMAP_CACHE[cacheKey].ts < PROP_HEATMAP_TTL) {
+    if (PROP_HEATMAP_CACHE[cacheKey] && now - PROP_HEATMAP_CACHE[cacheKey].timestamp < PROP_HEATMAP_TTL) {
       return res.json(PROP_HEATMAP_CACHE[cacheKey].data);
     }
 
@@ -724,7 +724,7 @@ module.exports = function (app, ctx) {
         timestamp: new Date().toISOString(),
       };
 
-      PROP_HEATMAP_CACHE[cacheKey] = { data: result, ts: now };
+      PROP_HEATMAP_CACHE[cacheKey] = { data: result, timestamp: now };
 
       logDebug(
         `[PropHeatmap] Computed ${cells.length} cells for ${freq} MHz [${txMode} @ ${txPower}W] from ${deLat.toFixed(1)},${deLon.toFixed(1)}`,
@@ -761,7 +761,7 @@ module.exports = function (app, ctx) {
     const cacheKey = `muf-${deLat.toFixed(0)}:${deLon.toFixed(0)}:${gridSize}`;
     const now = Date.now();
 
-    if (MUF_MAP_CACHE[cacheKey] && now - MUF_MAP_CACHE[cacheKey].ts < MUF_MAP_TTL) {
+    if (MUF_MAP_CACHE[cacheKey] && now - MUF_MAP_CACHE[cacheKey].timestamp < MUF_MAP_TTL) {
       return res.json(MUF_MAP_CACHE[cacheKey].data);
     }
 
@@ -815,7 +815,7 @@ module.exports = function (app, ctx) {
         timestamp: new Date().toISOString(),
       };
 
-      MUF_MAP_CACHE[cacheKey] = { data: result, ts: now };
+      MUF_MAP_CACHE[cacheKey] = { data: result, timestamp: now };
       logDebug(`[MUFMap] Computed ${cells.length} cells from ${deLat.toFixed(1)},${deLon.toFixed(1)}`);
       res.json(result);
     } catch (error) {

--- a/server/routes/winlink.js
+++ b/server/routes/winlink.js
@@ -25,7 +25,7 @@ module.exports = function (app, ctx) {
   const { fetch, WINLINK_API_KEY, logInfo, logWarn, logErrorOnce } = ctx;
 
   // Full gateway list (no grid filter) — shared across all users, refreshed hourly.
-  let fullListCache = { data: null, ts: 0 };
+  let fullListCache = { data: null, timestamp: 0 };
   // Grid-scoped proximity results — keyed by `${grid}|${range}|${mode}`, shorter TTL.
   const proximityCache = new Map();
 
@@ -71,12 +71,12 @@ module.exports = function (app, ctx) {
   }
 
   async function getFullGatewayList() {
-    if (fullListCache.data && Date.now() - fullListCache.ts < CACHE_TTL_MS) {
+    if (fullListCache.data && Date.now() - fullListCache.timestamp < CACHE_TTL_MS) {
       return fullListCache.data;
     }
     const json = await fetchFromWinlink('/gateway/channel/report');
     const list = (json.Channels || []).map(normalizeRow);
-    fullListCache = { data: list, ts: Date.now() };
+    fullListCache = { data: list, timestamp: Date.now() };
     logInfo('[Winlink]', 'cached', list.length, 'gateways (global list)');
     return list;
   }
@@ -84,16 +84,16 @@ module.exports = function (app, ctx) {
   async function getProximity(grid, range) {
     const key = `${grid}|${range || 500}`;
     const hit = proximityCache.get(key);
-    if (hit && Date.now() - hit.ts < PROXIMITY_CACHE_TTL_MS) return hit.data;
+    if (hit && Date.now() - hit.timestamp < PROXIMITY_CACHE_TTL_MS) return hit.data;
     const json = await fetchFromWinlink(
       `/gateway/proximity.json?GridSquare=${encodeURIComponent(grid)}&MaxDistance=${Number(range) || 500}`,
     );
     const list = (json.GatewayList || []).map(normalizeRow);
-    proximityCache.set(key, { data: list, ts: Date.now() });
+    proximityCache.set(key, { data: list, timestamp: Date.now() });
     // Keep the proximity cache bounded — arbitrary 50 distinct queries is
     // plenty for a shared deployment and prevents slow memory growth.
     if (proximityCache.size > 50) {
-      const oldest = [...proximityCache.entries()].sort((a, b) => a[1].ts - b[1].ts)[0];
+      const oldest = [...proximityCache.entries()].sort((a, b) => a[1].timestamp - b[1].timestamp)[0];
       if (oldest) proximityCache.delete(oldest[0]);
     }
     return list;
@@ -105,7 +105,7 @@ module.exports = function (app, ctx) {
       apiKeyConfigured: keyConfigured(),
       cacheTtlSeconds: CACHE_TTL_MS / 1000,
       fullListCached: !!fullListCache.data,
-      fullListAge: fullListCache.ts ? Math.round((Date.now() - fullListCache.ts) / 1000) : null,
+      fullListAge: fullListCache.timestamp ? Math.round((Date.now() - fullListCache.timestamp) / 1000) : null,
       fullListSize: fullListCache.data?.length ?? 0,
     });
   });

--- a/server/routes/wsjtx.js
+++ b/server/routes/wsjtx.js
@@ -816,13 +816,13 @@ module.exports = function (app, ctx) {
   function pruneN3fjpQsos() {
     const cutoff = Date.now() - N3FJP_QSO_RETENTION_MINUTES * 60 * 1000;
     n3fjpQsos = n3fjpQsos.filter((q) => {
-      const t = Date.parse(q.ts_utc || q.ts || '');
+      const t = Date.parse(q.ts_utc || q.timestamp || '');
       return !Number.isNaN(t) && t >= cutoff;
     });
   }
 
   // Simple in-memory cache so we don't hammer callsign lookup on every QSO
-  const n3fjpCallCache = new Map(); // key=callsign, val={ts, result}
+  const n3fjpCallCache = new Map(); // key=callsign, val={timestamp, result}
   const N3FJP_CALL_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
   async function lookupCallLatLon(callsign) {
@@ -830,7 +830,7 @@ module.exports = function (app, ctx) {
     if (!call) return null;
 
     const cached = n3fjpCallCache.get(call);
-    if (cached && Date.now() - cached.ts < N3FJP_CALL_CACHE_TTL_MS) {
+    if (cached && Date.now() - cached.timestamp < N3FJP_CALL_CACHE_TTL_MS) {
       return cached.result;
     }
 
@@ -841,7 +841,7 @@ module.exports = function (app, ctx) {
 
       const data = await resp.json();
       if (typeof data.lat === 'number' && typeof data.lon === 'number') {
-        n3fjpCallCache.set(call, { ts: Date.now(), result: data });
+        n3fjpCallCache.set(call, { timestamp: Date.now(), result: data });
         return data;
       }
     } catch (e) {

--- a/server/utils/cache.js
+++ b/server/utils/cache.js
@@ -21,10 +21,6 @@ const maintainCache = (cache, ttlMs, maxEntries, label = 'Cache') => {
         purged++;
       });
   }
-
-  if (purged > 0) {
-    logDebug(`[${label}] purged ${purged} stale entries, ${Object.keys(cache).length} remaining`);
-  }
 };
 
 module.exports = { maintainCache };

--- a/server/utils/cache.js
+++ b/server/utils/cache.js
@@ -1,0 +1,30 @@
+const maintainCache = (cache, ttlMs, maxEntries, label = 'Cache') => {
+  const now = Date.now();
+  let purged = 0;
+
+  // Remove stale entries
+  for (const key of Object.keys(cache)) {
+    if (now - cache[key].timestamp > ttlMs * 2) {
+      delete cache[key];
+      purged++;
+    }
+  }
+
+  // Enforce max size by evicting oldest
+  const remaining = Object.keys(cache);
+  if (remaining.length > maxEntries) {
+    remaining
+      .sort((a, b) => cache[a].timestamp - cache[b].timestamp)
+      .slice(0, remaining.length - maxEntries)
+      .forEach((key) => {
+        delete cache[key];
+        purged++;
+      });
+  }
+
+  if (purged > 0) {
+    logDebug(`[${label}] purged ${purged} stale entries, ${Object.keys(cache).length} remaining`);
+  }
+};
+
+module.exports = { maintainCache };

--- a/server/utils/dxNewsMerge.test.js
+++ b/server/utils/dxNewsMerge.test.js
@@ -259,10 +259,10 @@ describe('recency sort', () => {
       NOW.getTime() - 3 * 3600 * 1000,
       NOW.getTime() - 7 * 3600 * 1000,
     ];
-    const items = timestamps.map((ts, i) => ({
+    const items = timestamps.map((timestamp, i) => ({
       id: `dxnews:item${i}`,
       title: `Item ${i}`,
-      publishDate: new Date(ts).toISOString(),
+      publishDate: new Date(timestamp).toISOString(),
       callsign: null,
       source: 'DXNEWS',
       sourceUrl: 'https://dxnews.com/',


### PR DESCRIPTION
## What does this PR do?

closes https://github.com/accius/openhamclock/issues/947

- Created `server/utils/cache.js` with `maintainCache(...)` functionality. Removed existing definitions of same function.
- Load `maintainCache` in `server.js` and pass in `ctx` object.
- Validated that `emcomm.js` and `propagation.js` are able to call `maintainCache(...)` in `cache.js`
- So that all components follow a standard pattern, identified in `/server/**` any use of `.ts` as a field name in a cache and rename from `.ts` to `.timestamp`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [X] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin
