### PR TITLE
Hotfix: guard PropagationPanel against empty/invalid timeZone (RangeError on first load)

### DIFF
--- a/src/components/PropagationPanel.jsx
+++ b/src/components/PropagationPanel.jsx
@@ -2,7 +2,7 @@
  * PropagationPanel Component (VOACAP)
  * Toggleable between heatmap chart, bar chart, and band conditions view
  */
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatDistance } from '../utils/geo.js';
 import { saveConfig, loadConfig } from '../utils/config.js';
@@ -124,6 +124,18 @@ export const PropagationPanel = ({
   // Auto-rotate through views on a timer
   const rotate = useAutoRotate('propPanel', { onTick: cycleViewMode, itemCount: modes.length });
 
+  // Empty/invalid `timeZone` (e.g. fresh installs default to '') would make
+  // toLocaleString throw RangeError on every render — fall back to browser TZ.
+  const safeTimeZone = useMemo(() => {
+    if (!timeZone) return undefined;
+    try {
+      new Intl.DateTimeFormat(undefined, { timeZone });
+      return timeZone;
+    } catch {
+      return undefined;
+    }
+  }, [timeZone]);
+
   const getBandStyle = (condition) =>
     ({
       GOOD: { bg: 'rgba(0,255,136,0.2)', color: '#00ff88', border: 'rgba(0,255,136,0.4)' },
@@ -145,15 +157,9 @@ export const PropagationPanel = ({
   const { solarData, distance, currentBands, hourlyPredictions, muf, luf, dataSource } = propagation;
   const currentHour = propagation.currentHour ?? new Date().getUTCHours();
   const currentLocalMin = function () {
-    let [hr, mn] = currentTime
-      .toLocaleString('en-US', {
-        timeZone: timeZone,
-        hour12: false,
-        hour: 'numeric',
-        minute: 'numeric',
-      })
-      .split(':')
-      .map(Number);
+    const opts = { hour12: false, hour: 'numeric', minute: 'numeric' };
+    if (safeTimeZone) opts.timeZone = safeTimeZone;
+    let [hr, mn] = currentTime.toLocaleString('en-US', opts).split(':').map(Number);
     return (hr % 24) * 60 + mn;
   };
   const isDaytime =

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -34,7 +34,7 @@ export const DEFAULT_CONFIG = {
   theme: 'dark', // 'dark', 'light', 'legacy', or 'retro'
   layout: 'modern', // 'modern' or 'classic'
   mouseZoom: 50, // Factor to affect rate of zooming with scrollwheel (1-100)
-  timezone: '', // IANA timezone (e.g. 'America/Regina') — empty = browser default
+  timezone: '', // IANA timezone (e.g. 'America/Regina') — empty means consumers must fall back to browser default themselves; passing '' to Intl.DateTimeFormat throws RangeError
   use12Hour: true,
   swapHeaderClocks: false, // false = UTC first, true = Local first
   showMutualReception: true, // Show gold star on PSK spots with mutual reception


### PR DESCRIPTION
## Summary

Same-day hotfix for the `RangeError: invalid time zone specified` regression that surfaced after v26.3.1 hit production (PR #956). Reported by users and traced on PR #912 — see https://github.com/accius/openhamclock/pull/912#issuecomment-4394039157.

## Root cause

`PropagationPanel.jsx` passed the raw `config.timezone` straight into `toLocaleString({ timeZone })`, and `DEFAULT_CONFIG.timezone` is `''`. `Intl.DateTimeFormat({ timeZone: '' })` does not fall back to the browser default — it throws `RangeError`. Any user with an empty/missing timezone in localStorage took the panel down on every render.

## Fix

Mirrors the `safeTimezone` validation already present in `useTimeState.js:107-115`:

```js
const safeTimeZone = useMemo(() => {
  if (!timeZone) return undefined;
  try {
    new Intl.DateTimeFormat(undefined, { timeZone });
    return timeZone;
  } catch {
    return undefined;
  }
}, [timeZone]);
```

…and only sets `opts.timeZone` when `safeTimeZone` is truthy. When undefined, `toLocaleString` correctly uses the browser's default IANA zone.

Also corrected the misleading `// empty = browser default` comment on `DEFAULT_CONFIG.timezone` so future readers don't repeat the same mistake.

## What I deliberately didn't do

- **No version bump.** Hash-busted bundle reaches users on next load via Vite's content hashes; skipping the version bump avoids re-popping the WhatsNew modal hours after v26.3.1's modal already fired.
- **No new test.** Single small render-path guard, mirroring an existing validated pattern.

## Test plan

- [x] `npx vitest run` — 289/289 pass
- [x] `npx vite build` — clean
- [ ] Smoke-test in production: landing on a fresh browser profile (no localStorage) should render the propagation panel without console errors
- [ ] Verify users still seeing the error get unstuck on next reload (no manual cache clear required)