### PR TITLE
fix(update): use npm ci to prevent stale node_modules after update

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -223,12 +223,14 @@ done
 
 echo ""
 echo "📦 Installing dependencies..."
-# --include=dev ensures vite is installed even if NODE_ENV=production.
+# npm ci deletes node_modules and reinstalls from the lockfile exactly,
+# preventing stale packages from surviving across updates (e.g. a newly added
+# production dependency not appearing in an existing node_modules tree).
 # --ignore-scripts skips postinstall hooks that fail on Linux/Pi (e.g.
 # electron-winstaller copying Windows-only binaries).
 # ELECTRON_SKIP_BINARY_DOWNLOAD=1 avoids downloading the ~200 MB Electron
 # binary which is not needed for the server/kiosk build.
-ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm install --include=dev --ignore-scripts
+ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm ci --ignore-scripts
 
 echo ""
 echo "📦 Downloading vendor assets..."


### PR DESCRIPTION
## Summary

- Replaces `npm install --include=dev` with `npm ci` in `scripts/update.sh`
- `npm ci` wipes `node_modules` before installing, so newly added production dependencies (like `rss-parser` in v26.3.x) are guaranteed to be present after an update
- Fixes a user-reported issue where updating via `update.sh` left `rss-parser` absent, causing `[FATAL] Cannot find module 'rss-parser'` on service restart; re-running `setup-pi.sh` (which writes into a clean tree) resolved it

## Test plan

- [ ] Run `update.sh` on a Pi with an existing install from before `rss-parser` was added and confirm the service starts cleanly
- [ ] Confirm `npm ci` fails fast if `package.json` and `package-lock.json` are out of sync (expected safety net behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)