### PR TITLE
Issue951 maidenhead grid to utils geo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "26.3.1",
       "license": "MIT",
       "dependencies": {
-        "@hamset/maidenhead-locator": "^0.2.1",
         "axios": "^1.6.2",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
@@ -1387,12 +1386,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@hamset/maidenhead-locator": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@hamset/maidenhead-locator/-/maidenhead-locator-0.2.1.tgz",
-      "integrity": "sha512-vE6mLwKrqIDu6ldepKnzv7uXCrHn9GpBIW9/T6P+STb4gwbXJ3ok0v8PSje5u8QG47AUzvlMflMkX1/KVpyD3g==",
-      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "prepare": "husky || true"
   },
   "dependencies": {
-    "@hamset/maidenhead-locator": "^0.2.1",
     "axios": "^1.6.2",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/server/config.js
+++ b/server/config.js
@@ -5,6 +5,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { maidenheadToLatLon } = require('../server/utils/grid');
 
 const ROOT_DIR = path.join(__dirname, '..');
 
@@ -44,30 +45,6 @@ if (fs.existsSync(envPath)) {
   console.log('[Config] Loaded configuration from .env file');
 }
 
-// Convert Maidenhead grid locator to lat/lon (used only during config init)
-function gridToLatLon(grid) {
-  if (!grid || grid.length < 4) return null;
-
-  grid = grid.toUpperCase();
-  const lon = (grid.charCodeAt(0) - 65) * 20 - 180;
-  const lat = (grid.charCodeAt(1) - 65) * 10 - 90;
-  const lon2 = parseInt(grid[2]) * 2;
-  const lat2 = parseInt(grid[3]);
-
-  let longitude = lon + lon2 + 1; // Center of grid
-  let latitude = lat + lat2 + 0.5;
-
-  // 6-character grid for more precision
-  if (grid.length >= 6) {
-    const lon3 = (grid.charCodeAt(4) - 65) * (2 / 24);
-    const lat3 = (grid.charCodeAt(5) - 65) * (1 / 24);
-    longitude = lon + lon2 + lon3 + 1 / 24;
-    latitude = lat + lat2 + lat3 + 0.5 / 24;
-  }
-
-  return { latitude, longitude };
-}
-
 const PORT = Number(process.env.PORT) || 3000;
 const HOST = process.env.HOST || '0.0.0.0';
 
@@ -104,10 +81,10 @@ let stationLat = parseFloat(process.env.LATITUDE);
 let stationLon = parseFloat(process.env.LONGITUDE);
 
 if ((!Number.isFinite(stationLat) || !Number.isFinite(stationLon)) && locator) {
-  const coords = gridToLatLon(locator);
+  const coords = maidenheadToLatLon(locator);
   if (coords) {
-    stationLat = Number.isFinite(stationLat) ? stationLat : coords.latitude;
-    stationLon = Number.isFinite(stationLon) ? stationLon : coords.longitude;
+    stationLat = Number.isFinite(stationLat) ? stationLat : coords.lat;
+    stationLon = Number.isFinite(stationLon) ? stationLon : coords.lon;
   }
 }
 

--- a/server/routes/callsign.js
+++ b/server/routes/callsign.js
@@ -6,7 +6,7 @@
 const fs = require('fs');
 const path = require('path');
 const { lookupCall } = require('../../src/server/ctydat.js');
-const { maidenheadToLatLon } = require('../utils/grid.js');
+const { maidenheadToLatLon, validateGridLocator } = require('../utils/grid.js');
 
 module.exports = function (app, ctx) {
   const {
@@ -618,7 +618,7 @@ module.exports = function (app, ctx) {
       const grid1 = dualGridMatch[1].toUpperCase();
       const grid2 = dualGridMatch[2].toUpperCase();
       // Validate both are real grids
-      if (isValidGrid(grid1) && isValidGrid(grid2)) {
+      if (validateGridLocator(grid1) && validateGridLocator(grid2)) {
         return { spotterGrid: grid1, dxGrid: grid2 };
       }
     }
@@ -629,7 +629,7 @@ module.exports = function (app, ctx) {
     let match;
     while ((match = gridPattern.exec(comment)) !== null) {
       const grid = match[1].toUpperCase();
-      if (isValidGrid(grid)) {
+      if (validateGridLocator(grid)) {
         grids.push(grid);
       }
     }
@@ -645,15 +645,6 @@ module.exports = function (app, ctx) {
     }
 
     return { spotterGrid: null, dxGrid: null };
-  }
-
-  // Validate a grid square is realistic (not "CQ00", "DE12", etc)
-  function isValidGrid(grid) {
-    if (!grid || grid.length < 4) return false;
-    const firstChar = grid.charCodeAt(0);
-    const secondChar = grid.charCodeAt(1);
-    // First char should be A-R, second char should be A-R
-    return firstChar >= 65 && firstChar <= 82 && secondChar >= 65 && secondChar <= 82;
   }
 
   // Legacy single-grid extraction (kept for compatibility)
@@ -1925,7 +1916,6 @@ module.exports = function (app, ctx) {
     estimateLocationFromPrefix,
     extractGridFromComment,
     extractGridsFromComment,
-    isValidGrid,
     getCountryFromPrefix,
     cacheCallsignLookup,
     callsignLookupCache,

--- a/server/routes/callsign.js
+++ b/server/routes/callsign.js
@@ -6,6 +6,7 @@
 const fs = require('fs');
 const path = require('path');
 const { lookupCall } = require('../../src/server/ctydat.js');
+const { maidenheadToLatLon } = require('../utils/grid.js');
 
 module.exports = function (app, ctx) {
   const {
@@ -603,58 +604,6 @@ module.exports = function (app, ctx) {
       res.status(500).json({ error: 'Lookup failed' });
     }
   });
-
-  // Convert Maidenhead grid locator to lat/lon (center of grid square)
-  function maidenheadToLatLon(grid) {
-    if (!grid || typeof grid !== 'string') return null;
-
-    grid = grid.toUpperCase().trim();
-
-    // Validate grid format (2, 4, 6, or 8 characters)
-    if (!/^[A-R]{2}([0-9]{2}([A-X]{2}([0-9]{2})?)?)?$/.test(grid)) return null;
-
-    let lon = -180;
-    let lat = -90;
-
-    // Field (2 chars): 20° lon x 10° lat
-    lon += (grid.charCodeAt(0) - 65) * 20;
-    lat += (grid.charCodeAt(1) - 65) * 10;
-
-    if (grid.length >= 4) {
-      // Square (2 digits): 2° lon x 1° lat
-      lon += parseInt(grid[2]) * 2;
-      lat += parseInt(grid[3]) * 1;
-    }
-
-    if (grid.length >= 6) {
-      // Subsquare (2 chars): 5' lon x 2.5' lat
-      lon += (grid.charCodeAt(4) - 65) * (5 / 60);
-      lat += (grid.charCodeAt(5) - 65) * (2.5 / 60);
-    }
-
-    if (grid.length >= 8) {
-      // Extended square (2 digits): 0.5' lon x 0.25' lat
-      lon += parseInt(grid[6]) * (0.5 / 60);
-      lat += parseInt(grid[7]) * (0.25 / 60);
-    }
-
-    // Add offset to center of the grid square
-    if (grid.length === 2) {
-      lon += 10;
-      lat += 5;
-    } else if (grid.length === 4) {
-      lon += 1;
-      lat += 0.5;
-    } else if (grid.length === 6) {
-      lon += 2.5 / 60;
-      lat += 1.25 / 60;
-    } else if (grid.length === 8) {
-      lon += 0.25 / 60;
-      lat += 0.125 / 60;
-    }
-
-    return { lat, lon, grid };
-  }
 
   // Try to extract grid locators from a comment string
   // Returns { spotterGrid, dxGrid } - may have one, both, or neither
@@ -1974,7 +1923,6 @@ module.exports = function (app, ctx) {
     extractBaseCallsign,
     extractOperatingPrefix,
     estimateLocationFromPrefix,
-    maidenheadToLatLon,
     extractGridFromComment,
     extractGridsFromComment,
     isValidGrid,

--- a/server/routes/dxcluster.js
+++ b/server/routes/dxcluster.js
@@ -5,7 +5,7 @@
 
 const dgram = require('dgram');
 const net = require('net');
-const { gridToLatLon, getBandFromKHz } = require('../utils/grid');
+const { maidenheadToLatLon } = require('../utils/grid.js');
 const { areDXPathsDuplicate } = require('../utils/dxClusterPathIdentity');
 const { isPrivateIP, validateCustomHost } = require('../utils/ssrf');
 
@@ -21,10 +21,8 @@ module.exports = function (app, ctx) {
     extractBaseCallsign,
     extractOperatingPrefix,
     estimateLocationFromPrefix,
-    maidenheadToLatLon,
     extractGridFromComment,
     extractGridsFromComment,
-    isValidGrid,
     getCountryFromPrefix,
     cacheCallsignLookup,
     callsignLookupCache,

--- a/server/routes/n1mm.js
+++ b/server/routes/n1mm.js
@@ -4,6 +4,7 @@
  */
 
 const dgram = require('dgram');
+const { maidenheadToLatLon } = require('../utils/grid');
 
 module.exports = function (app, ctx) {
   const {
@@ -14,7 +15,6 @@ module.exports = function (app, ctx) {
     logErrorOnce,
     writeLimiter,
     requireWriteAuth,
-    maidenheadToLatLon,
     extractBaseCallsign,
     estimateLocationFromPrefix,
     extractGridFromComment,

--- a/server/routes/propagation.js
+++ b/server/routes/propagation.js
@@ -14,7 +14,6 @@ module.exports = function (app, ctx) {
     logWarn,
     logErrorOnce,
     upstream,
-    maidenheadToLatLon,
     n0nbhCache,
     maintainCache,
   } = ctx;

--- a/server/routes/pskreporter.js
+++ b/server/routes/pskreporter.js
@@ -4,7 +4,7 @@
  */
 
 const mqttLib = require('mqtt');
-const { gridToLatLon, getBandFromHz } = require('../utils/grid');
+const { maidenheadToLatLon, getBandFromHz } = require('../utils/grid');
 
 module.exports = function (app, ctx) {
   const {
@@ -164,30 +164,6 @@ module.exports = function (app, ctx) {
 
   // NOTE: PSKReporter spots are now handled entirely through the MQTT proxy system
   // (pskMqtt.recentSpots and pskMqtt.spotBuffer), not this legacy cache.
-
-  // Convert grid square to lat/lon
-  function gridToLatLonSimple(grid) {
-    if (!grid || grid.length < 4) return null;
-
-    const g = grid.toUpperCase();
-    const lon = (g.charCodeAt(0) - 65) * 20 - 180;
-    const lat = (g.charCodeAt(1) - 65) * 10 - 90;
-    const lonMin = parseInt(g[2]) * 2;
-    const latMin = parseInt(g[3]) * 1;
-
-    let finalLon = lon + lonMin + 1;
-    let finalLat = lat + latMin + 0.5;
-
-    // If 6-character grid, add more precision
-    if (grid.length >= 6) {
-      const lonSec = (g.charCodeAt(4) - 65) * (2 / 24);
-      const latSec = (g.charCodeAt(5) - 65) * (1 / 24);
-      finalLon = lon + lonMin + lonSec + 1 / 24;
-      finalLat = lat + latMin + latSec + 0.5 / 24;
-    }
-
-    return { lat: finalLat, lon: finalLon };
-  }
 
   // Get band name from frequency in Hz
   function getBandFromHz(freqHz) {
@@ -366,8 +342,8 @@ module.exports = function (app, ctx) {
         };
 
         // Add lat/lon based on grid for both directions
-        const senderLoc = gridToLatLonSimple(sl);
-        const receiverLoc = gridToLatLonSimple(rl);
+        const senderLoc = maidenheadToLatLon(sl);
+        const receiverLoc = maidenheadToLatLon(rl);
 
         pskMqtt.stats.spotsReceived++;
         pskMqtt.stats.lastSpotTime = now;

--- a/server/routes/pskreporter.js
+++ b/server/routes/pskreporter.js
@@ -15,7 +15,6 @@ module.exports = function (app, ctx) {
     logWarn,
     logErrorOnce,
     upstream,
-    maidenheadToLatLon,
     extractBaseCallsign,
     estimateLocationFromPrefix,
     cacheCallsignLookup,

--- a/server/routes/rbn.js
+++ b/server/routes/rbn.js
@@ -4,14 +4,7 @@
  */
 
 const net = require('net');
-const {
-  maidenheadToLatLon,
-  gridToLatLon,
-  latLonToGrid,
-  getBandFromHz,
-  getBandFromKHz,
-  haversineDistance,
-} = require('../utils/grid');
+const { maidenheadToLatLon, latLonToGrid, getBandFromHz, getBandFromKHz, haversineDistance } = require('../utils/grid');
 
 module.exports = function (app, ctx) {
   const {
@@ -860,8 +853,8 @@ module.exports = function (app, ctx) {
 
             if (band !== 'all' && spotBand !== band) continue;
 
-            const senderLoc = gridToLatLon(senderLocator);
-            const receiverLoc = gridToLatLon(receiverLocator);
+            const senderLoc = maidenheadToLatLon(senderLocator);
+            const receiverLoc = maidenheadToLatLon(receiverLocator);
 
             if (senderLoc && receiverLoc) {
               const powerWatts = power ? parseFloat(power) : null;

--- a/server/routes/rbn.js
+++ b/server/routes/rbn.js
@@ -4,7 +4,13 @@
  */
 
 const net = require('net');
-const { maidenheadToLatLon, latLonToGrid, getBandFromHz, getBandFromKHz, haversineDistance } = require('../utils/grid');
+const {
+  maidenheadToLatLon,
+  latLonToMaidenhead,
+  getBandFromHz,
+  getBandFromKHz,
+  haversineDistance,
+} = require('../utils/grid');
 
 module.exports = function (app, ctx) {
   const {
@@ -26,29 +32,6 @@ module.exports = function (app, ctx) {
   // ============================================
   // REVERSE BEACON NETWORK (RBN) API
   // ============================================
-
-  // Convert lat/lon to Maidenhead grid (6-character)
-  function latLonToGrid(lat, lon) {
-    if (!isFinite(lat) || !isFinite(lon)) return null;
-
-    // Adjust longitude to 0-360 range
-    let adjLon = lon + 180;
-    let adjLat = lat + 90;
-
-    // Field (2 chars): 20° lon x 10° lat
-    const field1 = String.fromCharCode(65 + Math.floor(adjLon / 20));
-    const field2 = String.fromCharCode(65 + Math.floor(adjLat / 10));
-
-    // Square (2 digits): 2° lon x 1° lat
-    const square1 = Math.floor((adjLon % 20) / 2);
-    const square2 = Math.floor((adjLat % 10) / 1);
-
-    // Subsquare (2 chars): 5' lon x 2.5' lat
-    const subsq1 = String.fromCharCode(65 + Math.floor(((adjLon % 2) * 60) / 5));
-    const subsq2 = String.fromCharCode(65 + Math.floor(((adjLat % 1) * 60) / 2.5));
-
-    return `${field1}${field2}${square1}${square2}${subsq1}${subsq2}`.toUpperCase();
-  }
 
   // Persistent RBN connection and spot storage
   let rbnConnection = null;
@@ -333,7 +316,7 @@ module.exports = function (app, ctx) {
                 logDebug(
                   `[RBN] Location sanity check FAILED for ${skimmerCall}: lookup=${locationData.lat.toFixed(1)},${locationData.lon.toFixed(1)} vs prefix=${prefixCoords.lat.toFixed(1)},${prefixCoords.lon.toFixed(1)} (${Math.round(dist)} km apart) — using prefix`,
                 );
-                const grid = latLonToGrid(prefixCoords.lat, prefixCoords.lon);
+                const grid = latLonToMaidenhead({ lat: prefixCoords.lat, lon: prefixCoords.lon });
                 const location = {
                   callsign: skimmerCall,
                   grid: grid,
@@ -353,7 +336,7 @@ module.exports = function (app, ctx) {
             }
           }
 
-          const grid = latLonToGrid(locationData.lat, locationData.lon);
+          const grid = latLonToMaidenhead({ lat: locationData.lat, lon: locationData.lon });
 
           const location = {
             callsign: skimmerCall,
@@ -417,7 +400,7 @@ module.exports = function (app, ctx) {
           Math.abs(locationData.lat) <= 90 &&
           Math.abs(locationData.lon) <= 180
         ) {
-          const grid = latLonToGrid(locationData.lat, locationData.lon);
+          const grid = latLonToMaidenhead({ lat: locationData.lat, lon: locationData.lon });
           const location = {
             callsign: dxCall,
             grid: grid,
@@ -574,7 +557,7 @@ module.exports = function (app, ctx) {
       const response = await fetch(`http://localhost:${PORT}/api/callsign/${encodeURIComponent(callsign)}`);
       if (response.ok) {
         const locationData = await response.json();
-        const grid = latLonToGrid(locationData.lat, locationData.lon);
+        const grid = latLonToMaidenhead({ lat: locationData.lat, lon: locationData.lon });
 
         const result = {
           callsign: callsign,

--- a/server/routes/rbn.js
+++ b/server/routes/rbn.js
@@ -4,7 +4,14 @@
  */
 
 const net = require('net');
-const { gridToLatLon, latLonToGrid, getBandFromHz, getBandFromKHz, haversineDistance } = require('../utils/grid');
+const {
+  maidenheadToLatLon,
+  gridToLatLon,
+  latLonToGrid,
+  getBandFromHz,
+  getBandFromKHz,
+  haversineDistance,
+} = require('../utils/grid');
 
 module.exports = function (app, ctx) {
   const {
@@ -16,7 +23,6 @@ module.exports = function (app, ctx) {
     logWarn,
     logErrorOnce,
     upstream,
-    maidenheadToLatLon,
     extractBaseCallsign,
     hamqthLookup,
     callsignLookupCache,

--- a/server/routes/wsjtx.js
+++ b/server/routes/wsjtx.js
@@ -7,7 +7,7 @@ const dgram = require('dgram');
 const fs = require('fs');
 const path = require('path');
 const { initCtyData, getCtyData, lookupCall } = require('../../src/server/ctydat.js');
-const { maidenheadToLatLon, gridToLatLon, getBandFromHz } = require('../utils/grid');
+const { maidenheadToLatLon, getBandFromHz } = require('../utils/grid.js');
 
 module.exports = function (app, ctx) {
   const {
@@ -411,7 +411,7 @@ module.exports = function (app, ctx) {
 
       // Cache this callsign's grid for future lookups
       if (result.caller && result.grid) {
-        const coords = gridToLatLon(result.grid);
+        const coords = maidenheadToLatLon(result.grid);
         if (coords) {
           wsjtxGridCache.set(result.caller.toUpperCase(), {
             grid: result.grid,
@@ -439,13 +439,13 @@ module.exports = function (app, ctx) {
       if (gridMatch && isGrid(gridMatch[1])) {
         result.grid = gridMatch[1];
         // Cache grid — in exchange it typically belongs to the calling station (dxCall)
-        const coords = gridToLatLon(result.grid);
+        const coords = maidenheadToLatLon(result.grid);
         if (coords) {
           const call = (result.deCall == CONFIG.callsign ? result.dxCall : result.deCall).toUpperCase();
           wsjtxGridCache.set(call, {
             grid: result.grid,
-            lat: coords.latitude,
-            lon: coords.longitude,
+            lat: coords.lat,
+            lon: coords.lon,
             timestamp: Date.now(),
           });
         }
@@ -521,7 +521,7 @@ module.exports = function (app, ctx) {
         if (dxCall) {
           // 1. Try dxGrid from WSJT-X (if it knows the DX station's grid)
           if (dxGrid) {
-            const coords = gridToLatLon(dxGrid);
+            const coords = maidenheadToLatLon(dxGrid);
             if (coords !== null) {
               dxLat = coords.lat;
               dxLon = coords.lon;
@@ -621,10 +621,10 @@ module.exports = function (app, ctx) {
 
         // Resolve grid to lat/lon for map plotting
         if (parsed.grid) {
-          const coords = gridToLatLon(parsed.grid);
+          const coords = maidenheadToLatLon(parsed.grid);
           if (coords) {
-            decode.lat = coords.latitude;
-            decode.lon = coords.longitude;
+            decode.lat = coords.lat;
+            decode.lon = coords.lon;
           }
         }
 
@@ -750,10 +750,10 @@ module.exports = function (app, ctx) {
         };
         // Resolve grid to lat/lon
         if (msg.dxGrid) {
-          const coords = gridToLatLon(msg.dxGrid);
+          const coords = maidenheadToLatLon(msg.dxGrid);
           if (coords) {
-            qso.lat = coords.latitude;
-            qso.lon = coords.longitude;
+            qso.lat = coords.lat;
+            qso.lon = coords.lon;
           }
         }
         // Deduplicate: skip if same call + freq + mode within 60 seconds
@@ -788,10 +788,10 @@ module.exports = function (app, ctx) {
         };
         // Resolve grid to lat/lon for map plotting
         if (msg.grid) {
-          const coords = gridToLatLon(msg.grid);
+          const coords = maidenheadToLatLon(msg.grid);
           if (coords) {
-            wsprDecode.lat = coords.latitude;
-            wsprDecode.lon = coords.longitude;
+            wsprDecode.lat = coords.lat;
+            wsprDecode.lon = coords.lon;
           }
         }
         if (msg.isNew) {

--- a/server/routes/wsjtx.js
+++ b/server/routes/wsjtx.js
@@ -7,7 +7,7 @@ const dgram = require('dgram');
 const fs = require('fs');
 const path = require('path');
 const { initCtyData, getCtyData, lookupCall } = require('../../src/server/ctydat.js');
-const { gridToLatLon, getBandFromHz } = require('../utils/grid');
+const { maidenheadToLatLon, gridToLatLon, getBandFromHz } = require('../utils/grid');
 
 module.exports = function (app, ctx) {
   const {
@@ -21,7 +21,6 @@ module.exports = function (app, ctx) {
     logErrorOnce,
     writeLimiter,
     requireWriteAuth,
-    maidenheadToLatLon,
     extractBaseCallsign,
     estimateLocationFromPrefix,
     extractGridFromComment,

--- a/server/utils/grid.js
+++ b/server/utils/grid.js
@@ -137,43 +137,6 @@ const latLonToMaidenhead = ({ lat, lon }, precision = 6) => {
 };
 
 /**
- * Convert Maidenhead grid locator to lat/lon.
- * Supports 4-char and 6-char grids. Case-insensitive.
- * @param {string} grid - Grid locator (e.g., 'DM79' or 'DM79lv')
- * @returns {{ lat: number, lon: number } | null}
- */
-function gridToLatLon(grid) {
-  if (!grid) return null;
-  const g = String(grid).trim().toUpperCase();
-  if (g.length < 4) return null;
-
-  const A = 'A'.charCodeAt(0);
-
-  const lonField = g.charCodeAt(0) - A;
-  const latField = g.charCodeAt(1) - A;
-  const lonSquare = parseInt(g[2], 10);
-  const latSquare = parseInt(g[3], 10);
-  if (!Number.isFinite(lonSquare) || !Number.isFinite(latSquare)) return null;
-
-  let lon = -180 + lonField * 20 + lonSquare * 2;
-  let lat = -90 + latField * 10 + latSquare * 1;
-
-  if (g.length >= 6) {
-    const lonSub = g.charCodeAt(4) - A;
-    const latSub = g.charCodeAt(5) - A;
-    lon += lonSub * (2 / 24);
-    lat += latSub * (1 / 24);
-    lon += 1 / 24;
-    lat += 0.5 / 24;
-  } else {
-    lon += 1.0;
-    lat += 0.5;
-  }
-
-  return { lat, lon };
-}
-
-/**
  * Convert lat/lon to Maidenhead grid locator (6-character).
  */
 function latLonToGrid(lat, lon) {
@@ -241,7 +204,6 @@ module.exports = {
   maidenheadToLatLon,
   latLonToMaidenhead,
   maidenheadToBoundingBox,
-  gridToLatLon,
   latLonToGrid,
   getBandFromHz,
   getBandFromKHz,

--- a/server/utils/grid.js
+++ b/server/utils/grid.js
@@ -137,25 +137,6 @@ const latLonToMaidenhead = ({ lat, lon }, precision = 6) => {
 };
 
 /**
- * Convert lat/lon to Maidenhead grid locator (6-character).
- */
-function latLonToGrid(lat, lon) {
-  if (!isFinite(lat) || !isFinite(lon)) return null;
-
-  let adjLon = lon + 180;
-  let adjLat = lat + 90;
-
-  const field1 = String.fromCharCode(65 + Math.floor(adjLon / 20));
-  const field2 = String.fromCharCode(65 + Math.floor(adjLat / 10));
-  const square1 = Math.floor((adjLon % 20) / 2);
-  const square2 = Math.floor((adjLat % 10) / 1);
-  const subsq1 = String.fromCharCode(65 + Math.floor(((adjLon % 2) * 60) / 5));
-  const subsq2 = String.fromCharCode(65 + Math.floor(((adjLat % 1) * 60) / 2.5));
-
-  return `${field1}${field2}${square1}${square2}${subsq1}${subsq2}`.toUpperCase();
-}
-
-/**
  * Get amateur radio band name from frequency in Hz.
  */
 function getBandFromHz(freqHz) {
@@ -204,7 +185,6 @@ module.exports = {
   maidenheadToLatLon,
   latLonToMaidenhead,
   maidenheadToBoundingBox,
-  latLonToGrid,
   getBandFromHz,
   getBandFromKHz,
   haversineDistance,

--- a/server/utils/grid.js
+++ b/server/utils/grid.js
@@ -1,7 +1,140 @@
 /**
  * Grid locator (Maidenhead) and frequency/band utilities.
- * Consolidates duplicate grid conversion functions that were scattered across server.js.
  */
+
+/**
+ * Validate Maidenhead grid locator, can be 2, 4, 6, or 8 characters long, e.g. DM, DM12, DM12kv, or DM12kv99 are all valid locators.
+ * @param gridLocator Maidenhead grid locator
+ * @returns true if the grid locator is valid, else false
+ */
+const validateGridLocator = (gridLocator) => {
+  if (!gridLocator || typeof gridLocator !== 'string') return false;
+  if (gridLocator.length < 2 || gridLocator.length > 8) return false;
+  if (gridLocator.length % 2 !== 0) return false;
+  const regex = /^[A-R]{2}([0-9]{2}([A-Xa-x]{2}([0-9]{2})?)?)?$/;
+  return regex.test(gridLocator);
+};
+
+/**
+ * Convert Maidenhead grid locator to latitude/longitude coordinates
+ * @param grid Maidenhead grid locator
+ * @returns Latitude and longitude coordinates
+ */
+const maidenheadToLatLon = (grid) => {
+  const bbox = maidenheadToBoundingBox(grid);
+  if (!bbox || bbox.length !== 2 || bbox[0].length !== 2 || bbox[1].length !== 2) return null;
+  const lat = (bbox[0][0] + bbox[1][0]) / 2;
+  const lon = (bbox[0][1] + bbox[1][1]) / 2;
+  return { lat, lon };
+};
+
+/**
+ * Convert Maidenhead grid square to lat/lon bounding box coordinates, [SW, NE] corners
+ * @param grid Maidenhead grid locator
+ * @returns A two-dimensional array containing two diagonal coordinates of bounds
+ */
+const maidenheadToBoundingBox = (grid) => {
+  if (!grid || !validateGridLocator(grid)) return null;
+
+  const gridUpper = grid.toUpperCase();
+  let minLat = -90;
+  let maxLat = 90;
+  let minLon = -180;
+  let maxLon = 180;
+
+  // Field (2 chars): 20° lon x 10° lat
+  if (gridUpper.length >= 2) {
+    const fieldLat = gridUpper.charCodeAt(1) - 65; // A-R
+    const fieldLon = gridUpper.charCodeAt(0) - 65; // A-R
+
+    minLat += fieldLat * 10;
+    maxLat = minLat + 10;
+    minLon += fieldLon * 20;
+    maxLon = minLon + 20;
+  }
+
+  // Square (2 digits): 2° lon x 1° lat
+  if (gridUpper.length >= 4) {
+    const sqLon = parseInt(gridUpper[2]);
+    const sqLat = parseInt(gridUpper[3]);
+
+    minLon += sqLon * 2;
+    maxLon = minLon + 2;
+    minLat += sqLat * 1;
+    maxLat = minLat + 1;
+  }
+
+  // Subsquare (2 chars): 5' lon x 2.5' lat
+  if (gridUpper.length >= 6) {
+    const subLat = gridUpper.charCodeAt(5) - 65; // A thru X
+    const subLon = gridUpper.charCodeAt(4) - 65; // A thru X
+
+    minLat += (subLat * 2.5) / 60;
+    maxLat = minLat + 2.5 / 60;
+    minLon += (subLon * 5) / 60;
+    maxLon = minLon + 5 / 60;
+  }
+
+  // Extended square (2 digits): 0.5' lon x 0.25' lat
+  if (gridUpper.length >= 8) {
+    const subLat = parseInt(gridUpper[7]);
+    const subLon = parseInt(gridUpper[6]);
+
+    minLat += (subLat * 0.25) / 60;
+    maxLat = minLat + 0.25 / 60;
+    minLon += (subLon * 0.5) / 60;
+    maxLon = minLon + 0.5 / 60;
+  }
+
+  return [
+    [minLat, minLon],
+    [maxLat, maxLon],
+  ];
+};
+
+/**
+ * Convert latitude/longitude coordinates to Maidenhead grid locator of specified precision (character length)
+ * @param Latitude and longitude coordinates
+ * @param precision Precision (character length) of the grid locator returned, can be 2, 4, 6, or 8. (default if not specified is 6)
+ * @returns Maidenhead grid locator
+ */
+const latLonToMaidenhead = ({ lat, lon }, precision = 6) => {
+  if (lat < -90 || lat > 90) throw new Error('invalid latitude, it should be between -90 and 90');
+  if (lon < -180 || lon > 180) throw new Error('invalid longitude, it should be between -180 and 180');
+
+  const latNorm = lat + 90;
+  const lonNorm = lon + 180;
+
+  // Field (2 chars): 20° lon x 10° lat
+  const field1 = String.fromCharCode(65 + Math.floor(lonNorm / 20)); // A-R
+  const field2 = String.fromCharCode(65 + Math.floor(latNorm / 10)); // A-R
+
+  if (precision === 2) {
+    return `${field1}${field2}`;
+  } else {
+    // Square (2 digits): 2° lon x 1° lat
+    const square1 = Math.floor((lonNorm % 20) / 2);
+    const square2 = Math.floor((latNorm % 10) / 1);
+
+    if (precision === 4) {
+      return `${field1}${field2}${square1}${square2}`;
+    } else {
+      // Subsquare (2 chars): 5' lon x 2.5' lat
+      const subsq1 = String.fromCharCode(97 + Math.floor(((lonNorm % 2) * 60) / 5)); // a-x
+      const subsq2 = String.fromCharCode(97 + Math.floor(((latNorm % 1) * 60) / 2.5)); // a-x
+
+      if (precision === 6) {
+        return `${field1}${field2}${square1}${square2}${subsq1}${subsq2}`;
+      } else if (precision === 8) {
+        // Extended square (2 digits): 0.5' lon x 0.25' lat
+        const extSq1 = Math.floor((((lonNorm % 2) * 60) % 5) / 0.5);
+        const extSq2 = Math.floor((((latNorm % 1) * 60) % 2.5) / 0.25);
+
+        return `${field1}${field2}${square1}${square2}${subsq1}${subsq2}${extSq1}${extSq2}`;
+      } else return null; // Invalid precision
+    }
+  }
+};
 
 /**
  * Convert Maidenhead grid locator to lat/lon.
@@ -103,4 +236,14 @@ function haversineDistance(lat1, lon1, lat2, lon2) {
   return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }
 
-module.exports = { gridToLatLon, latLonToGrid, getBandFromHz, getBandFromKHz, haversineDistance };
+module.exports = {
+  validateGridLocator,
+  maidenheadToLatLon,
+  latLonToMaidenhead,
+  maidenheadToBoundingBox,
+  gridToLatLon,
+  latLonToGrid,
+  getBandFromHz,
+  getBandFromKHz,
+  haversineDistance,
+};

--- a/src/components/AzimuthalMap.jsx
+++ b/src/components/AzimuthalMap.jsx
@@ -10,7 +10,7 @@
 import { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getBandColor, getBandFromFreq } from '../utils/callsign.js';
-import { calculateGridSquare } from '../utils/geo.js';
+import { latLonToMaidenhead } from '../utils/geo.js';
 import { MAP_STYLES } from '../utils/config.js';
 import { createTileReprojector } from '../utils/tileReproject.js';
 import { createAzimuthalCRS } from '../utils/azimuthalCRS.js';
@@ -232,7 +232,7 @@ export default function AzimuthalMap({
       setTooltip({
         x: e.containerPoint.x,
         y: e.containerPoint.y,
-        text: `${e.latlng.lat.toFixed(1)}°, ${e.latlng.lng.toFixed(1)}°  ${calculateGridSquare(e.latlng.lat, e.latlng.lng)}  ${Math.round(p.dist)} km  ${Math.round(bearing)}°`,
+        text: `${e.latlng.lat.toFixed(1)}°, ${e.latlng.lng.toFixed(1)}°  ${latLonToMaidenhead({ lat: e.latlng.lat, lon: e.latlng.lng })}  ${Math.round(p.dist)} km  ${Math.round(bearing)}°`,
       });
     });
     map.on('mouseout', () => setTooltip(null));
@@ -822,7 +822,7 @@ export default function AzimuthalMap({
       ctx.font = '11px "JetBrains Mono", monospace';
       ctx.textAlign = 'left';
       ctx.textBaseline = 'middle';
-      const grid = calculateGridSquare(lat0, lon0);
+      const grid = latLonToMaidenhead({ lat: lat0, lon: lon0 });
       ctx.fillText(`Azimuthal Equidistant · ${grid} · ${lat0.toFixed(2)}°, ${lon0.toFixed(2)}°`, 14, size.h - 19);
     }
   }, [

--- a/src/components/DXFavorites.jsx
+++ b/src/components/DXFavorites.jsx
@@ -4,7 +4,7 @@
  * Stores favorites in localStorage as openhamclock_dxFavorites.
  */
 import { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react';
-import { calculateGridSquare } from '../utils/geo.js';
+import { latLonToMaidenhead } from '../utils/geo.js';
 import { syncAllSettingsToServer } from '../utils';
 
 const STORAGE_KEY = 'openhamclock_dxFavorites';
@@ -74,7 +74,7 @@ export function DXFavorites({ dxLocation, dxGrid, onDXChange, dxLocked }) {
 
   const addCurrent = () => {
     if (!dxLocation || favorites.length >= MAX_FAVORITES) return;
-    const grid = dxGrid || calculateGridSquare(dxLocation.lat, dxLocation.lon);
+    const grid = dxGrid || latLonToMaidenhead({ lat: dxLocation.lat, lon: dxLocation.lon });
     // Don't add duplicates (same grid)
     if (favorites.some((f) => f.grid === grid)) return;
     const newFav = {
@@ -115,7 +115,7 @@ export function DXFavorites({ dxLocation, dxGrid, onDXChange, dxLocked }) {
   };
 
   const hasFavorites = favorites.length > 0;
-  const currentGrid = dxGrid || (dxLocation ? calculateGridSquare(dxLocation.lat, dxLocation.lon) : '');
+  const currentGrid = dxGrid || (dxLocation ? latLonToMaidenhead({ lat: dxLocation.lat, lon: dxLocation.lon }) : '');
   const isCurrentSaved = favorites.some((f) => f.grid === currentGrid);
 
   return (

--- a/src/components/DXFavorites.jsx
+++ b/src/components/DXFavorites.jsx
@@ -4,7 +4,7 @@
  * Stores favorites in localStorage as openhamclock_dxFavorites.
  */
 import { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react';
-import { parseGridSquare, calculateGridSquare } from '../utils/geo.js';
+import { calculateGridSquare } from '../utils/geo.js';
 import { syncAllSettingsToServer } from '../utils';
 
 const STORAGE_KEY = 'openhamclock_dxFavorites';

--- a/src/components/DXGridInput.jsx
+++ b/src/components/DXGridInput.jsx
@@ -10,7 +10,7 @@
  */
 import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { parseGridSquare } from '../utils/geo.js';
+import { maidenheadToLatLon } from '../utils/geo.js';
 
 export function DXGridInput({ dxGrid, onDXChange, dxLocked, style }) {
   const { t } = useTranslation();
@@ -26,7 +26,7 @@ export function DXGridInput({ dxGrid, onDXChange, dxLocked, style }) {
 
   const commit = (value) => {
     const trimmed = value.trim();
-    const parsed = parseGridSquare(trimmed);
+    const parsed = maidenheadToLatLon(trimmed);
     if (parsed) {
       onDXChange({ lat: parsed.lat, lon: parsed.lon });
     } else {

--- a/src/components/LocationPanel.jsx
+++ b/src/components/LocationPanel.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import {
-  calculateGridSquare,
+  latLonToMaidenhead,
   calculateBearing,
   calculateDistance,
   formatDistance,
@@ -21,8 +21,8 @@ export const LocationPanel = ({
   dxLocked,
   onToggleDxLock,
 }) => {
-  const deGrid = calculateGridSquare(config.location.lat, config.location.lon);
-  const dxGrid = calculateGridSquare(dxLocation.lat, dxLocation.lon);
+  const deGrid = latLonToMaidenhead({ lat: config.location.lat, lon: config.location.lon });
+  const dxGrid = latLonToMaidenhead({ lat: dxLocation.lat, lon: dxLocation.lon });
   const bearing = calculateBearing(config.location.lat, config.location.lon, dxLocation.lat, dxLocation.lon);
   const distance = calculateDistance(config.location.lat, config.location.lon, dxLocation.lat, dxLocation.lon);
   const moonPhase = getMoonPhase(currentTime);

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -3,7 +3,7 @@
  * Full settings modal with map layer controls
  */
 import { useState, useEffect, useRef } from 'react';
-import { calculateGridSquare, maidenheadToLatLon } from '../utils/geo.js';
+import { latLonToMaidenhead, maidenheadToLatLon } from '../utils/geo.js';
 import { useTranslation, Trans } from 'react-i18next';
 import { LANGUAGES } from '../lang/i18n.js';
 import {
@@ -205,7 +205,7 @@ export const SettingsPanel = ({
       setAutoMode(config.rigControl?.autoMode !== false);
       setRigApiToken(config.rigControl?.apiToken || '');
       if (config.location?.lat != null && config.location?.lon != null) {
-        const grid = calculateGridSquare(config.location.lat, config.location.lon);
+        const grid = latLonToMaidenhead({ lat: config.location.lat, lon: config.location.lon });
         setGridSquare(grid);
         setConfigLocator(grid);
       }
@@ -337,7 +337,7 @@ export const SettingsPanel = ({
     gridEditingRef.current = false;
     // Now recalculate full 6-char grid from lat/lon
     if (lat != null && lon != null) {
-      const grid = calculateGridSquare(lat, lon);
+      const grid = latLonToMaidenhead({ lat, lon });
       setGridSquare(grid);
       setConfigLocator(grid);
     }
@@ -347,7 +347,7 @@ export const SettingsPanel = ({
     // Skip auto-completion while user is actively typing in the grid field
     if (gridEditingRef.current) return;
     if (lat != null && lon != null) {
-      const grid = calculateGridSquare(lat, lon);
+      const grid = latLonToMaidenhead({ lat, lon });
       setGridSquare(grid);
       setConfigLocator(grid);
     }

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -3,7 +3,7 @@
  * Full settings modal with map layer controls
  */
 import { useState, useEffect, useRef } from 'react';
-import { calculateGridSquare, parseGridSquare } from '../utils/geo.js';
+import { calculateGridSquare, maidenheadToLatLon } from '../utils/geo.js';
 import { useTranslation, Trans } from 'react-i18next';
 import { LANGUAGES } from '../lang/i18n.js';
 import {
@@ -324,7 +324,7 @@ export const SettingsPanel = ({
     gridEditingRef.current = true;
     setGridSquare(grid.toUpperCase());
     if (grid.length >= 4) {
-      const parsed = parseGridSquare(grid);
+      const parsed = maidenheadToLatLon(grid);
       if (parsed) {
         setLat(parsed.lat);
         setLon(parsed.lon);

--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -6,7 +6,7 @@ import React, { useRef, useEffect, useState, useMemo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next';
 import { MAP_STYLES } from '../utils/config.js';
 import {
-  calculateGridSquare,
+  latLonToMaidenhead,
   getSunPosition,
   getMoonPosition,
   getGreatCirclePoints,
@@ -353,7 +353,7 @@ export const WorldMap = ({
   // Calculate grid locator from DE location for plugins
   const deLocator = useMemo(() => {
     if (deLocation?.lat == null || deLocation?.lon == null) return '';
-    return calculateGridSquare(deLocation.lat, deLocation.lon);
+    return latLonToMaidenhead({ lat: deLocation.lat, lon: deLocation.lon });
   }, [deLocation?.lat, deLocation?.lon]);
 
   const selectedMapBands = useMemo(() => {
@@ -1250,7 +1250,7 @@ export const WorldMap = ({
         iconSize: [32, 32],
         iconAnchor: [16, 16],
       });
-      const html = `<b>DE - Your Location</b><br>${esc(calculateGridSquare(deLocation.lat, deLocation.lon))}<br>${deLocation.lat.toFixed(4)}°, ${deLocation.lon.toFixed(4)}°`;
+      const html = `<b>DE - Your Location</b><br>${esc(latLonToMaidenhead({ lat: deLocation.lat, lon: deLocation.lon }))}<br>${deLocation.lat.toFixed(4)}°, ${deLocation.lon.toFixed(4)}°`;
       const m = L.marker([lat, lon], { icon: deIcon, zIndexOffset: 20000 }).addTo(map);
       attachPopupWeather(m, lat, lon, html);
       deMarkerRef.current.push(m);
@@ -1264,7 +1264,7 @@ export const WorldMap = ({
         iconSize: [32, 32],
         iconAnchor: [16, 16],
       });
-      const baseHtml = `<b>DX - Target</b><br>${esc(calculateGridSquare(dxLocation.lat, dxLocation.lon))}<br>${dxLocation.lat.toFixed(4)}°, ${dxLocation.lon.toFixed(4)}°`;
+      const baseHtml = `<b>DX - Target</b><br>${esc(latLonToMaidenhead({ lat: dxLocation.lat, lon: dxLocation.lon }))}<br>${dxLocation.lat.toFixed(4)}°, ${dxLocation.lon.toFixed(4)}°`;
       const m = L.marker([lat, lon], { icon: dxIcon, zIndexOffset: 19000 }).addTo(map);
       attachPopupWeather(m, lat, lon, baseHtml);
       dxMarkerRef.current.push(m);

--- a/src/hooks/app/useTimeState.js
+++ b/src/hooks/app/useTimeState.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { calculateGridSquare, calculateSunTimes } from '../../utils';
+import { latLonToMaidenhead, calculateSunTimes } from '../../utils';
 
 function convertTimeUTCtoLocal(sunTimes, tz, currentTime) {
   // We are only ever going to be doing this for local timezone
@@ -98,8 +98,8 @@ export default function useTimeState(configLocation, dxLocation, timezone) {
     return () => clearTimeout(timeout);
   }, [startTime]);
 
-  const deGrid = useMemo(() => calculateGridSquare(configLocation.lat, configLocation.lon), [configLocation]);
-  const dxGrid = useMemo(() => calculateGridSquare(dxLocation.lat, dxLocation.lon), [dxLocation]);
+  const deGrid = useMemo(() => latLonToMaidenhead(configLocation.lat, configLocation.lon), [configLocation]);
+  const dxGrid = useMemo(() => latLonToMaidenhead(dxLocation.lat, dxLocation.lon), [dxLocation]);
 
   // Validate the timezone once per changed value, not on every render.
   // new Intl.DateTimeFormat throws a RangeError for invalid values such as

--- a/src/hooks/usePOTASpots.js
+++ b/src/hooks/usePOTASpots.js
@@ -5,31 +5,8 @@
 import { useState, useEffect, useRef } from 'react';
 import { useVisibilityRefresh } from './useVisibilityRefresh';
 import { apiFetch } from '../utils/apiFetch';
-import { WGS84ToMaidenhead } from '@hamset/maidenhead-locator';
+import { latLonToMaidenhead, maidenheadToLatLon } from '../utils/geo';
 import { getBandFromFreq } from '../utils/callsign';
-
-// Convert grid square to lat/lon
-function gridToLatLon(grid) {
-  if (!grid || grid.length < 4) return null;
-
-  const g = grid.toUpperCase();
-  const lon = (g.charCodeAt(0) - 65) * 20 - 180;
-  const lat = (g.charCodeAt(1) - 65) * 10 - 90;
-  const lonMin = parseInt(g[2]) * 2;
-  const latMin = parseInt(g[3]) * 1;
-
-  let finalLon = lon + lonMin + 1;
-  let finalLat = lat + latMin + 0.5;
-
-  if (grid.length >= 6) {
-    const lonSec = (g.charCodeAt(4) - 65) * (2 / 24);
-    const latSec = (g.charCodeAt(5) - 65) * (1 / 24);
-    finalLon = lon + lonMin + lonSec + 1 / 24;
-    finalLat = lat + latMin + latSec + 0.5 / 24;
-  }
-
-  return { lat: finalLat, lon: finalLon };
-}
 
 export const usePOTASpots = () => {
   const [data, setData] = useState([]);
@@ -99,14 +76,14 @@ export const usePOTASpots = () => {
               let lon = s.longitude != null ? parseFloat(s.longitude) : null;
 
               if ((lat == null || lon == null) && s.grid6) {
-                const loc = gridToLatLon(s.grid6);
+                const loc = maidenheadToLatLon(s.grid6);
                 if (loc) {
                   lat = loc.lat;
                   lon = loc.lon;
                 }
               }
               if ((lat == null || lon == null) && s.grid4) {
-                const loc = gridToLatLon(s.grid4);
+                const loc = maidenheadToLatLon(s.grid4);
                 if (loc) {
                   lat = loc.lat;
                   lon = loc.lon;
@@ -139,7 +116,7 @@ export const usePOTASpots = () => {
                     })()
                   : '',
                 expire: s.expire || 0,
-                grid: s.grid6 ? s.grid6 : s.grid4 ? s.grid4 : WGS84ToMaidenhead({ lat: lat, lng: lon }),
+                grid: s.grid6 ? s.grid6 : s.grid4 ? s.grid4 : latLonToMaidenhead({ lat, lon }),
               };
             }),
           );

--- a/src/hooks/useSOTASpots.js
+++ b/src/hooks/useSOTASpots.js
@@ -5,7 +5,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useVisibilityRefresh } from './useVisibilityRefresh';
 import { apiFetch } from '../utils/apiFetch';
-import { WGS84ToMaidenhead } from '@hamset/maidenhead-locator';
+import { latLonToMaidenhead } from '../utils/geo';
 import { getBandFromFreq } from '../utils/callsign';
 
 export const useSOTASpots = () => {
@@ -93,7 +93,7 @@ export const useSOTASpots = () => {
                       return new Date(ts).toISOString().substr(11, 5) + 'z';
                     })()
                   : '',
-                grid: WGS84ToMaidenhead({ lat: lat, lng: lon }),
+                grid: latLonToMaidenhead({ lat, lon }),
               };
             });
 

--- a/src/hooks/useWWBOTASpots.js
+++ b/src/hooks/useWWBOTASpots.js
@@ -6,7 +6,7 @@
  * Handles spot data with frequency, callsign, bunker reference, and coordinates
  */
 import { useState, useEffect, useRef } from 'react';
-import { WGS84ToMaidenhead } from '@hamset/maidenhead-locator';
+import { latLonToMaidenhead } from '../utils/geo';
 import { getBandFromFreq } from '../utils';
 
 export const useWWBOTASpots = () => {
@@ -144,7 +144,7 @@ export const useWWBOTASpots = () => {
                 time: time ? time.substring(11, 16) + 'z' : '', // Extract HH:MM from ISO string
                 isoTime: time, // Store the original ISO time
                 type: spot.type || 'Live', // Live, QRT, or Test
-                grid: WGS84ToMaidenhead({ lat: lat, lng: lon }),
+                grid: latLonToMaidenhead({ lat, lon }),
               };
 
               // Skip QRT spots

--- a/src/hooks/useWWFFSpots.js
+++ b/src/hooks/useWWFFSpots.js
@@ -5,7 +5,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useVisibilityRefresh } from './useVisibilityRefresh';
 import { apiFetch } from '../utils/apiFetch';
-import { WGS84ToMaidenhead } from '@hamset/maidenhead-locator';
+import { latLonToMaidenhead } from '../utils/geo';
 import { getBandFromFreq } from '../utils';
 
 export const useWWFFSpots = () => {
@@ -80,7 +80,7 @@ export const useWWFFSpots = () => {
                 lon,
                 time: s.spot_time ? s.spot_time_formatted.substr(11, 5) + 'z' : '',
                 expire: 0,
-                grid: WGS84ToMaidenhead({ lat: lat, lng: lon }),
+                grid: latLonToMaidenhead({ lat, lon }),
               };
             }),
           );

--- a/src/layouts/EmcommLayout.jsx
+++ b/src/layouts/EmcommLayout.jsx
@@ -5,7 +5,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { WorldMap } from '../components';
-import { calculateDistance, formatDistance, parseGridSquare } from '../utils/geo.js';
+import { calculateDistance, formatDistance, maidenheadToLatLon } from '../utils/geo.js';
 import { esc } from '../utils/escapeHtml.js';
 import { apiFetch } from '../utils/apiFetch.js';
 import { winlinkModeLabel, winlinkModeColor } from '../utils/winlinkModes.js';
@@ -255,7 +255,7 @@ export default function EmcommLayout(props) {
       if (!r.callsign || !r.gridsquare) continue;
       let entry = byCall.get(r.callsign);
       if (!entry) {
-        const pos = parseGridSquare(r.gridsquare);
+        const pos = maidenheadToLatLon(r.gridsquare);
         if (!pos) continue;
         entry = {
           callsign: r.callsign,

--- a/src/plugins/layers/rbn/README.md
+++ b/src/plugins/layers/rbn/README.md
@@ -322,7 +322,6 @@ src/plugins/layers/
 
 ### Key Functions
 
-- `gridToLatLon(grid)`: Converts Maidenhead grid to coordinates
 - `getSNRColor(snr)`: Maps SNR to color gradient
 - `getMarkerSize(snr)`: Maps SNR to marker size
 - `getGreatCirclePath()`: Calculates curved paths

--- a/src/plugins/layers/useN3FJPLoggedQSOs.js
+++ b/src/plugins/layers/useN3FJPLoggedQSOs.js
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import { esc } from '../../utils/escapeHtml.js';
 import { addMinimizeToggle } from './addMinimizeToggle.js';
 import { makeDraggable } from './makeDraggable.js';
-import { getGreatCirclePoints, replicatePath } from '../../utils/geo.js';
+import { getGreatCirclePoints, replicatePath, maidenheadToLatLon } from '../../utils/geo.js';
 
 export const metadata = {
   id: 'n3fjp_logged_qsos',

--- a/src/plugins/layers/useRBN.js
+++ b/src/plugins/layers/useRBN.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { esc } from '../../utils/escapeHtml.js';
 import { addMinimizeToggle } from './addMinimizeToggle.js';
 import { makeDraggable } from './makeDraggable.js';
+import { maidenheadToLatLon } from '../../utils/geo.js';
 
 /**
  * Reverse Beacon Network (RBN) Plugin v1.0.0
@@ -32,29 +33,6 @@ export const metadata = {
   defaultOpacity: 0.7,
   version: '1.0.0',
 };
-
-// Convert grid square to lat/lon
-function gridToLatLon(grid) {
-  if (!grid || grid.length < 4) return null;
-
-  grid = grid.toUpperCase();
-  const lon = (grid.charCodeAt(0) - 65) * 20 - 180;
-  const lat = (grid.charCodeAt(1) - 65) * 10 - 90;
-  const lon2 = parseInt(grid[2]) * 2;
-  const lat2 = parseInt(grid[3]);
-
-  let longitude = lon + lon2 + 1;
-  let latitude = lat + lat2 + 0.5;
-
-  if (grid.length >= 6) {
-    const lon3 = (grid.charCodeAt(4) - 65) * (2 / 24);
-    const lat3 = (grid.charCodeAt(5) - 65) * (1 / 24);
-    longitude = lon + lon2 + lon3 + 1 / 24;
-    latitude = lat + lat2 + lat3 + 0.5 / 24;
-  }
-
-  return { lat: latitude, lon: longitude };
-}
 
 // Get color based on SNR (signal-to-noise ratio)
 function getSNRColor(snr) {
@@ -435,7 +413,7 @@ export function useLayer({
       if (first.skimmerLat != null && first.skimmerLon != null) {
         spotterOrigin = { lat: first.skimmerLat, lon: first.skimmerLon };
       } else if (first.grid) {
-        spotterOrigin = gridToLatLon(first.grid);
+        spotterOrigin = maidenheadToLatLon(first.grid);
       }
     }
 
@@ -510,7 +488,7 @@ export function useLayer({
         if (spot.skimmerLat != null && spot.skimmerLon != null) {
           skimmerLoc = { lat: spot.skimmerLat, lon: spot.skimmerLon };
         } else {
-          skimmerLoc = gridToLatLon(skimmerGrid);
+          skimmerLoc = maidenheadToLatLon(skimmerGrid);
         }
 
         if (!skimmerLoc) return;

--- a/src/plugins/layers/useWSPR.js
+++ b/src/plugins/layers/useWSPR.js
@@ -3,6 +3,7 @@ import { esc } from '../../utils/escapeHtml.js';
 import { addMinimizeToggle } from './addMinimizeToggle.js';
 import { makeDraggable } from './makeDraggable.js';
 import { getBandFromFreq } from '../../utils/callsign.js';
+import { maidenheadToLatLon } from '../../utils/geo.js';
 
 /**
  * WSPR Propagation Heatmap Plugin v1.6.0
@@ -46,29 +47,6 @@ export const metadata = {
   defaultOpacity: 0.7,
   version: '1.6.1',
 };
-
-// Convert grid square to lat/lon
-function gridToLatLon(grid) {
-  if (!grid || grid.length < 4) return null;
-
-  grid = grid.toUpperCase();
-  const lon = (grid.charCodeAt(0) - 65) * 20 - 180;
-  const lat = (grid.charCodeAt(1) - 65) * 10 - 90;
-  const lon2 = parseInt(grid[2]) * 2;
-  const lat2 = parseInt(grid[3]);
-
-  let longitude = lon + lon2 + 1;
-  let latitude = lat + lat2 + 0.5;
-
-  if (grid.length >= 6) {
-    const lon3 = (grid.charCodeAt(4) - 65) * (2 / 24);
-    const lat3 = (grid.charCodeAt(5) - 65) * (1 / 24);
-    longitude = lon + lon2 + lon3 + 1 / 24;
-    latitude = lat + lat2 + lat3 + 0.5 / 24;
-  }
-
-  return { lat: latitude, lon: longitude };
-}
 
 // Format distance using global units preference
 function fmtDist(km) {
@@ -358,7 +336,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
 
             // Convert sender grid to lat/lon if missing
             if ((!spot.senderLat || !spot.senderLon) && spot.senderGrid) {
-              const loc = gridToLatLon(spot.senderGrid);
+              const loc = maidenheadToLatLon(spot.senderGrid);
               if (loc) {
                 updated.senderLat = loc.lat;
                 updated.senderLon = loc.lon;
@@ -367,7 +345,7 @@ export function useLayer({ enabled = false, map = null, callsign, locator, lowMe
 
             // Convert receiver grid to lat/lon if missing
             if ((!spot.receiverLat || !spot.receiverLon) && spot.receiverGrid) {
-              const loc = gridToLatLon(spot.receiverGrid);
+              const loc = maidenheadToLatLon(spot.receiverGrid);
               if (loc) {
                 updated.receiverLat = loc.lat;
                 updated.receiverLon = loc.lon;

--- a/src/plugins/layers/useWinlinkGateways.js
+++ b/src/plugins/layers/useWinlinkGateways.js
@@ -11,7 +11,7 @@
  */
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { esc } from '../../utils/escapeHtml.js';
-import { parseGridSquare, replicatePoint } from '../../utils/geo.js';
+import { maidenheadToLatLon, replicatePoint } from '../../utils/geo.js';
 import { apiFetch } from '../../utils/apiFetch.js';
 import {
   WINLINK_MODE_FAMILIES,
@@ -51,7 +51,7 @@ function aggregateByCallsign(rows) {
   const byCall = new Map();
   for (const r of rows) {
     if (!r.callsign || !r.gridsquare) continue;
-    const pos = parseGridSquare(r.gridsquare);
+    const pos = maidenheadToLatLon(r.gridsquare);
     if (!pos) continue;
     let entry = byCall.get(r.callsign);
     if (!entry) {

--- a/src/plugins/layers/wspr/README.md
+++ b/src/plugins/layers/wspr/README.md
@@ -411,7 +411,6 @@ src/plugins/layers/
 
 ### Key Functions
 
-- `gridToLatLon(grid)`: Converts Maidenhead grid to coordinates
 - `getSNRColor(snr)`: Maps SNR to color gradient
 - `getLineWeight(snr)`: Maps SNR to line thickness
 - `useLayer()`: Main plugin hook (called by PluginLayer.jsx)

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -138,14 +138,6 @@ export const latLonToMaidenhead = ({ lat, lon }, precision = 6) => {
 };
 
 /**
- * Calculate Maidenhead grid square (size 6) from coordinates.
- * Deprecated, use latLonToMaidenhead({lat, lon}) which defaults to size 6.
- */
-export const calculateGridSquare = (lat, lon) => {
-  return latLonToMaidenhead({ lat, lon }, 6);
-};
-
-/**
  * Calculate bearing between two points
  */
 export const calculateBearing = (lat1, lon1, lat2, lon2) => {
@@ -545,7 +537,6 @@ export default {
   maidenheadToLatLon,
   latLonToMaidenhead,
   maidenheadToBoundingBox,
-  calculateGridSquare,
   calculateBearing,
   calculateDistance,
   getSunPosition,

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -138,16 +138,6 @@ export const latLonToMaidenhead = ({ lat, lon }, precision = 6) => {
 };
 
 /**
- * Parse a Maidenhead grid square string into lat/lon coordinates.
- * Supports 4-character (e.g. "JN58") and 6-character (e.g. "JN58sm") locators.
- * Returns { lat, lon } of the grid square center, or null if input is invalid.
- * Deprecated, use maidenheadToLatLon(grid)
- */
-export const parseGridSquare = (grid) => {
-  return maidenheadToLatLon(grid);
-};
-
-/**
  * Calculate Maidenhead grid square (size 6) from coordinates.
  * Deprecated, use latLonToMaidenhead({lat, lon}) which defaults to size 6.
  */
@@ -555,7 +545,6 @@ export default {
   maidenheadToLatLon,
   latLonToMaidenhead,
   maidenheadToBoundingBox,
-  parseGridSquare,
   calculateGridSquare,
   calculateBearing,
   calculateDistance,

--- a/src/utils/geo.test.js
+++ b/src/utils/geo.test.js
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest';
-import { calculateGridSquare } from './geo.js';
 import { validateGridLocator, latLonToMaidenhead, maidenheadToLatLon, maidenheadToBoundingBox } from './geo.js';
 
 describe('Maidenhead Grid tests', () => {
@@ -134,29 +133,5 @@ describe('Maidenhead Grid tests', () => {
         expect(result[1][1]).toBeCloseTo(latLonNECornerGrid6[1], 3);
       },
     );
-  }
-});
-
-describe('Maidenhead Grid tests - legacy functions', () => {
-  // legacy functions
-  // export const calculateGridSquare = (lat, lon) => { return string; }
-
-  const gridCases = [
-    {
-      grid2: 'DM',
-      grid4: 'DM12',
-      grid6: 'DM12kv',
-      actualLatLon: [32.91254, -117.08409],
-      latlonCenter: [32.896, -117.125],
-      latlonSWCorner: [32.875, -117.167],
-      latlonNECorner: [32.917, -117.083],
-    },
-  ];
-
-  for (const { grid2, grid4, grid6, actualLatLon, latlonCenter, latlonSWCorner, latlonNECorner } of gridCases) {
-    it('should convert Lat/Lon to Maidenhead precision 6', () => {
-      const result = calculateGridSquare(actualLatLon[0], actualLatLon[1]);
-      expect(result).toBe(grid6);
-    });
   }
 });

--- a/src/utils/geo.test.js
+++ b/src/utils/geo.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseGridSquare, calculateGridSquare } from './geo.js';
+import { calculateGridSquare } from './geo.js';
 import { validateGridLocator, latLonToMaidenhead, maidenheadToLatLon, maidenheadToBoundingBox } from './geo.js';
 
 describe('Maidenhead Grid tests', () => {
@@ -139,7 +139,6 @@ describe('Maidenhead Grid tests', () => {
 
 describe('Maidenhead Grid tests - legacy functions', () => {
   // legacy functions
-  // export const parseGridSquare = (grid) => { return { lat, lon }; }
   // export const calculateGridSquare = (lat, lon) => { return string; }
 
   const gridCases = [
@@ -158,12 +157,6 @@ describe('Maidenhead Grid tests - legacy functions', () => {
     it('should convert Lat/Lon to Maidenhead precision 6', () => {
       const result = calculateGridSquare(actualLatLon[0], actualLatLon[1]);
       expect(result).toBe(grid6);
-    });
-
-    it('should convert Maidenhead to Lat/Lon', () => {
-      const { lat, lon } = parseGridSquare(grid6);
-      expect(lat).toBeCloseTo(actualLatLon[0], 1);
-      expect(lon).toBeCloseTo(actualLatLon[1], 1);
     });
   }
 });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -23,7 +23,6 @@ export {
   latLonToMaidenhead,
   maidenheadToLatLon,
   maidenheadToBoundingBox,
-  calculateGridSquare,
   calculateBearing,
   calculateDistance,
   getSunPosition,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -23,7 +23,6 @@ export {
   latLonToMaidenhead,
   maidenheadToLatLon,
   maidenheadToBoundingBox,
-  parseGridSquare,
   calculateGridSquare,
   calculateBearing,
   calculateDistance,


### PR DESCRIPTION
closes https://github.com/accius/openhamclock/issues/951

- previously there were multiple sources of Maidenhead grid locator helper code
- all code now points to (client side) `utils/geo.js`, or to (server side) `utils/grid.js`
- remove `@hamset/maidenhead-locator` (in `package.json`)
- instances of `parseGridSquare` converted to `maidenheadToLatLon`
- add missing reference to `maidenheadToLatLon` in `src\plugins\layers\useN3FJPLoggedQSOs.js`
- remove unused references to `maidenheadToLatLon` in `server\routes\propagation.js` and `server\routes\pskreporter.js`
- instances of `calculateGridSquare` converted to `latLonToMaidenhead`
- duplicate Maidenhead grid content of `src\utils\geo.js` into `server\utils\grid.js` - the two cannot easily share a common source since the export patterns of the server (CommonJS) and client (ESM) are different.
- remove duplicate functionality `maidenheadToLatLon` from `server\routes\callsign.js
- point server existing uses of `maidenheadToLatLon` to `server\utils\grid.js`
- replace `isValidGrid` with `validateGridLocator`
- remove multiple versions of `gridToLatLon` from server and client, point existing use of `gridToLatLon` to respective `maidenheadToLatLon` versions in util (server or client). Note, `/rig-bridge/**` not modified.
- Global removal and replacement of `latLonToGrid` with `latLonToMaidenhead`. Note, `/AddOns/APRS-AutoPos/aprs_autopos.user.js` not modified.
- remove unused `parseGridSquare`
- remove unused `calculateGridSquare`

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [X] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included
