### PR TITLE
fix(whats-new): OK button unreachable on mobile — use svh units

### DIFF
--- a/src/components/WhatsNew.jsx
+++ b/src/components/WhatsNew.jsx
@@ -1356,13 +1356,13 @@ export default function WhatsNew({ showWhatsNew }) {
     >
       <div
         onClick={(e) => e.stopPropagation()}
+        className="whats-new-modal"
         style={{
           background: 'var(--bg-secondary, #1a1a2e)',
           border: '1px solid var(--border-color, #333)',
           borderRadius: '12px',
           maxWidth: '560px',
           width: '100%',
-          maxHeight: '85vh',
           display: 'flex',
           flexDirection: 'column',
           boxShadow: '0 20px 60px rgba(0, 0, 0, 0.5)',
@@ -1451,6 +1451,8 @@ export default function WhatsNew({ showWhatsNew }) {
             overflowY: 'auto',
             padding: '16px 24px',
             flex: 1,
+            WebkitOverflowScrolling: 'touch',
+            overscrollBehavior: 'contain',
           }}
         >
           {entry.features.map((f, i) => (
@@ -1540,6 +1542,10 @@ export default function WhatsNew({ showWhatsNew }) {
             opacity: 1;
             transform: translateY(0) scale(1);
           }
+        }
+        .whats-new-modal {
+          max-height: 85vh;
+          max-height: calc(100svh - 40px);
         }
       `}</style>
     </div>


### PR DESCRIPTION
## Problem

On mobile browsers the "Got it — 73!" button in the What's New dialog was pushed below the visible screen edge. `85vh` is measured against the *full* viewport including browser chrome (address bar, navigation buttons), so when that chrome is visible the modal can overflow the actually-visible area. Because the button sits in a fixed footer *outside* the scrollable feature list, users had no way to scroll to it.

Reported by Tim Gelvin.

## Fix

- Replaced the inline `maxHeight: '85vh'` with a CSS class `.whats-new-modal` in the component's `<style>` block, using a two-declaration fallback:
  ```css
  .whats-new-modal {
    max-height: 85vh;                  /* fallback — old browsers */
    max-height: calc(100svh - 40px);   /* modern — guaranteed visible area */
  }
  ```
  `svh` (small viewport height) is always the *minimum* visible height — it excludes all browser chrome. `40px` accounts for the backdrop's `20px` padding on each side. Support: Chrome 108+, Firefox 101+, Safari 15.4+ (all current mobile browsers).

- Added `WebkitOverflowScrolling: touch` and `overscrollBehavior: contain` to the scrollable feature list for smooth iOS momentum scrolling and to prevent bleed-through to the page behind the modal.

## Test plan

- [ ] Open the What's New dialog on a mobile device (or DevTools mobile emulation) — "Got it — 73!" button should be visible without needing to scroll
- [ ] Feature list still scrolls independently on iOS and Android
- [ ] Tapping the backdrop still dismisses the dialog
- [ ] No visual regression on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)