### PR TITLE
[Fix] use language coded version of 'VISIBLE' inside prediction table

### DIFF
--- a/src/plugins/layers/useSatelliteLayer.js
+++ b/src/plugins/layers/useSatelliteLayer.js
@@ -701,7 +701,7 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
                     }
 
                     const timeFromNow = isVisibleNow
-                      ? 'VISIBLE'
+                      ? `${t('station.settings.satellites.visible')}`
                       : secsFromNow > 3600
                         ? `${String(Math.floor(secsFromNow / 3600)).padStart(2, '0')}:${String(Math.floor((secsFromNow % 3600) / 60)).padStart(2, '0')}:${String(secsFromNow % 60).padStart(2, '0')}`
                         : secsFromNow > 60


### PR DESCRIPTION
## What does this PR do?

- this is a one-line change
- when satellite is visible the word visible appears on the top line in the prediction table
- PR fixes by using the language coded version

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [X] Translation
- [ ] Map layer plugin

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included
