### PR TITLE
fix(grid-display): restore Maidenhead grid square in DE/DX panels

### DIFF
--- a/src/hooks/app/useTimeState.js
+++ b/src/hooks/app/useTimeState.js
@@ -98,8 +98,8 @@ export default function useTimeState(configLocation, dxLocation, timezone) {
     return () => clearTimeout(timeout);
   }, [startTime]);
 
-  const deGrid = useMemo(() => latLonToMaidenhead(configLocation.lat, configLocation.lon), [configLocation]);
-  const dxGrid = useMemo(() => latLonToMaidenhead(dxLocation.lat, dxLocation.lon), [dxLocation]);
+  const deGrid = useMemo(() => latLonToMaidenhead(configLocation), [configLocation]);
+  const dxGrid = useMemo(() => latLonToMaidenhead(dxLocation), [dxLocation]);
 
   // Validate the timezone once per changed value, not on every render.
   // new Intl.DateTimeFormat throws a RangeError for invalid values such as


### PR DESCRIPTION
## Summary

- Fixes blank Maidenhead grid squares in both the DE and DX location panels
- Root cause: commit d1ab3d5 (PR #964) replaced `calculateGridSquare(lat, lon)` with `latLonToMaidenhead` but kept the old two-positional-argument call style — `latLonToMaidenhead` expects a `{ lat, lon }` object as its first argument
- Passing a bare number caused destructuring to yield `undefined` for both `lat` and `lon`, producing `NaN` throughout the calculation and invisible characters in the rendered grid

## Change

`src/hooks/app/useTimeState.js` lines 101-102:

Before (broken): `latLonToMaidenhead(configLocation.lat, configLocation.lon)`
After (correct):  `latLonToMaidenhead(configLocation)`

Both `configLocation` and `dxLocation` are already `{ lat, lon }` objects, so they can be passed directly.

## Test plan

- [ ] Open the app and confirm the DE panel shows a 6-character Maidenhead locator (e.g. `GH52lj`)
- [ ] Confirm the DX panel also shows a locator
- [ ] Set a DX location manually and confirm the locator updates
- [ ] Verify a station at lat=0 / lon=0 (equator / prime meridian) renders `JJ00aa` — not blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)
