### PR TITLE
[server utils] Add utils normalize, mutex, statemachine

### DIFF
--- a/server/utils/mutex.js
+++ b/server/utils/mutex.js
@@ -1,0 +1,90 @@
+/**
+ * A simple mutex implementation for Node.js to manage concurrent access to shared resources.
+ * The Mutex class provides basic locking and unlocking functionality, while MutexValue and MutexCounter
+ * extend this functionality to manage a value and a counter, respectively.
+ *
+ * @class Mutex
+ * @typedef {Mutex}
+ */
+class Mutex {
+  constructor() {
+    this.locked = false;
+    this.queue = [];
+  }
+
+  async lock() {
+    return new Promise((resolve) => {
+      if (!this.locked) {
+        this.locked = true;
+        resolve();
+      } else {
+        this.queue.push(resolve);
+      }
+    });
+  }
+
+  unlock() {
+    if (this.queue.length > 0) {
+      const nextResolve = this.queue.shift();
+      nextResolve();
+    } else {
+      this.locked = false;
+    }
+  }
+}
+
+/**
+ * A MutexValue class that encapsulates a value and provides thread-safe access to it using a mutex.
+ * The update method allows for atomic updates to the value,
+ * while the get method retrieves the current value in a thread-safe manner.
+ *
+ * @class MutexValue
+ * @typedef {MutexValue}
+ */
+class MutexValue {
+  constructor(initialValue) {
+    this.value = initialValue;
+    this.mutex = new Mutex();
+  }
+
+  async update(fn) {
+    await this.mutex.lock();
+    try {
+      this.value = await fn(this.value);
+      return this.value;
+    } finally {
+      this.mutex.unlock();
+    }
+  }
+
+  async get() {
+    await this.mutex.lock();
+    try {
+      return this.value;
+    } finally {
+      this.mutex.unlock();
+    }
+  }
+}
+
+/**
+ * A MutexCounter class that extends MutexValue to provide a simple counter
+ * that can be safely incremented across multiple threads.
+ * The increment method atomically increases the counter value by one,
+ * ensuring that concurrent increments do not lead.
+ *
+ * @class MutexCounter
+ * @typedef {MutexCounter}
+ * @extends {MutexValue}
+ */
+class MutexCounter extends MutexValue {
+  async increment() {
+    return this.update((v) => v + 1);
+  }
+
+  async setValue(newValue) {
+    return this.update(() => newValue);
+  }
+}
+
+module.exports = { Mutex, MutexValue, MutexCounter };

--- a/server/utils/mutex.test.js
+++ b/server/utils/mutex.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { Mutex, MutexValue, MutexCounter } from './mutex.js';
+
+describe('Mutex', () => {
+  it('should lock and unlock properly', async () => {
+    const mutex = new Mutex();
+    await mutex.lock();
+    expect(mutex.locked).toBe(true);
+    await mutex.unlock();
+    expect(mutex.locked).toBe(false);
+  });
+
+  it('should queue locks properly', async () => {
+    const mutex = new Mutex();
+    let order = [];
+
+    const func1 = async () => {
+      await mutex.lock();
+      order.push(1);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      order.push(2);
+      mutex.unlock();
+    };
+
+    const func2 = async () => {
+      await mutex.lock();
+      order.push(3);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      order.push(4);
+      mutex.unlock();
+    };
+
+    await Promise.all([func1(), func2()]);
+    expect(order).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe('MutexValue', () => {
+  it('should update and get value properly', async () => {
+    const mutexValue = new MutexValue(0);
+    await mutexValue.update(() => 5);
+    expect(await mutexValue.get()).toBe(5);
+  });
+});
+
+describe('MutexCounter', () => {
+  it('should increment and get count properly', async () => {
+    const counter = new MutexCounter(0);
+    await counter.increment();
+    await counter.increment();
+    expect(await counter.get()).toBe(2);
+  });
+});

--- a/server/utils/normalize.js
+++ b/server/utils/normalize.js
@@ -1,0 +1,62 @@
+/**
+ * Recursively normalize all values in the JSON tree, converting numeric strings to numbers.
+ *
+ * @param {*} node
+ * @returns {*}
+ */
+const normalizeJsonTree = (node) => {
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i++) {
+      node[i] = normalizeJsonTree(node[i]);
+    }
+    return node;
+  }
+
+  if (node !== null && typeof node === 'object') {
+    for (const key of Object.keys(node)) {
+      node[key] = normalizeJsonTree(node[key]);
+    }
+    return node;
+  }
+
+  return normalizeNumber(node);
+};
+
+/**
+ * Normalize numeric strings, especially those in scientific notation or with leading dots.
+ *
+ * @param {*} value
+ * @returns {*}
+ */
+const normalizeNumber = (value) => {
+  if (typeof value !== 'string') return value;
+
+  const v = value.trim();
+
+  // Leading-dot float: ".001206" → "0.001206"
+  if (/^[+-]?\.\d+$/.test(v)) {
+    return Number('0' + v);
+  }
+
+  // Scientific notation with digits: "1.23E-4"
+  if (/^[+-]?\d*\.?\d+e[+-]?\d+$/i.test(v)) {
+    return Number(v);
+  }
+
+  // Scientific notation with leading dot: "-.5E-6"
+  if (/^[+-]?\.\d+e[+-]?\d+$/i.test(v)) {
+    return Number('0' + v);
+  }
+
+  // Plain integer or float
+  if (/^[+-]?\d+(\.\d+)?$/.test(v)) {
+    return Number(v);
+  }
+
+  return value;
+};
+
+module.exports = {
+  normalizeJsonTree,
+  normalizeNumber,
+};

--- a/server/utils/normalize.test.js
+++ b/server/utils/normalize.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeNumber, normalizeJsonTree } from './normalize.js';
+
+describe('normalizeNumber', () => {
+  it('should return a number if input is a valid number string', () => {
+    expect(normalizeNumber('1')).toBe(1);
+    expect(normalizeNumber('2.5')).toBe(2.5);
+    expect(normalizeNumber('-1.2E-7')).toBe(-1.2e-7);
+    expect(normalizeNumber('.00000001')).toBe(1e-8);
+    expect(normalizeNumber('hello')).toBe('hello');
+  });
+});
+
+describe('normalizeJsonTree', () => {
+  it('should normalize a JSON tree', () => {
+    const input = { a: '1', b: '2.5', c: '-1e-7', d: '.00000001', e: 'hello' };
+    const expected = { a: 1, b: 2.5, c: -1e-7, d: 1e-8, e: 'hello' };
+    expect(normalizeJsonTree(input)).toEqual(expected);
+  });
+});

--- a/server/utils/normalize.test.js
+++ b/server/utils/normalize.test.js
@@ -8,6 +8,7 @@ describe('normalizeNumber', () => {
     expect(normalizeNumber('-1.2E-7')).toBe(-1.2e-7);
     expect(normalizeNumber('.00000001')).toBe(1e-8);
     expect(normalizeNumber('hello')).toBe('hello');
+    expect(normalizeNumber(1)).toBe(1);
   });
 });
 

--- a/server/utils/statemachine.js
+++ b/server/utils/statemachine.js
@@ -1,4 +1,4 @@
-const { MutexCounter } = require('../utils/mutex');
+const { Mutex, MutexValue, MutexCounter } = require('../utils/mutex');
 
 /**
  * A simple state machine implementation with safety checks to prevent invalid states and handlers.

--- a/server/utils/statemachine.js
+++ b/server/utils/statemachine.js
@@ -1,0 +1,76 @@
+const { MutexCounter } = require('../utils/mutex');
+
+/**
+ * A simple state machine implementation with safety checks to prevent invalid states and handlers.
+ * The StateMachine class takes an array of states and a corresponding handlers object. Each handler should return the name of the next state.
+ * The run() method executes the current state's handler and transitions to the next state based on the handler's return value.
+ * If an invalid state or handler is encountered, it resets to the initial state and logs an error.
+ * @class StateMachine
+ * @typedef {StateMachine}
+ */
+class StateMachine {
+  constructor(states, handlers) {
+    if (!Array.isArray(states) || states.length === 0) {
+      throw new Error('StateMachine requires a non-empty array of states');
+    }
+
+    this.states = states;
+    this.handlers = handlers;
+    this.state = new MutexValue(0); // protects stateIndex
+
+    // Validate handlers up front
+    for (const s of states) {
+      if (typeof handlers[s] !== 'function') {
+        throw new Error(`Missing handler for state "${s}"`);
+      }
+    }
+  }
+
+  async run() {
+    await this.state.update(async (index) => {
+      // --- SAFETY 1: clamp invalid index ---
+      if (index < 0 || index >= this.states.length) {
+        console.warn(`Invalid stateIndex=${index}, resetting to 0`);
+        index = 0;
+      }
+
+      const stateName = this.states[index];
+      const handler = this.handlers[stateName];
+
+      // --- SAFETY 2: handler must exist ---
+      if (!handler) {
+        console.error(`No handler for state "${stateName}", resetting`);
+        return 0;
+      }
+
+      // Run handler (may be async)
+      const nextStateName = await handler();
+
+      // --- SAFETY 3: next state must be valid ---
+      const nextIndex = this.states.indexOf(nextStateName);
+      if (nextIndex === -1) {
+        console.error(`Invalid next state "${nextStateName}", resetting`);
+        return 0;
+      }
+
+      return nextIndex;
+    });
+  }
+
+  async currentState() {
+    const index = await this.state.get();
+    if (index < 0 || index >= this.states.length) {
+      console.warn(`Invalid stateIndex=${index} in currentState(), resetting to 0`);
+      await this.state.update(() => 0);
+      return this.states[0];
+    }
+
+    return this.states[index];
+  }
+
+  reset() {
+    return this.state.update(() => 0);
+  }
+}
+
+module.exports = { StateMachine };

--- a/server/utils/statemachine.test.js
+++ b/server/utils/statemachine.test.js
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { StateMachine } from './statemachine.js';
+
+describe('StateMachine', () => {
+  const states = ['A', 'B', 'C'];
+  const handlers = {
+    A: () => 'B',
+    B: () => 'C',
+    C: () => 'C',
+  };
+
+  it('should initialize with valid states and handlers', () => {
+    const sm = new StateMachine(states, handlers);
+    expect(sm).toBeInstanceOf(StateMachine);
+  });
+
+  it('should iterate through states correctly', async () => {
+    const sm = new StateMachine(states, handlers);
+    expect(await sm.currentState()).toBe('A');
+    await sm.run();
+    expect(await sm.currentState()).toBe('B');
+    await sm.run();
+    expect(await sm.currentState()).toBe('C');
+    await sm.run();
+    expect(await sm.currentState()).toBe('C'); // stays in C
+  });
+
+  it('should reset to initial state', async () => {
+    const sm = new StateMachine(states, handlers);
+    await sm.run();
+    await sm.run();
+    expect(await sm.currentState()).toBe('C');
+    await sm.reset();
+    expect(await sm.currentState()).toBe('A');
+  });
+});
+
+describe('StateMachine with invalid inputs', () => {
+  it('should throw if states array is empty', () => {
+    expect(() => new StateMachine([], {})).toThrow();
+  });
+
+  it('should throw if handler is missing for a state', () => {
+    expect(() => new StateMachine(['A'], {})).toThrow();
+  });
+
+  it('should throw if invalid state index is provided', () => {
+    expect(() => {
+      new StateMachine(['A'], { A: () => 'B' });
+      sm.run(); // will try to run handler for state 'A' which returns 'B' (invalid)
+    }).toThrow();
+  });
+
+  {
+    const states = ['A', 'B', 'C'];
+    const handlers = {
+      A: () => 'B',
+      B: () => 'C',
+      C: () => 'C',
+    };
+
+    it('should recover from forcible invalid index in run()', async () => {
+      const sm = new StateMachine(['A'], { A: () => 'A' });
+      await sm.state.update(() => -1); // force invalid index
+      await sm.run();
+      expect(await sm.currentState()).toBe('A');
+    });
+
+    it('should reset if invalid index is provided', async () => {
+      const sm = new StateMachine(['A', 'B'], { A: () => 'B', B: () => 'B' });
+      await sm.run();
+      expect(await sm.currentState()).toBe('B');
+      await sm.state.update(() => -1); // force invalid index
+      expect(await sm.currentState()).toBe('A'); // should reset to 'A'
+    });
+
+    {
+      const states = ['A'];
+      const handlers = { A: () => 'A' };
+      it('should gracefully cope with missing handler', async () => {
+        const sm = new StateMachine(states, handlers);
+        handlers.A = null; // force missing handler
+        await sm.run();
+        expect(await sm.currentState()).toBe('A'); // should reset to 'A'
+      });
+    }
+
+    it('should reset if next state is invalid', async () => {
+      const sm = new StateMachine(states, { A: () => 'X', B: () => 'C', C: () => 'C' }); // A returns invalid state 'X'
+      await sm.run(); // will try to run handler for state 'A' which returns 'X' (invalid)
+      expect(await sm.currentState()).toBe('A'); // should reset to 'A'
+    });
+  }
+});


### PR DESCRIPTION
## What does this PR do?

- add server utils
  - normalize = string to numeric conversion, JSON string to numeric conversion
  - mutex = locking/unlocking, safe value and counters for asynchronous operation
  - statemachine = basic state machine with defined named states and handlers
- includes unit tests for each component

### is used where? not yet, coming soon

## Type of change
### utils
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [X] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [X] No `.bak`, `.old`, `console.log` debug lines, or test scripts included
