### PR TITLE
Move the QRZ.COM credentials settings to the Integrations Page

### DIFF
--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -2738,6 +2738,79 @@ export const SettingsPanel = ({
                     />
                   </div>
                 </div>
+
+                <details style={{ marginTop: 10 }}>
+                  <summary
+                    style={{
+                      cursor: 'pointer',
+                      color: 'var(--accent-amber)',
+                      fontSize: 12,
+                      userSelect: 'none',
+                    }}
+                  >
+                    Learn how
+                  </summary>
+
+                  <div
+                    style={{
+                      marginTop: 8,
+                      color: 'var(--text-secondary)',
+                      fontSize: 12,
+                      lineHeight: 1.55,
+                    }}
+                  >
+                    <div style={{ marginBottom: 6 }}>
+                      <b>Quick start (Local Only):</b>
+                    </div>
+
+                    <ol style={{ margin: 0, paddingLeft: 18 }}>
+                      <li>
+                        Run OpenHamClock locally:
+                        <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>npm start</div>
+                        Open the local URL shown in your terminal (example: http://127.0.0.1:3001).
+                      </li>
+
+                      <li style={{ marginTop: 6 }}>
+                        Install the N3FJP bridge on the same PC (or LAN machine) that can access your N3FJP logger.
+                      </li>
+
+                      <li style={{ marginTop: 6 }}>
+                        Edit the bridge <b>config.json</b> file and set:
+                        <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>
+                          "OHC_BASE_URL": "http://127.0.0.1:3001"
+                        </div>
+                        (Use the exact URL printed by OpenHamClock.)
+                      </li>
+
+                      <li style={{ marginTop: 6 }}>
+                        Ensure:
+                        <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>"ENABLE_OHC_HTTP": true</div>
+                      </li>
+
+                      <li style={{ marginTop: 6 }}>
+                        Start the bridge script (PowerShell or VBS launcher). You should see log messages when QSOs are
+                        entered.
+                      </li>
+
+                      <li style={{ marginTop: 6 }}>
+                        Enable this integration here, then turn on
+                        <b> Logged QSOs (N3FJP)</b> in
+                        <b> Settings → Map Layers</b>.
+                      </li>
+                    </ol>
+
+                    <div style={{ marginTop: 10, fontSize: 11, color: 'var(--text-muted)' }}>
+                      Tip: If you see “connection refused,” verify that OpenHamClock is running locally and that the
+                      port matches your
+                      <b> OHC_BASE_URL</b> setting.
+                    </div>
+
+                    <div style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
+                      Note: This integration cannot work on the hosted site because it requires access to your local
+                      N3FJP logger and LAN services.
+                    </div>
+                  </div>
+                </details>
               </div>
 
               {/* QRZ.com XML API Credentials */}
@@ -2946,79 +3019,6 @@ export const SettingsPanel = ({
                   </>
                 )}
               </div>
-
-              <details style={{ marginTop: 10 }}>
-                <summary
-                  style={{
-                    cursor: 'pointer',
-                    color: 'var(--accent-amber)',
-                    fontSize: 12,
-                    userSelect: 'none',
-                  }}
-                >
-                  Learn how
-                </summary>
-
-                <div
-                  style={{
-                    marginTop: 8,
-                    color: 'var(--text-secondary)',
-                    fontSize: 12,
-                    lineHeight: 1.55,
-                  }}
-                >
-                  <div style={{ marginBottom: 6 }}>
-                    <b>Quick start (Local Only):</b>
-                  </div>
-
-                  <ol style={{ margin: 0, paddingLeft: 18 }}>
-                    <li>
-                      Run OpenHamClock locally:
-                      <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>npm start</div>
-                      Open the local URL shown in your terminal (example: http://127.0.0.1:3001).
-                    </li>
-
-                    <li style={{ marginTop: 6 }}>
-                      Install the N3FJP bridge on the same PC (or LAN machine) that can access your N3FJP logger.
-                    </li>
-
-                    <li style={{ marginTop: 6 }}>
-                      Edit the bridge <b>config.json</b> file and set:
-                      <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>
-                        "OHC_BASE_URL": "http://127.0.0.1:3001"
-                      </div>
-                      (Use the exact URL printed by OpenHamClock.)
-                    </li>
-
-                    <li style={{ marginTop: 6 }}>
-                      Ensure:
-                      <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>"ENABLE_OHC_HTTP": true</div>
-                    </li>
-
-                    <li style={{ marginTop: 6 }}>
-                      Start the bridge script (PowerShell or VBS launcher). You should see log messages when QSOs are
-                      entered.
-                    </li>
-
-                    <li style={{ marginTop: 6 }}>
-                      Enable this integration here, then turn on
-                      <b> Logged QSOs (N3FJP)</b> in
-                      <b> Settings → Map Layers</b>.
-                    </li>
-                  </ol>
-
-                  <div style={{ marginTop: 10, fontSize: 11, color: 'var(--text-muted)' }}>
-                    Tip: If you see “connection refused,” verify that OpenHamClock is running locally and that the port
-                    matches your
-                    <b> OHC_BASE_URL</b> setting.
-                  </div>
-
-                  <div style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
-                    Note: This integration cannot work on the hosted site because it requires access to your local N3FJP
-                    logger and LAN services.
-                  </div>
-                </div>
-              </details>
             </div>
           </div>
         )}

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -2738,80 +2738,287 @@ export const SettingsPanel = ({
                     />
                   </div>
                 </div>
+              </div>
 
-                <details style={{ marginTop: 10 }}>
-                  <summary
-                    style={{
-                      cursor: 'pointer',
-                      color: 'var(--accent-amber)',
-                      fontSize: 12,
-                      userSelect: 'none',
-                    }}
+              {/* QRZ.com XML API Credentials */}
+              <div
+                style={{
+                  borderTop: '1px solid rgba(255,255,255,0.08)',
+                  paddingTop: 12,
+                  marginTop: 14,
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: '12px',
+                    fontWeight: '600',
+                    color: 'var(--accent-amber)',
+                    marginBottom: '4px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                  }}
+                >
+                  <span>📡 QRZ.com Callsign Lookup</span>
+                  {qrzStatus?.configured && (
+                    <span
+                      style={{
+                        fontSize: '10px',
+                        fontWeight: '500',
+                        padding: '1px 6px',
+                        borderRadius: '3px',
+                        background: qrzStatus.hasSession ? 'rgba(46, 204, 113, 0.15)' : 'rgba(241, 196, 15, 0.15)',
+                        color: qrzStatus.hasSession ? '#2ecc71' : '#f1c40f',
+                      }}
+                    >
+                      {qrzStatus.hasSession ? '● Connected' : '○ Configured'}
+                      {qrzStatus.source === 'env' ? ' (env)' : ''}
+                    </span>
+                  )}
+                </div>
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '8px', lineHeight: 1.4 }}>
+                  Enables precise station locations from{' '}
+                  <a
+                    href="https://www.qrz.com/i/subscriptions.html"
+                    target="_blank"
+                    rel="noopener"
+                    style={{ color: 'var(--accent-blue)' }}
                   >
-                    Learn how
-                  </summary>
-
+                    QRZ.com
+                  </a>{' '}
+                  user profiles (user-supplied coordinates, geocoded addresses, grid squares). Without this, locations
+                  fall back to HamQTH (country-level only). Requires a QRZ Logbook Data subscription.
+                  <br />
+                  <strong>Note</strong> this is a server setting and is not related to clicking a callsign to go to
+                  qrz.com. If you are not running a server, you will likely not have the permissions to change this.
+                </div>
+                {qrzStatus?.source === 'env' ? (
                   <div
                     style={{
-                      marginTop: 8,
-                      color: 'var(--text-secondary)',
-                      fontSize: 12,
-                      lineHeight: 1.55,
+                      fontSize: '11px',
+                      color: 'var(--text-muted)',
+                      padding: '8px',
+                      background: 'var(--bg-primary)',
+                      borderRadius: '4px',
                     }}
                   >
-                    <div style={{ marginBottom: 6 }}>
-                      <b>Quick start (Local Only):</b>
-                    </div>
-
-                    <ol style={{ margin: 0, paddingLeft: 18 }}>
-                      <li>
-                        Run OpenHamClock locally:
-                        <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>npm start</div>
-                        Open the local URL shown in your terminal (example: http://127.0.0.1:3001).
-                      </li>
-
-                      <li style={{ marginTop: 6 }}>
-                        Install the N3FJP bridge on the same PC (or LAN machine) that can access your N3FJP logger.
-                      </li>
-
-                      <li style={{ marginTop: 6 }}>
-                        Edit the bridge <b>config.json</b> file and set:
-                        <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>
-                          "OHC_BASE_URL": "http://127.0.0.1:3001"
-                        </div>
-                        (Use the exact URL printed by OpenHamClock.)
-                      </li>
-
-                      <li style={{ marginTop: 6 }}>
-                        Ensure:
-                        <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>"ENABLE_OHC_HTTP": true</div>
-                      </li>
-
-                      <li style={{ marginTop: 6 }}>
-                        Start the bridge script (PowerShell or VBS launcher). You should see log messages when QSOs are
-                        entered.
-                      </li>
-
-                      <li style={{ marginTop: 6 }}>
-                        Enable this integration here, then turn on
-                        <b> Logged QSOs (N3FJP)</b> in
-                        <b> Settings → Map Layers</b>.
-                      </li>
-                    </ol>
-
-                    <div style={{ marginTop: 10, fontSize: 11, color: 'var(--text-muted)' }}>
-                      Tip: If you see “connection refused,” verify that OpenHamClock is running locally and that the
-                      port matches your
-                      <b> OHC_BASE_URL</b> setting.
-                    </div>
-
-                    <div style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
-                      Note: This integration cannot work on the hosted site because it requires access to your local
-                      N3FJP logger and LAN services.
-                    </div>
+                    ✓ Credentials configured via{' '}
+                    <code style={{ background: 'var(--bg-tertiary)', padding: '1px 4px', borderRadius: '2px' }}>
+                      QRZ_USERNAME
+                    </code>{' '}
+                    /{' '}
+                    <code style={{ background: 'var(--bg-tertiary)', padding: '1px 4px', borderRadius: '2px' }}>
+                      QRZ_PASSWORD
+                    </code>{' '}
+                    in .env file
+                    {qrzStatus.lookupCount > 0 && (
+                      <span style={{ color: 'var(--accent-green)' }}>
+                        {' '}
+                        — {qrzStatus.lookupCount} lookups this session
+                      </span>
+                    )}
                   </div>
-                </details>
+                ) : (
+                  <>
+                    <div style={{ display: 'flex', gap: '8px', marginBottom: '8px' }}>
+                      <input
+                        disabled={!isLocalInstall}
+                        type="text"
+                        placeholder="QRZ Username (callsign)"
+                        value={qrzUsername}
+                        onChange={(e) => setQrzUsername(e.target.value)}
+                        style={{
+                          flex: 1,
+                          padding: '8px 12px',
+                          background: 'var(--bg-primary)',
+                          border: '1px solid var(--border-color)',
+                          borderRadius: '4px',
+                          color: 'var(--text-primary)',
+                          fontSize: '12px',
+                          fontFamily: 'var(--font-mono)',
+                          boxSizing: 'border-box',
+                        }}
+                      />
+                      <input
+                        disabled={!isLocalInstall}
+                        type="password"
+                        placeholder="QRZ Password"
+                        value={qrzPassword}
+                        onChange={(e) => setQrzPassword(e.target.value)}
+                        style={{
+                          flex: 1,
+                          padding: '8px 12px',
+                          background: 'var(--bg-primary)',
+                          border: '1px solid var(--border-color)',
+                          borderRadius: '4px',
+                          color: 'var(--text-primary)',
+                          fontSize: '12px',
+                          fontFamily: 'var(--font-mono)',
+                          boxSizing: 'border-box',
+                        }}
+                      />
+                    </div>
+                    <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                      <button
+                        disabled={!isLocalInstall || qrzTesting || !qrzUsername.trim() || !qrzPassword.trim()}
+                        onClick={async () => {
+                          setQrzTesting(true);
+                          setQrzMessage(null);
+                          try {
+                            const res = await fetch('/api/qrz/configure', {
+                              method: 'POST',
+                              headers: { 'Content-Type': 'application/json' },
+                              body: JSON.stringify({ username: qrzUsername.trim(), password: qrzPassword.trim() }),
+                            });
+                            const data = await res.json();
+                            if (data.success) {
+                              setQrzMessage({ type: 'success', text: 'Connected to QRZ.com successfully!' });
+                              setQrzPassword('');
+                              // Refresh status
+                              const st = await fetch('/api/qrz/status').then((r) => r.json());
+                              setQrzStatus(st);
+                            } else {
+                              setQrzMessage({ type: 'error', text: data.error || 'Login failed' });
+                            }
+                          } catch (e) {
+                            setQrzMessage({ type: 'error', text: 'Connection error' });
+                          }
+                          setQrzTesting(false);
+                        }}
+                        style={{
+                          padding: '6px 14px',
+                          fontSize: '11px',
+                          fontWeight: '600',
+                          borderRadius: '4px',
+                          border: 'none',
+                          cursor: qrzTesting || !qrzUsername.trim() || !qrzPassword.trim() ? 'not-allowed' : 'pointer',
+                          background: 'var(--accent-amber)',
+                          color: '#000',
+                          opacity: qrzTesting || !qrzUsername.trim() || !qrzPassword.trim() ? 0.5 : 1,
+                        }}
+                      >
+                        {qrzTesting ? 'Testing...' : 'Save & Test'}
+                      </button>
+                      {qrzStatus?.configured && qrzStatus.source !== 'env' && (
+                        <button
+                          onClick={async () => {
+                            await fetch('/api/qrz/remove', { method: 'POST' });
+                            setQrzUsername('');
+                            setQrzPassword('');
+                            setQrzMessage(null);
+                            const st = await fetch('/api/qrz/status').then((r) => r.json());
+                            setQrzStatus(st);
+                          }}
+                          style={{
+                            padding: '6px 12px',
+                            fontSize: '11px',
+                            borderRadius: '4px',
+                            border: '1px solid var(--border-color)',
+                            cursor: 'pointer',
+                            background: 'transparent',
+                            color: 'var(--text-muted)',
+                          }}
+                        >
+                          Remove
+                        </button>
+                      )}
+                      {qrzStatus?.configured && qrzStatus.lookupCount > 0 && (
+                        <span style={{ fontSize: '10px', color: 'var(--text-muted)' }}>
+                          {qrzStatus.lookupCount} lookups this session
+                        </span>
+                      )}
+                    </div>
+                    {qrzMessage && (
+                      <div
+                        style={{
+                          marginTop: '6px',
+                          fontSize: '11px',
+                          padding: '6px 10px',
+                          borderRadius: '4px',
+                          background:
+                            qrzMessage.type === 'success' ? 'rgba(46, 204, 113, 0.1)' : 'rgba(231, 76, 60, 0.1)',
+                          color: qrzMessage.type === 'success' ? '#2ecc71' : '#e74c3c',
+                        }}
+                      >
+                        {qrzMessage.type === 'success' ? '✓' : '✗'} {qrzMessage.text}
+                      </div>
+                    )}
+                  </>
+                )}
               </div>
+
+              <details style={{ marginTop: 10 }}>
+                <summary
+                  style={{
+                    cursor: 'pointer',
+                    color: 'var(--accent-amber)',
+                    fontSize: 12,
+                    userSelect: 'none',
+                  }}
+                >
+                  Learn how
+                </summary>
+
+                <div
+                  style={{
+                    marginTop: 8,
+                    color: 'var(--text-secondary)',
+                    fontSize: 12,
+                    lineHeight: 1.55,
+                  }}
+                >
+                  <div style={{ marginBottom: 6 }}>
+                    <b>Quick start (Local Only):</b>
+                  </div>
+
+                  <ol style={{ margin: 0, paddingLeft: 18 }}>
+                    <li>
+                      Run OpenHamClock locally:
+                      <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>npm start</div>
+                      Open the local URL shown in your terminal (example: http://127.0.0.1:3001).
+                    </li>
+
+                    <li style={{ marginTop: 6 }}>
+                      Install the N3FJP bridge on the same PC (or LAN machine) that can access your N3FJP logger.
+                    </li>
+
+                    <li style={{ marginTop: 6 }}>
+                      Edit the bridge <b>config.json</b> file and set:
+                      <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>
+                        "OHC_BASE_URL": "http://127.0.0.1:3001"
+                      </div>
+                      (Use the exact URL printed by OpenHamClock.)
+                    </li>
+
+                    <li style={{ marginTop: 6 }}>
+                      Ensure:
+                      <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>"ENABLE_OHC_HTTP": true</div>
+                    </li>
+
+                    <li style={{ marginTop: 6 }}>
+                      Start the bridge script (PowerShell or VBS launcher). You should see log messages when QSOs are
+                      entered.
+                    </li>
+
+                    <li style={{ marginTop: 6 }}>
+                      Enable this integration here, then turn on
+                      <b> Logged QSOs (N3FJP)</b> in
+                      <b> Settings → Map Layers</b>.
+                    </li>
+                  </ol>
+
+                  <div style={{ marginTop: 10, fontSize: 11, color: 'var(--text-muted)' }}>
+                    Tip: If you see “connection refused,” verify that OpenHamClock is running locally and that the port
+                    matches your
+                    <b> OHC_BASE_URL</b> setting.
+                  </div>
+
+                  <div style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
+                    Note: This integration cannot work on the hosted site because it requires access to your local N3FJP
+                    logger and LAN services.
+                  </div>
+                </div>
+              </details>
             </div>
           </div>
         )}
@@ -4212,213 +4419,6 @@ export const SettingsPanel = ({
                       );
                     })}
                 </div>
-              )}
-            </div>
-
-            {/* QRZ.com XML API Credentials */}
-            <div
-              style={{
-                padding: '12px',
-                background: 'var(--bg-tertiary)',
-                borderRadius: '8px',
-                border: '1px solid var(--border-color)',
-                marginBottom: '12px',
-              }}
-            >
-              <div
-                style={{
-                  fontSize: '12px',
-                  fontWeight: '600',
-                  color: 'var(--accent-amber)',
-                  marginBottom: '4px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '8px',
-                }}
-              >
-                <span>📡 QRZ.com Callsign Lookup</span>
-                {qrzStatus?.configured && (
-                  <span
-                    style={{
-                      fontSize: '10px',
-                      fontWeight: '500',
-                      padding: '1px 6px',
-                      borderRadius: '3px',
-                      background: qrzStatus.hasSession ? 'rgba(46, 204, 113, 0.15)' : 'rgba(241, 196, 15, 0.15)',
-                      color: qrzStatus.hasSession ? '#2ecc71' : '#f1c40f',
-                    }}
-                  >
-                    {qrzStatus.hasSession ? '● Connected' : '○ Configured'}
-                    {qrzStatus.source === 'env' ? ' (env)' : ''}
-                  </span>
-                )}
-              </div>
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '8px', lineHeight: 1.4 }}>
-                Enables precise station locations from{' '}
-                <a
-                  href="https://www.qrz.com/i/subscriptions.html"
-                  target="_blank"
-                  rel="noopener"
-                  style={{ color: 'var(--accent-blue)' }}
-                >
-                  QRZ.com
-                </a>{' '}
-                user profiles (user-supplied coordinates, geocoded addresses, grid squares). Without this, locations
-                fall back to HamQTH (country-level only). Requires a QRZ Logbook Data subscription.
-                <br />
-                <strong>Note</strong> this is a server setting and is not related to clicking a callsign to go to
-                qrz.com. If you are not running a server, you will likely not have the permissions to change this.
-              </div>
-              {qrzStatus?.source === 'env' ? (
-                <div
-                  style={{
-                    fontSize: '11px',
-                    color: 'var(--text-muted)',
-                    padding: '8px',
-                    background: 'var(--bg-primary)',
-                    borderRadius: '4px',
-                  }}
-                >
-                  ✓ Credentials configured via{' '}
-                  <code style={{ background: 'var(--bg-tertiary)', padding: '1px 4px', borderRadius: '2px' }}>
-                    QRZ_USERNAME
-                  </code>{' '}
-                  /{' '}
-                  <code style={{ background: 'var(--bg-tertiary)', padding: '1px 4px', borderRadius: '2px' }}>
-                    QRZ_PASSWORD
-                  </code>{' '}
-                  in .env file
-                  {qrzStatus.lookupCount > 0 && (
-                    <span style={{ color: 'var(--accent-green)' }}>
-                      {' '}
-                      — {qrzStatus.lookupCount} lookups this session
-                    </span>
-                  )}
-                </div>
-              ) : (
-                <>
-                  <div style={{ display: 'flex', gap: '8px', marginBottom: '8px' }}>
-                    <input
-                      type="text"
-                      placeholder="QRZ Username (callsign)"
-                      value={qrzUsername}
-                      onChange={(e) => setQrzUsername(e.target.value)}
-                      style={{
-                        flex: 1,
-                        padding: '8px 12px',
-                        background: 'var(--bg-primary)',
-                        border: '1px solid var(--border-color)',
-                        borderRadius: '4px',
-                        color: 'var(--text-primary)',
-                        fontSize: '12px',
-                        fontFamily: 'var(--font-mono)',
-                        boxSizing: 'border-box',
-                      }}
-                    />
-                    <input
-                      type="password"
-                      placeholder="QRZ Password"
-                      value={qrzPassword}
-                      onChange={(e) => setQrzPassword(e.target.value)}
-                      style={{
-                        flex: 1,
-                        padding: '8px 12px',
-                        background: 'var(--bg-primary)',
-                        border: '1px solid var(--border-color)',
-                        borderRadius: '4px',
-                        color: 'var(--text-primary)',
-                        fontSize: '12px',
-                        fontFamily: 'var(--font-mono)',
-                        boxSizing: 'border-box',
-                      }}
-                    />
-                  </div>
-                  <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-                    <button
-                      disabled={qrzTesting || !qrzUsername.trim() || !qrzPassword.trim()}
-                      onClick={async () => {
-                        setQrzTesting(true);
-                        setQrzMessage(null);
-                        try {
-                          const res = await fetch('/api/qrz/configure', {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ username: qrzUsername.trim(), password: qrzPassword.trim() }),
-                          });
-                          const data = await res.json();
-                          if (data.success) {
-                            setQrzMessage({ type: 'success', text: 'Connected to QRZ.com successfully!' });
-                            setQrzPassword('');
-                            // Refresh status
-                            const st = await fetch('/api/qrz/status').then((r) => r.json());
-                            setQrzStatus(st);
-                          } else {
-                            setQrzMessage({ type: 'error', text: data.error || 'Login failed' });
-                          }
-                        } catch (e) {
-                          setQrzMessage({ type: 'error', text: 'Connection error' });
-                        }
-                        setQrzTesting(false);
-                      }}
-                      style={{
-                        padding: '6px 14px',
-                        fontSize: '11px',
-                        fontWeight: '600',
-                        borderRadius: '4px',
-                        border: 'none',
-                        cursor: qrzTesting || !qrzUsername.trim() || !qrzPassword.trim() ? 'not-allowed' : 'pointer',
-                        background: 'var(--accent-amber)',
-                        color: '#000',
-                        opacity: qrzTesting || !qrzUsername.trim() || !qrzPassword.trim() ? 0.5 : 1,
-                      }}
-                    >
-                      {qrzTesting ? 'Testing...' : 'Save & Test'}
-                    </button>
-                    {qrzStatus?.configured && qrzStatus.source !== 'env' && (
-                      <button
-                        onClick={async () => {
-                          await fetch('/api/qrz/remove', { method: 'POST' });
-                          setQrzUsername('');
-                          setQrzPassword('');
-                          setQrzMessage(null);
-                          const st = await fetch('/api/qrz/status').then((r) => r.json());
-                          setQrzStatus(st);
-                        }}
-                        style={{
-                          padding: '6px 12px',
-                          fontSize: '11px',
-                          borderRadius: '4px',
-                          border: '1px solid var(--border-color)',
-                          cursor: 'pointer',
-                          background: 'transparent',
-                          color: 'var(--text-muted)',
-                        }}
-                      >
-                        Remove
-                      </button>
-                    )}
-                    {qrzStatus?.configured && qrzStatus.lookupCount > 0 && (
-                      <span style={{ fontSize: '10px', color: 'var(--text-muted)' }}>
-                        {qrzStatus.lookupCount} lookups this session
-                      </span>
-                    )}
-                  </div>
-                  {qrzMessage && (
-                    <div
-                      style={{
-                        marginTop: '6px',
-                        fontSize: '11px',
-                        padding: '6px 10px',
-                        borderRadius: '4px',
-                        background:
-                          qrzMessage.type === 'success' ? 'rgba(46, 204, 113, 0.1)' : 'rgba(231, 76, 60, 0.1)',
-                        color: qrzMessage.type === 'success' ? '#2ecc71' : '#e74c3c',
-                      }}
-                    >
-                      {qrzMessage.type === 'success' ? '✓' : '✗'} {qrzMessage.text}
-                    </div>
-                  )}
-                </>
               )}
             </div>
 


### PR DESCRIPTION
## What does this PR do?

In spite of a clear notice that this is a setting only for folks running local servers people are still asking about how to set it.

This PR moves it to the Integrations settings panel and have it part of the Local-only settings and have it only settable if isLocalInstall is true.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [X] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Run up with a local server
   a. Verify the QRZ.COM Credentials settings do not appear on the Profiles Settings panel
   b. Verify the QRZ.COM Credentials settings appear on the integrations page, the fields can be filled in and on completion of both text fields, the button becomes enabled.
2. Fudge isLocalServer to be false in SettingsPanel and restart server
   a. Verify the QRZ.COM Credentials settings do not appear on the Profiles Settings panel
   b. Verify that the QRZ.COm credentials settings cannot be edited

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [X] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [X] No `.bak`, `.old`, `console.log` debug lines, or test scripts included
