### PR TITLE
[satellites] update satellites tracked

### DIFF
--- a/server/routes/satellites-tracked.js
+++ b/server/routes/satellites-tracked.js
@@ -230,7 +230,7 @@ const HAM_SATELLITES = {
   'ELEKTRO-L4': {
     data_source: 'celestrak_active',
     norad: 55506,
-    name: 'ELEKTRO-L3',
+    name: 'ELEKTRO-L4',
     color: '#ff9900',
     priority: 2,
   },

--- a/server/routes/satellites-tracked.js
+++ b/server/routes/satellites-tracked.js
@@ -43,11 +43,17 @@
 // removed TEVEL satellites, added TEVEL2 satellites
 // remove (deactivated) GOES-13
 // remove (decayed) SO-124, CAS-4A, CAS-4B, EO-88, XW-2A, XW-2B, XW-2C, XW-2F
+//
+// May 18, 2026
+// added #41866 GOES-16 celestrak_weather
+// added #55506 ELEKTRO-L4 celestrak_active
+// added #67756 ELEKTRO-L5 celestrak_active
+// removed #53106(payload) = #53109(rocket body) = IO-117(Greencube), satellite decommissioned
 
 const HAM_SATELLITES = {
   // ── High Priority — Popular FM Satellites ──────────────────────
   ISS: {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 25544,
     name: 'ISS (ZARYA)',
     color: '#00ffff',
@@ -58,7 +64,7 @@ const HAM_SATELLITES = {
     tone: '67.0 Hz',
   },
   'SO-50': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 27607,
     name: 'SO-50',
     color: '#00ff00',
@@ -70,7 +76,7 @@ const HAM_SATELLITES = {
     armTone: '74.4 Hz',
   },
   'AO-91': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 43017,
     name: 'AO-91 (Fox-1B)',
     color: '#ff6600',
@@ -81,7 +87,7 @@ const HAM_SATELLITES = {
     tone: '67.0 Hz',
   },
   'AO-123': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 61781,
     name: 'AO-123 (ASRTU-1)',
     color: '#ff3399',
@@ -92,7 +98,7 @@ const HAM_SATELLITES = {
     tone: '67.0 Hz',
   },
   'SO-125': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63492,
     name: 'SO-125 (HADES-ICM)',
     color: '#ff55bb',
@@ -103,7 +109,7 @@ const HAM_SATELLITES = {
     tone: '67.0 Hz',
   },
   'QMR-KWT-2': {
-    // CelesTrak group: active
+    data_source: 'celestrak_active',
     norad: 67291,
     name: 'QMR-KWT-2',
     color: '#ff88dd',
@@ -114,7 +120,7 @@ const HAM_SATELLITES = {
     tone: '67.0 Hz',
   },
   'PO-101': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 43678,
     name: 'PO-101 (DIWATA-2B)',
     color: '#cc66ff',
@@ -126,8 +132,15 @@ const HAM_SATELLITES = {
   },
 
   // ── Weather Satellites — GOES & METEOR ─────────────────────────
+  'GOES-16': {
+    data_source: 'celestrak_weather',
+    norad: 41866,
+    name: 'GOES-16',
+    color: '#66ff66',
+    priority: 1,
+  },
   'GOES-18': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 51850,
     name: 'GOES-18',
     color: '#66ff66',
@@ -137,7 +150,7 @@ const HAM_SATELLITES = {
     grbFrequency: '1686.600 MHz',
   },
   'GOES-19': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 60133,
     name: 'GOES-19',
     color: '#33cc33',
@@ -147,7 +160,7 @@ const HAM_SATELLITES = {
     grbFrequency: '1686.600 MHz',
   },
   'METOP-B': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 38771,
     name: 'MetOp-B',
     color: '#FF6600',
@@ -156,7 +169,7 @@ const HAM_SATELLITES = {
     hrptFrequency: '1701.300 MHz',
   },
   'METOP-C': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 43689,
     name: 'MetOp-C',
     color: '#FF8800',
@@ -165,7 +178,7 @@ const HAM_SATELLITES = {
     hrptFrequency: '1701.300 MHz',
   },
   'METEOR-M2-3': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 57166,
     name: 'METEOR M2-3',
     color: '#FF0000',
@@ -175,7 +188,7 @@ const HAM_SATELLITES = {
     hrptFrequency: '1700.000 MHz',
   },
   'METEOR-M2-4': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 59051,
     name: 'METEOR M2-4',
     color: '#FF0000',
@@ -187,7 +200,7 @@ const HAM_SATELLITES = {
 
   // ── Weather Satellites — Geostationary (non-GOES) ─────────────
   'EWS-G2': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 36411,
     name: 'EWS-G2 (GOES-15)',
     color: '#0044cc',
@@ -197,7 +210,7 @@ const HAM_SATELLITES = {
     sdFrequency: '1676.000 MHz',
   },
   'ELEKTRO-L2': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 41105,
     name: 'ELEKTRO-L2',
     color: '#ffcc00',
@@ -206,7 +219,7 @@ const HAM_SATELLITES = {
     frequency: '1691.000 MHz',
   },
   'ELEKTRO-L3': {
-    // CelesTrak group: active
+    data_source: 'celestrak_active',
     norad: 44903,
     name: 'ELEKTRO-L3',
     color: '#ff9900',
@@ -214,8 +227,22 @@ const HAM_SATELLITES = {
     mode: 'HRIT/LRIT',
     frequency: '1691.000 MHz',
   },
+  'ELEKTRO-L4': {
+    data_source: 'celestrak_active',
+    norad: 55506,
+    name: 'ELEKTRO-L3',
+    color: '#ff9900',
+    priority: 2,
+  },
+  'ELEKTRO-L5': {
+    data_source: 'celestrak_active',
+    norad: 67756,
+    name: 'ELEKTRO-L5',
+    color: '#ff9900',
+    priority: 2,
+  },
   'GK-2A': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 43823,
     name: 'GK-2A',
     color: '#ff33cc',
@@ -224,7 +251,7 @@ const HAM_SATELLITES = {
     frequency: '1692.140 MHz',
   },
   'HIMAWARI-9': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 41836,
     name: 'HIMAWARI-9',
     color: '#9900cc',
@@ -235,7 +262,7 @@ const HAM_SATELLITES = {
 
   // ── Weather Satellites — Polar (X-Band) ───────────────────────
   'NOAA-20': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 43013,
     name: 'NOAA-20',
     color: '#00ccff',
@@ -244,7 +271,7 @@ const HAM_SATELLITES = {
     frequency: '7812.000 MHz',
   },
   'NOAA-21': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 54234,
     name: 'NOAA-21',
     color: '#0099ff',
@@ -255,7 +282,7 @@ const HAM_SATELLITES = {
 
   // ── Linear Transponder Satellites ──────────────────────────────
   'RS-44': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 44909,
     name: 'RS-44 (DOSAAF)',
     color: '#ff0066',
@@ -265,7 +292,7 @@ const HAM_SATELLITES = {
     uplink: '145.935 - 145.995 MHz',
   },
   'QO-100': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 43700,
     name: "QO-100 (Es'hail-2)",
     color: '#ffff00',
@@ -275,7 +302,7 @@ const HAM_SATELLITES = {
     uplink: '2400.050 - 2400.300 MHz',
   },
   'AO-7': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 7530,
     name: 'AO-7',
     color: '#ffcc00',
@@ -285,7 +312,7 @@ const HAM_SATELLITES = {
     uplink: '432.125 - 432.175 MHz',
   },
   'FO-29': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 24278,
     name: 'FO-29 (JAS-2)',
     color: '#ff6699',
@@ -295,7 +322,7 @@ const HAM_SATELLITES = {
     uplink: '145.900 - 146.000 MHz',
   },
   'JO-97': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 43803,
     name: 'JO-97 (JY1Sat)',
     color: '#cc99ff',
@@ -305,7 +332,7 @@ const HAM_SATELLITES = {
     uplink: '435.100 - 435.120 MHz',
   },
   'AO-73': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 39444,
     name: 'AO-73 (FUNcube-1)',
     color: '#ffcc66',
@@ -317,7 +344,7 @@ const HAM_SATELLITES = {
 
   // ── CAS (Chinese Amateur Satellites) ───────────────────────────
   'CAS-6': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 44881,
     name: 'CAS-6 (TO-108)',
     color: '#cc66ff',
@@ -329,7 +356,7 @@ const HAM_SATELLITES = {
 
   // ── Digipeaters ────────────────────────────────────────────────
   'IO-86': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 40931,
     name: 'IO-86 (LAPAN-A2/ORARI)',
     color: '#33ccaa',
@@ -338,76 +365,66 @@ const HAM_SATELLITES = {
     downlink: '145.825 MHz',
     uplink: '145.825 MHz',
   },
-  'IO-117': {
-    // CelesTrak group: satnogs
-    norad: 53106,
-    name: 'IO-117 (GreenCube)',
-    color: '#00ff99',
-    priority: 2,
-    mode: 'Digipeater',
-    downlink: '435.310 MHz',
-    uplink: '435.310 MHz',
-  },
 
   // ── TEVEL2 Constellation — activated periodically ───────────────
   'TEVEL2-1': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63217,
     name: 'TEVEL2-1',
     color: '#66ccff',
     priority: 3,
   },
   'TEVEL2-2': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63219,
     name: 'TEVEL2-2',
     color: '#66ccff',
     priority: 3,
   },
   'TEVEL2-3': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63218,
     name: 'TEVEL2-3',
     color: '#66ccff',
     priority: 3,
   },
   'TEVEL2-4': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63213,
     name: 'TEVEL2-4',
     color: '#66ccff',
     priority: 3,
   },
   'TEVEL2-5': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63214,
     name: 'TEVEL2-5',
     color: '#66ccff',
     priority: 3,
   },
   'TEVEL2-6': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63215,
     name: 'TEVEL2-6',
     color: '#66ccff',
     priority: 3,
   },
   'TEVEL2-7': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63238,
     name: 'TEVEL2-7',
     color: '#66ccff',
     priority: 3,
   },
   'TEVEL2-8': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63239,
     name: 'TEVEL2-8',
     color: '#66ccff',
     priority: 3,
   },
   'TEVEL2-9': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63237,
     name: 'TEVEL2-9',
     color: '#66ccff',


### PR DESCRIPTION
## What does this PR do?

- update satellites tracked list, ref/thank @creinemann 
- added #41866 GOES-16 celestrak_weather
- added #55506 ELEKTRO-L4 celestrak_active
- added #67756 ELEKTRO-L5 celestrak_active
- removed #53106(payload) = #53109(rocket body) = IO-117(Greencube), satellite decommissioned
- for all entries adds data_source field with CelesTrak group data source

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test


## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

