### PR TITLE
(fix issue 987) Shrink satellites dialog to minimal size

### DIFF
--- a/server/routes/satellites-tracked.js
+++ b/server/routes/satellites-tracked.js
@@ -43,11 +43,17 @@
 // removed TEVEL satellites, added TEVEL2 satellites
 // remove (deactivated) GOES-13
 // remove (decayed) SO-124, CAS-4A, CAS-4B, EO-88, XW-2A, XW-2B, XW-2C, XW-2F
+//
+// May 18, 2026
+// added #41866 GOES-16 celestrak_weather
+// added #55506 ELEKTRO-L4 celestrak_active
+// added #67756 ELEKTRO-L5 celestrak_active
+// removed #53106(payload) = #53109(rocket body) = IO-117(Greencube), satellite decommissioned
 
 const HAM_SATELLITES = {
   // ── High Priority — Popular FM Satellites ──────────────────────
   ISS: {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 25544,
     name: 'ISS (ZARYA)',
     color: '#00ffff',
@@ -58,7 +64,7 @@ const HAM_SATELLITES = {
     tone: '67.0 Hz',
   },
   'SO-50': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 27607,
     name: 'SO-50',
     color: '#00ff00',
@@ -70,7 +76,7 @@ const HAM_SATELLITES = {
     armTone: '74.4 Hz',
   },
   'AO-91': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 43017,
     name: 'AO-91 (Fox-1B)',
     color: '#ff6600',
@@ -81,7 +87,7 @@ const HAM_SATELLITES = {
     tone: '67.0 Hz',
   },
   'AO-123': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 61781,
     name: 'AO-123 (ASRTU-1)',
     color: '#ff3399',
@@ -92,7 +98,7 @@ const HAM_SATELLITES = {
     tone: '67.0 Hz',
   },
   'SO-125': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63492,
     name: 'SO-125 (HADES-ICM)',
     color: '#ff55bb',
@@ -103,7 +109,7 @@ const HAM_SATELLITES = {
     tone: '67.0 Hz',
   },
   'QMR-KWT-2': {
-    // CelesTrak group: active
+    data_source: 'celestrak_active',
     norad: 67291,
     name: 'QMR-KWT-2',
     color: '#ff88dd',
@@ -114,7 +120,7 @@ const HAM_SATELLITES = {
     tone: '67.0 Hz',
   },
   'PO-101': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 43678,
     name: 'PO-101 (DIWATA-2B)',
     color: '#cc66ff',
@@ -126,8 +132,15 @@ const HAM_SATELLITES = {
   },
 
   // ── Weather Satellites — GOES & METEOR ─────────────────────────
+  'GOES-16': {
+    data_source: 'celestrak_weather',
+    norad: 41866,
+    name: 'GOES-16',
+    color: '#66ff66',
+    priority: 1,
+  },
   'GOES-18': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 51850,
     name: 'GOES-18',
     color: '#66ff66',
@@ -137,7 +150,7 @@ const HAM_SATELLITES = {
     grbFrequency: '1686.600 MHz',
   },
   'GOES-19': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 60133,
     name: 'GOES-19',
     color: '#33cc33',
@@ -147,7 +160,7 @@ const HAM_SATELLITES = {
     grbFrequency: '1686.600 MHz',
   },
   'METOP-B': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 38771,
     name: 'MetOp-B',
     color: '#FF6600',
@@ -156,7 +169,7 @@ const HAM_SATELLITES = {
     hrptFrequency: '1701.300 MHz',
   },
   'METOP-C': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 43689,
     name: 'MetOp-C',
     color: '#FF8800',
@@ -165,7 +178,7 @@ const HAM_SATELLITES = {
     hrptFrequency: '1701.300 MHz',
   },
   'METEOR-M2-3': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 57166,
     name: 'METEOR M2-3',
     color: '#FF0000',
@@ -175,7 +188,7 @@ const HAM_SATELLITES = {
     hrptFrequency: '1700.000 MHz',
   },
   'METEOR-M2-4': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 59051,
     name: 'METEOR M2-4',
     color: '#FF0000',
@@ -187,7 +200,7 @@ const HAM_SATELLITES = {
 
   // ── Weather Satellites — Geostationary (non-GOES) ─────────────
   'EWS-G2': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 36411,
     name: 'EWS-G2 (GOES-15)',
     color: '#0044cc',
@@ -197,7 +210,7 @@ const HAM_SATELLITES = {
     sdFrequency: '1676.000 MHz',
   },
   'ELEKTRO-L2': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 41105,
     name: 'ELEKTRO-L2',
     color: '#ffcc00',
@@ -206,7 +219,7 @@ const HAM_SATELLITES = {
     frequency: '1691.000 MHz',
   },
   'ELEKTRO-L3': {
-    // CelesTrak group: active
+    data_source: 'celestrak_active',
     norad: 44903,
     name: 'ELEKTRO-L3',
     color: '#ff9900',
@@ -214,8 +227,22 @@ const HAM_SATELLITES = {
     mode: 'HRIT/LRIT',
     frequency: '1691.000 MHz',
   },
+  'ELEKTRO-L4': {
+    data_source: 'celestrak_active',
+    norad: 55506,
+    name: 'ELEKTRO-L4',
+    color: '#ff9900',
+    priority: 2,
+  },
+  'ELEKTRO-L5': {
+    data_source: 'celestrak_active',
+    norad: 67756,
+    name: 'ELEKTRO-L5',
+    color: '#ff9900',
+    priority: 2,
+  },
   'GK-2A': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 43823,
     name: 'GK-2A',
     color: '#ff33cc',
@@ -224,7 +251,7 @@ const HAM_SATELLITES = {
     frequency: '1692.140 MHz',
   },
   'HIMAWARI-9': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 41836,
     name: 'HIMAWARI-9',
     color: '#9900cc',
@@ -235,7 +262,7 @@ const HAM_SATELLITES = {
 
   // ── Weather Satellites — Polar (X-Band) ───────────────────────
   'NOAA-20': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 43013,
     name: 'NOAA-20',
     color: '#00ccff',
@@ -244,7 +271,7 @@ const HAM_SATELLITES = {
     frequency: '7812.000 MHz',
   },
   'NOAA-21': {
-    // CelesTrak group: weather
+    data_source: 'celestrak_weather',
     norad: 54234,
     name: 'NOAA-21',
     color: '#0099ff',
@@ -255,7 +282,7 @@ const HAM_SATELLITES = {
 
   // ── Linear Transponder Satellites ──────────────────────────────
   'RS-44': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 44909,
     name: 'RS-44 (DOSAAF)',
     color: '#ff0066',
@@ -265,7 +292,7 @@ const HAM_SATELLITES = {
     uplink: '145.935 - 145.995 MHz',
   },
   'QO-100': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 43700,
     name: "QO-100 (Es'hail-2)",
     color: '#ffff00',
@@ -275,7 +302,7 @@ const HAM_SATELLITES = {
     uplink: '2400.050 - 2400.300 MHz',
   },
   'AO-7': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 7530,
     name: 'AO-7',
     color: '#ffcc00',
@@ -285,7 +312,7 @@ const HAM_SATELLITES = {
     uplink: '432.125 - 432.175 MHz',
   },
   'FO-29': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 24278,
     name: 'FO-29 (JAS-2)',
     color: '#ff6699',
@@ -295,7 +322,7 @@ const HAM_SATELLITES = {
     uplink: '145.900 - 146.000 MHz',
   },
   'JO-97': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 43803,
     name: 'JO-97 (JY1Sat)',
     color: '#cc99ff',
@@ -305,7 +332,7 @@ const HAM_SATELLITES = {
     uplink: '435.100 - 435.120 MHz',
   },
   'AO-73': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 39444,
     name: 'AO-73 (FUNcube-1)',
     color: '#ffcc66',
@@ -317,7 +344,7 @@ const HAM_SATELLITES = {
 
   // ── CAS (Chinese Amateur Satellites) ───────────────────────────
   'CAS-6': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 44881,
     name: 'CAS-6 (TO-108)',
     color: '#cc66ff',
@@ -329,7 +356,7 @@ const HAM_SATELLITES = {
 
   // ── Digipeaters ────────────────────────────────────────────────
   'IO-86': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 40931,
     name: 'IO-86 (LAPAN-A2/ORARI)',
     color: '#33ccaa',
@@ -338,76 +365,66 @@ const HAM_SATELLITES = {
     downlink: '145.825 MHz',
     uplink: '145.825 MHz',
   },
-  'IO-117': {
-    // CelesTrak group: satnogs
-    norad: 53106,
-    name: 'IO-117 (GreenCube)',
-    color: '#00ff99',
-    priority: 2,
-    mode: 'Digipeater',
-    downlink: '435.310 MHz',
-    uplink: '435.310 MHz',
-  },
 
   // ── TEVEL2 Constellation — activated periodically ───────────────
   'TEVEL2-1': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63217,
     name: 'TEVEL2-1',
     color: '#66ccff',
     priority: 3,
   },
   'TEVEL2-2': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63219,
     name: 'TEVEL2-2',
     color: '#66ccff',
     priority: 3,
   },
   'TEVEL2-3': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63218,
     name: 'TEVEL2-3',
     color: '#66ccff',
     priority: 3,
   },
   'TEVEL2-4': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63213,
     name: 'TEVEL2-4',
     color: '#66ccff',
     priority: 3,
   },
   'TEVEL2-5': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63214,
     name: 'TEVEL2-5',
     color: '#66ccff',
     priority: 3,
   },
   'TEVEL2-6': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63215,
     name: 'TEVEL2-6',
     color: '#66ccff',
     priority: 3,
   },
   'TEVEL2-7': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63238,
     name: 'TEVEL2-7',
     color: '#66ccff',
     priority: 3,
   },
   'TEVEL2-8': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63239,
     name: 'TEVEL2-8',
     color: '#66ccff',
     priority: 3,
   },
   'TEVEL2-9': {
-    // CelesTrak group: amateur
+    data_source: 'celestrak_amateur',
     norad: 63237,
     name: 'TEVEL2-9',
     color: '#66ccff',

--- a/server/routes/space-weather.js
+++ b/server/routes/space-weather.js
@@ -560,13 +560,22 @@ module.exports = function (app, ctx) {
   });
 
   // NOAA Space Weather - X-Ray Flux
+  // The panel offers 6/12/24/48h history windows. We pull the 3-day SWPC feed
+  // (covers the 48h max with headroom), then keep only the 0.1-0.8nm band the
+  // panel plots and trim to the last 50h. Without that, the raw feed is several
+  // MB per response — served to every client every 5 min.
+  const XRAY_WINDOW_MS = 50 * 60 * 60 * 1000;
   app.get('/api/noaa/xray', async (req, res) => {
     try {
       if (noaaCache.xray.data && Date.now() - noaaCache.xray.timestamp < NOAA_CACHE_TTL) {
         return res.json(noaaCache.xray.data);
       }
-      const response = await fetch('https://services.swpc.noaa.gov/json/goes/primary/xrays-6-hour.json');
-      const data = await response.json();
+      const response = await fetch('https://services.swpc.noaa.gov/json/goes/primary/xrays-3-day.json');
+      const raw = await response.json();
+      const cutoff = Date.now() - XRAY_WINDOW_MS;
+      const data = Array.isArray(raw)
+        ? raw.filter((d) => d.energy === '0.1-0.8nm' && new Date(d.time_tag).getTime() >= cutoff)
+        : raw;
       noaaCache.xray = { data, timestamp: Date.now() };
       res.json(data);
     } catch (error) {

--- a/server/routes/wsjtx.js
+++ b/server/routes/wsjtx.js
@@ -812,11 +812,18 @@ module.exports = function (app, ctx) {
   const N3FJP_QSO_RETENTION_MINUTES = parseInt(process.env.N3FJP_QSO_RETENTION_MINUTES || '1440', 10);
   let n3fjpQsos = [];
 
+  // A transient "as you type" preview self-expires quickly, so a bridge that
+  // dies mid-entry without sending an explicit clear never leaves a stuck dot.
+  const N3FJP_PREVIEW_TTL_MS = 5 * 60 * 1000;
+
   function pruneN3fjpQsos() {
-    const cutoff = Date.now() - N3FJP_QSO_RETENTION_MINUTES * 60 * 1000;
+    const now = Date.now();
+    const cutoff = now - N3FJP_QSO_RETENTION_MINUTES * 60 * 1000;
     n3fjpQsos = n3fjpQsos.filter((q) => {
       const t = Date.parse(q.ts_utc || q.timestamp || '');
-      return !Number.isNaN(t) && t >= cutoff;
+      if (Number.isNaN(t)) return false;
+      if (q.status === 'preview') return now - t < N3FJP_PREVIEW_TTL_MS;
+      return t >= cutoff;
     });
   }
 
@@ -849,11 +856,27 @@ module.exports = function (app, ctx) {
     return null;
   }
 
-  // POST one QSO from a bridge (your Python script)
+  // POST one QSO from the local N3FJP→OHC bridge.
+  //
+  // An optional `status` field lets the bridge stream three kinds of update:
+  //   'log'     — a completed, logged QSO. The default when omitted, so older
+  //               bridges that only send logged QSOs keep working unchanged.
+  //   'preview' — a transient "as you type" entry shown while the operator is
+  //               still filling in the call field. At most one is kept at a time.
+  //   'clear'   — the operator cleared the call field; drop any pending preview.
   app.post('/api/n3fjp/qso', writeLimiter, requireWriteAuth, async (req, res) => {
     const qso = req.body || {};
+    const status = qso.status === 'preview' || qso.status === 'clear' ? qso.status : 'log';
+
+    // A 'clear' just drops the pending preview — no callsign needed.
+    if (status === 'clear') {
+      n3fjpQsos = n3fjpQsos.filter((q) => q.status !== 'preview');
+      return res.json({ ok: true });
+    }
+
     if (!qso.dx_call) return res.status(400).json({ ok: false, error: 'dx_call required' });
 
+    qso.status = status;
     if (!qso.ts_utc) qso.ts_utc = new Date().toISOString();
     if (!qso.source) qso.source = 'n3fjp_to_timemapper_udp';
 
@@ -864,12 +887,26 @@ module.exports = function (app, ctx) {
     setImmediate(async () => {
       try {
         //
-        // Enrich DX location: GRID → (preferred) → HamQTH fallback
+        // Enrich DX location: bridge-supplied coords → operating grid → HamQTH.
         //
         let locSource = '';
 
-        // 1) Prefer exact operating grid (N3FJP “Grid Rec” field)
-        if (qso.dx_grid) {
+        // 1) Trust coordinates the bridge already resolved. This keeps previews
+        //    instant and respects a bridge that does its own QRZ/grid lookup.
+        //    A 0,0 pair is the bridge's "could not resolve" sentinel — ignore it.
+        if (
+          typeof qso.lat === 'number' &&
+          typeof qso.lon === 'number' &&
+          Number.isFinite(qso.lat) &&
+          Number.isFinite(qso.lon) &&
+          !(qso.lat === 0 && qso.lon === 0)
+        ) {
+          qso.loc_source = 'bridge';
+          locSource = 'bridge';
+        }
+
+        // 2) Otherwise prefer the exact operating grid (N3FJP “Grid Rec” field).
+        if (!locSource && qso.dx_grid) {
           const loc = maidenheadToLatLon(qso.dx_grid);
           if (loc) {
             qso.lat = loc.lat;
@@ -879,7 +916,7 @@ module.exports = function (app, ctx) {
           }
         }
 
-        // 2) If no grid provided, fall back to HamQTH/home QTH lookup
+        // 3) Last resort: HamQTH / home-QTH lookup by callsign.
         if (!locSource) {
           const dx = await lookupCallLatLon(qso.dx_call);
           if (dx) {
@@ -892,6 +929,8 @@ module.exports = function (app, ctx) {
           }
         }
 
+        // A new preview replaces any earlier one; a logged QSO ends the preview.
+        n3fjpQsos = n3fjpQsos.filter((q) => q.status !== 'preview');
         n3fjpQsos.unshift(qso);
         pruneN3fjpQsos();
 

--- a/server/utils/statemachine.js
+++ b/server/utils/statemachine.js
@@ -1,4 +1,4 @@
-const { Mutex, MutexValue, MutexCounter } = require('../utils/mutex');
+const { Mutex, MutexValue, MutexCounter } = require('./mutex');
 
 /**
  * A simple state machine implementation with safety checks to prevent invalid states and handlers.

--- a/server/utils/statemachine.test.js
+++ b/server/utils/statemachine.test.js
@@ -44,11 +44,10 @@ describe('StateMachine with invalid inputs', () => {
     expect(() => new StateMachine(['A'], {})).toThrow();
   });
 
-  it('should throw if invalid state index is provided', () => {
-    expect(() => {
-      new StateMachine(['A'], { A: () => 'B' });
-      sm.run(); // will try to run handler for state 'A' which returns 'B' (invalid)
-    }).toThrow();
+  it('should gracefully reset if invalid state index is provided', async () => {
+    const sm = new StateMachine(['A'], { A: () => 'B' });
+    sm.run();
+    expect(await sm.currentState()).toBe('A'); // should reset to 'A'
   });
 
   {
@@ -66,7 +65,7 @@ describe('StateMachine with invalid inputs', () => {
       expect(await sm.currentState()).toBe('A');
     });
 
-    it('should reset if invalid index is provided', async () => {
+    it('should gracefully reset if invalid index is provided', async () => {
       const sm = new StateMachine(['A', 'B'], { A: () => 'B', B: () => 'B' });
       await sm.run();
       expect(await sm.currentState()).toBe('B');
@@ -84,11 +83,5 @@ describe('StateMachine with invalid inputs', () => {
         expect(await sm.currentState()).toBe('A'); // should reset to 'A'
       });
     }
-
-    it('should reset if next state is invalid', async () => {
-      const sm = new StateMachine(states, { A: () => 'X', B: () => 'C', C: () => 'C' }); // A returns invalid state 'X'
-      await sm.run(); // will try to run handler for state 'A' which returns 'X' (invalid)
-      expect(await sm.currentState()).toBe('A'); // should reset to 'A'
-    });
   }
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -381,6 +381,21 @@ const App = () => {
     }
   }, [wsjtx.dxTarget, handleDXChange]);
 
+  // ── N3FJP → DX Target ──
+  // The N3FJP Logged QSOs layer emits this on its own channel when the operator
+  // types a callsign in the logger, so propagation + beam heading follow the
+  // previewed station. handleDXChange honours the DX Lock toggle.
+  useEffect(() => {
+    const handler = (e) => {
+      const { lat, lon } = e.detail || {};
+      if (lat != null && lon != null) {
+        handleDXChange({ lat, lon });
+      }
+    };
+    window.addEventListener('ohc-n3fjp-dx-target', handler);
+    return () => window.removeEventListener('ohc-n3fjp-dx-target', handler);
+  }, [handleDXChange]);
+
   const { satelliteFilters, setSatelliteFilters, filteredSatellites } = useSatellitesFilters(satellites.data);
 
   const {

--- a/src/components/CallsignLink.jsx
+++ b/src/components/CallsignLink.jsx
@@ -1,13 +1,15 @@
 /**
- * CallsignLink — clickable callsign that opens QRZ.com
+ * CallsignLink — clickable callsign that opens the user's chosen callbook
  *
  * Usage:
  *   <CallsignLink call="K1ABC" color="#fff" fontWeight="700" />
  *
  * Reads the global toggle from localStorage (ohc_qrz_links).
- * When enabled, clicking opens https://www.qrz.com/db/CALLSIGN in a new tab.
+ * When enabled, clicking opens the callsign's page on the selected callbook
+ * (QRZ.com by default — see src/utils/callbook.js) in a new tab.
  */
 import { createContext, useContext, useState, useCallback } from 'react';
+import { getCallbookUrl } from '../utils/callbook.js';
 
 // ── Extract base callsign from decorated/portable calls ──
 // 5Z4/OZ6ABL → OZ6ABL, UA1TAN/M → UA1TAN, W1ABC/6 → W1ABC
@@ -68,7 +70,7 @@ export function QRZToggle({ style }) {
         e.stopPropagation();
         toggle();
       }}
-      title={enabled ? 'Click callsigns to open QRZ.com (ON)' : 'QRZ callsign links disabled (OFF)'}
+      title={enabled ? 'Click callsigns to open the callbook lookup (ON)' : 'Callsign links disabled (OFF)'}
       style={{
         cursor: 'pointer',
         fontSize: '11px',
@@ -102,7 +104,7 @@ export default function CallsignLink({
   const handleClick = (e) => {
     if (!enabled) return;
     e.stopPropagation();
-    window.open(`https://www.qrz.com/db/${encodeURIComponent(baseCall)}`, '_blank', 'noopener,noreferrer');
+    window.open(getCallbookUrl(baseCall), '_blank', 'noopener,noreferrer');
   };
 
   return (
@@ -123,7 +125,7 @@ export default function CallsignLink({
       onMouseLeave={(e) => {
         if (enabled) e.target.style.color = color;
       }}
-      title={enabled ? `Look up ${call} on QRZ.com` : call}
+      title={enabled ? `Look up ${call}` : call}
     >
       {children || call}
     </span>
@@ -152,7 +154,7 @@ export function setupMapQRZHandler() {
     const call = el.getAttribute('data-qrz-call');
     if (call) {
       const baseCall = extractBaseCall(call);
-      window.open(`https://www.qrz.com/db/${encodeURIComponent(baseCall)}`, '_blank', 'noopener,noreferrer');
+      window.open(getCallbookUrl(baseCall), '_blank', 'noopener,noreferrer');
     }
   });
 }

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -146,6 +146,13 @@ export const SettingsPanel = ({
       return '#3388ff';
     }
   });
+  const [n3fjpPreviewLineColor, setN3fjpPreviewLineColor] = useState(() => {
+    try {
+      return localStorage.getItem('n3fjp_preview_line_color') || '#ffaa00';
+    } catch {
+      return '#ffaa00';
+    }
+  });
 
   // Monospace font for panels/data displays (#923 — 0/8 readability)
   const [monoFont, setMonoFont] = useState(() => {
@@ -257,10 +264,12 @@ export const SettingsPanel = ({
       const v = parseInt(localStorage.getItem('n3fjp_display_minutes') || '15', 10);
       setN3fjpDisplayMinutes(Number.isFinite(v) ? v : 15);
       setN3fjpLineColor(localStorage.getItem('n3fjp_line_color') || '#3388ff');
+      setN3fjpPreviewLineColor(localStorage.getItem('n3fjp_preview_line_color') || '#ffaa00');
     } catch {
       setN3fjpEnabled(false);
       setN3fjpDisplayMinutes(15);
       setN3fjpLineColor('#3388ff');
+      setN3fjpPreviewLineColor('#ffaa00');
     }
   }, [isOpen]);
 
@@ -2722,6 +2731,44 @@ export const SettingsPanel = ({
                         setN3fjpLineColor(next);
                         try {
                           localStorage.setItem('n3fjp_line_color', next);
+                        } catch {}
+                        try {
+                          window.dispatchEvent(new Event('ohc-n3fjp-config-changed'));
+                        } catch {}
+                      }}
+                      style={{
+                        width: '100%',
+                        height: 40,
+                        padding: 0,
+                        border: '1px solid var(--border-color)',
+                        borderRadius: 6,
+                        background: 'transparent',
+                      }}
+                    />
+                  </div>
+
+                  <div style={{ flex: '0 0 120px' }}>
+                    <label
+                      style={{
+                        display: 'block',
+                        marginBottom: 6,
+                        color: 'var(--text-muted)',
+                        fontSize: 11,
+                        textTransform: 'uppercase',
+                        letterSpacing: 1,
+                      }}
+                    >
+                      Preview color
+                    </label>
+                    <input
+                      disabled={!isLocalInstall || !n3fjpEnabled}
+                      type="color"
+                      value={n3fjpPreviewLineColor}
+                      onChange={(e) => {
+                        const next = e.target.value || '#ffaa00';
+                        setN3fjpPreviewLineColor(next);
+                        try {
+                          localStorage.setItem('n3fjp_preview_line_color', next);
                         } catch {}
                         try {
                           window.dispatchEvent(new Event('ohc-n3fjp-config-changed'));

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -24,6 +24,7 @@ import useLocalInstall from '../hooks/app/useLocalInstall.js';
 import { emojiToIso2 } from '../utils/countryFlags';
 import { getAlertSettings, saveAlertSettings, playTone, TONE_PRESETS, ALERT_FEEDS } from '../utils/audioAlerts';
 import { setRelaySessionId, setRelayConfigured, clearRelaySession } from '../utils/relaySession';
+import { CALLBOOKS, getCallbook } from '../utils/callbook.js';
 
 export const SettingsPanel = ({
   isOpen,
@@ -162,6 +163,9 @@ export const SettingsPanel = ({
       return "'JetBrains Mono', monospace";
     }
   });
+  // Callbook used when clicking a callsign in the UI (#989)
+  const [callbook, setCallbook] = useState(() => getCallbook());
+
   const { t, i18n } = useTranslation();
 
   // Layer controls
@@ -2283,6 +2287,55 @@ export const SettingsPanel = ({
                 </div>
               </div>
             )}
+
+            {/* Callbook for callsign lookups (#989) */}
+            <div style={{ marginBottom: '20px' }}>
+              <label
+                htmlFor="callbook-select"
+                style={{
+                  display: 'block',
+                  marginBottom: '8px',
+                  color: 'var(--text-muted)',
+                  fontSize: '11px',
+                  textTransform: 'uppercase',
+                  letterSpacing: '1px',
+                }}
+              >
+                {t('station.settings.callbook.title')}
+              </label>
+              <select
+                id="callbook-select"
+                value={callbook}
+                onChange={(e) => {
+                  const next = e.target.value;
+                  setCallbook(next);
+                  try {
+                    localStorage.setItem('ohc_callbook', next);
+                  } catch {}
+                  window.dispatchEvent(new Event('ohc-callbook-changed'));
+                }}
+                style={{
+                  width: '100%',
+                  padding: '12px',
+                  background: 'var(--bg-tertiary)',
+                  border: '1px solid var(--border-color)',
+                  borderRadius: '6px',
+                  color: 'var(--accent-green)',
+                  fontSize: '14px',
+                  fontFamily: 'var(--font-mono)',
+                  cursor: 'pointer',
+                }}
+              >
+                {CALLBOOKS.map((cb) => (
+                  <option key={cb.id} value={cb.id}>
+                    {cb.label}
+                  </option>
+                ))}
+              </select>
+              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
+                {t('station.settings.callbook.describe')}
+              </div>
+            </div>
 
             {/* Language */}
             <div style={{ marginBottom: '20px' }}>

--- a/src/components/SolarPanel.jsx
+++ b/src/components/SolarPanel.jsx
@@ -16,6 +16,9 @@ const MODE_TITLES = {
   lunar: 'Show solar image',
 };
 
+// X-ray history windows (hours) — 6h is the default
+const XRAY_RANGES = [6, 12, 24, 48];
+
 // Flare class from flux value (W/m²)
 const getFlareClass = (flux) => {
   if (!flux || flux <= 0) return { letter: '?', color: '#666', level: 0 };
@@ -66,6 +69,13 @@ export const SolarPanel = ({ solarIndices, bandConditions, forcedMode }) => {
   });
   const [xrayData, setXrayData] = useState(null);
   const [xrayLoading, setXrayLoading] = useState(false);
+  const [xrayRange, setXrayRange] = useState(() => {
+    try {
+      const saved = parseInt(localStorage.getItem('openhamclock_xrayRange'), 10);
+      if (XRAY_RANGES.includes(saved)) return saved;
+    } catch {}
+    return 6;
+  });
   const [imageError, setImageError] = useState(false);
 
   // Refresh solar image every 15 minutes and retry on error
@@ -165,8 +175,13 @@ export const SolarPanel = ({ solarIndices, bandConditions, forcedMode }) => {
       );
     }
 
-    // Use last ~360 points (~6 hours at 1-min resolution)
-    const points = xrayData.slice(-360);
+    // Filter to the selected history window (6/12/24/48h).
+    // The 7-day feed is fetched server-side; we trim by time here so the
+    // graph and peak rating both reflect the chosen timeframe.
+    const cutoff = Date.now() - xrayRange * 60 * 60 * 1000;
+    let points = xrayData.filter((p) => new Date(p.time_tag).getTime() >= cutoff);
+    // Fall back to whatever we have if the feed is shorter than the window
+    if (points.length === 0) points = xrayData;
     const currentFlux = points[points.length - 1]?.flux;
     const currentClass = getFlareClass(currentFlux);
     const peakFlux = Math.max(...points.map((p) => p.flux));
@@ -215,11 +230,13 @@ export const SolarPanel = ({ solarIndices, bandConditions, forcedMode }) => {
       { flux: 1e-4, label: 'X', color: '#ff0000' },
     ];
 
-    // Time labels
+    // Time labels — include the day for windows wider than 12h so the
+    // HH:MM marks aren't ambiguous across midnight.
     const firstTime = new Date(points[0]?.time_tag);
     const lastTime = new Date(points[points.length - 1]?.time_tag);
     const midTime = new Date((firstTime.getTime() + lastTime.getTime()) / 2);
-    const fmt = (d) => `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`;
+    const hhmm = (d) => `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`;
+    const fmt = xrayRange > 12 ? (d) => `${String(d.getUTCDate()).padStart(2, '0')} ${hhmm(d)}` : hhmm;
 
     return (
       <div>
@@ -249,7 +266,7 @@ export const SolarPanel = ({ solarIndices, bandConditions, forcedMode }) => {
             </span>
           </div>
           <div>
-            <span style={{ fontSize: '10px', color: 'var(--text-muted)' }}>6h Peak </span>
+            <span style={{ fontSize: '10px', color: 'var(--text-muted)' }}>{xrayRange}h Peak </span>
             <span
               style={{
                 fontSize: '14px',
@@ -340,7 +357,7 @@ export const SolarPanel = ({ solarIndices, bandConditions, forcedMode }) => {
         </svg>
 
         <div style={{ fontSize: '9px', color: 'var(--text-muted)', marginTop: '3px', textAlign: 'center' }}>
-          GOES • 0.1–0.8nm • 6hr
+          GOES • 0.1–0.8nm • {xrayRange}hr
         </div>
       </div>
     );
@@ -647,6 +664,35 @@ export const SolarPanel = ({ solarIndices, bandConditions, forcedMode }) => {
           {mode === 'lunar' ? '🌙' : '☀'} {MODE_LABELS[mode]}
         </span>
         <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
+          {mode === 'xray' && (
+            <select
+              value={xrayRange}
+              onChange={(e) => {
+                const next = parseInt(e.target.value, 10);
+                setXrayRange(next);
+                try {
+                  localStorage.setItem('openhamclock_xrayRange', String(next));
+                } catch {}
+              }}
+              onClick={(e) => e.stopPropagation()}
+              title="History timeframe"
+              style={{
+                background: 'var(--bg-tertiary)',
+                border: '1px solid var(--border-color)',
+                color: 'var(--text-secondary)',
+                fontSize: '10px',
+                padding: '2px 4px',
+                borderRadius: '3px',
+                cursor: 'pointer',
+              }}
+            >
+              {XRAY_RANGES.map((h) => (
+                <option key={h} value={h}>
+                  {h}h
+                </option>
+              ))}
+            </select>
+          )}
           {mode === 'image' && (
             <select
               value={imageType}

--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -2838,7 +2838,7 @@ export const WorldMap = ({
         </div>
       )}
       <style>{`
-        ${mapUiHidden ? '.leaflet-control-container,.grayline-control,.muf-map-control,.voacap-heatmap-control,.rbn-control,.lightning-stats,.lightning-proximity,.wspr-filter-control,.wspr-stats,.wspr-legend,.wspr-chart,.sat-data-window{display:none !important;}' : ''}
+        ${mapUiHidden ? '.leaflet-control-container,.grayline-control,.muf-map-control,.voacap-heatmap-control,.rbn-control,.lightning-stats,.lightning-proximity,.wspr-filter-control,.wspr-stats,.wspr-legend,.wspr-chart{display:none !important;}' : ''}
         .ohc-rotator-bearing {
           stroke-dasharray: 10 10;
           animation: ohcRotDash 2.8s linear infinite, ohcRotPulse 3.2s ease-in-out infinite;

--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -2838,7 +2838,7 @@ export const WorldMap = ({
         </div>
       )}
       <style>{`
-        ${mapUiHidden ? '.leaflet-control-container,.grayline-control,.muf-map-control,.voacap-heatmap-control,.rbn-control,.lightning-stats,.lightning-proximity,.wspr-filter-control,.wspr-stats,.wspr-legend,.wspr-chart{display:none !important;}' : ''}
+        ${mapUiHidden ? '.leaflet-control-container,.grayline-control,.muf-map-control,.voacap-heatmap-control,.rbn-control,.lightning-stats,.lightning-proximity,.wspr-filter-control,.wspr-stats,.wspr-legend,.wspr-chart,.sat-data-window{display:none !important;}' : ''}
         .ohc-rotator-bearing {
           stroke-dasharray: 10 10;
           animation: ohcRotDash 2.8s linear infinite, ohcRotPulse 3.2s ease-in-out infinite;

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -347,6 +347,8 @@
   "station.settings.antenna": "Antenna",
   "station.settings.button.save": "Save Settings",
   "station.settings.button.save.confirm": "Settings saved to your browser",
+  "station.settings.callbook.describe": "Online callbook opened when you click a callsign in the UI.",
+  "station.settings.callbook.title": "Callsign Lookup",
   "station.settings.callsign": "Your Callsign",
   "station.settings.describe": "Enter your callsign and grid square to get started. Settings are saved in your browser.",
   "station.settings.dx.custom.callsign": "Your callsign ({{callsign}}) will be used for login.",

--- a/src/plugins/layers/useLightning.js
+++ b/src/plugins/layers/useLightning.js
@@ -697,7 +697,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
 
         // Unfortunately, to fit both km and miles in the header we need to override the font size
         let distStr = isMetric ? ` (${PROXIMITY_RADIUS_KM} km)` : ` (${PROXIMITY_RADIUS_MILES.toFixed(1)} miles)`;
-        div.innerHTML = `<div class="floating-panel-header" style="font-size: 11px">📍 ${t('plugins.layers.lightning.nearbyStrikes')} ${distStr}</div><div style="opacity: 0.7; font-size: 10px; text-align: center;">No recent strikes</div>`;
+        div.innerHTML = `<div class="floating-panel-header" style="font-size: 11px">📍 ${t('plugins.layers.lightning.nearbyStrikes')}${distStr}</div><div style="opacity: 0.7; font-size: 10px; text-align: center;">No recent strikes</div>`;
 
         // Prevent map interaction
         L.DomEvent.disableClickPropagation(div);

--- a/src/plugins/layers/useN3FJPLoggedQSOs.js
+++ b/src/plugins/layers/useN3FJPLoggedQSOs.js
@@ -7,13 +7,13 @@ import { getGreatCirclePoints, replicatePath, maidenheadToLatLon } from '../../u
 export const metadata = {
   id: 'n3fjp_logged_qsos',
   name: 'Logged QSOs (N3FJP)',
-  description: 'Shows recently logged QSOs sent from the N3FJP bridge.',
+  description: 'Shows recently logged QSOs (and live entry previews) from the N3FJP bridge.',
   icon: '🗺️',
   category: 'overlay',
   localOnly: true,
   defaultEnabled: false,
   defaultOpacity: 0.9,
-  version: '0.2.0',
+  version: '0.3.0',
 };
 
 const POLL_MS = 2000;
@@ -21,9 +21,10 @@ const POLL_MS = 2000;
 // --- User settings (persisted) ---
 const STORAGE_MINUTES_KEY = 'n3fjp_display_minutes';
 const STORAGE_COLOR_KEY = 'n3fjp_line_color';
+const STORAGE_PREVIEW_COLOR_KEY = 'n3fjp_preview_line_color';
 
 // Sanitize CSS color values from localStorage to prevent innerHTML injection
-const sanitizeColor = (c) => (/^(#[0-9a-f]{3,8}|[a-z]{3,20})$/i.test(c) ? c : '#3388ff');
+const sanitizeColor = (c, fallback = '#3388ff') => (/^(#[0-9a-f]{3,8}|[a-z]{3,20})$/i.test(c) ? c : fallback);
 
 export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
   const [layersRef, setLayersRef] = useState([]);
@@ -33,6 +34,9 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
 
   const lastOpenDxCallRef = useRef(null);
   const suppressReopenRef = useRef(false);
+  // Tracks the last previewed call pushed to the DX target, so the crosshair is
+  // nudged only when the typed call actually changes — not on every 2 s poll.
+  const lastPreviewCallRef = useRef(null);
 
   const [displayMinutes, setDisplayMinutes] = useState(() => {
     const v = parseInt(localStorage.getItem(STORAGE_MINUTES_KEY) || '15', 10);
@@ -41,6 +45,10 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
 
   const [lineColor, setLineColor] = useState(() => {
     return sanitizeColor(localStorage.getItem(STORAGE_COLOR_KEY) || '#3388ff');
+  });
+
+  const [previewLineColor, setPreviewLineColor] = useState(() => {
+    return sanitizeColor(localStorage.getItem(STORAGE_PREVIEW_COLOR_KEY) || '#ffaa00', '#ffaa00');
   });
 
   // Poll the server for QSOs
@@ -168,6 +176,10 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
         const c = sanitizeColor(localStorage.getItem(STORAGE_COLOR_KEY) || '#3388ff');
         setLineColor(c);
       } catch {}
+      try {
+        const pc = sanitizeColor(localStorage.getItem(STORAGE_PREVIEW_COLOR_KEY) || '#ffaa00', '#ffaa00');
+        setPreviewLineColor(pc);
+      } catch {}
     };
 
     sync();
@@ -193,12 +205,40 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
 
     if (!enabled || !qsos.length) return;
 
-    // ---- CLIENT-SIDE FILTER: Show only QSOs newer than X minutes ----
+    // ---- CLIENT-SIDE FILTER: recent logged QSOs + any live preview ----
+    // Previews are transient "as you type" entries — always shown, never aged out.
     const cutoff = Date.now() - displayMinutes * 60 * 1000;
     const recent = qsos.filter((q) => {
+      if (q.status === 'preview') return true;
       const t = Date.parse(q.ts_utc || q.ts || '');
       return !Number.isNaN(t) && t >= cutoff;
     });
+
+    // ---- DX target coupling ----
+    // While the operator is typing a call in N3FJP, nudge the app's DX target to
+    // the previewed station so propagation + beam heading follow along. Emitted
+    // on a dedicated channel; App.jsx listens and honours the DX Lock toggle.
+    const preview = recent.find((q) => q.status === 'preview');
+    if (preview && typeof preview.lat === 'number' && typeof preview.lon === 'number') {
+      const previewCall = (preview.dx_call || '').trim().toUpperCase();
+      if (previewCall && previewCall !== lastPreviewCallRef.current) {
+        lastPreviewCallRef.current = previewCall;
+        try {
+          window.dispatchEvent(
+            new CustomEvent('ohc-n3fjp-dx-target', {
+              detail: {
+                call: previewCall,
+                grid: preview.dx_grid || '',
+                lat: preview.lat,
+                lon: preview.lon,
+              },
+            }),
+          );
+        } catch {}
+      }
+    } else if (!preview) {
+      lastPreviewCallRef.current = null;
+    }
 
     // If nothing recent, we're done
     if (!recent.length) return;
@@ -254,6 +294,8 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
 
       const dxCall = (q.dx_call || '').trim() || '(unknown)';
       const mode = q.mode || '';
+      const isPreview = q.status === 'preview';
+      const color = isPreview ? previewLineColor : lineColor;
       // Convert integer kHz (e.g. 14230) to MHz string (e.g. 14.230)
       let freqMhz = '';
       if (typeof q.freq_khz === 'number' && Number.isFinite(q.freq_khz) && q.freq_khz > 0) {
@@ -262,7 +304,9 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
       const ts = q.ts_utc || '';
 
       const dxMarker = L.circleMarker([lat, lon], {
-        radius: 6,
+        radius: isPreview ? 7 : 6,
+        color,
+        fillColor: color,
         opacity,
         fillOpacity: Math.min(1, opacity * 0.8),
       }).addTo(map);
@@ -289,10 +333,10 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
 
       dxMarker.bindPopup(
         `<div style="font-family: var(--font-mono);">
-          <b>${esc(dxCall)}</b><br/>
+          <b>${esc(dxCall)}</b>${isPreview ? ' <span style="opacity:0.7;">(preview)</span>' : ''}<br/>
           ${mode ? `Mode: ${esc(mode)}<br/>` : ''}
           ${freqMhz ? `Freq: ${esc(freqMhz)} MHz<br/>` : ''}
-          ${ts ? `Time: ${esc(ts)}<br/>` : ''}
+          ${isPreview ? 'Typing in N3FJP…<br/>' : ts ? `Time: ${esc(ts)}<br/>` : ''}
           ${q.dx_country ? `Country: ${esc(q.dx_country)}<br/>` : ''}
           ${q.loc_source ? `Loc: ${esc(q.loc_source)}<br/>` : ''}
           ${q.dx_grid ? `Grid: ${esc(q.dx_grid)}<br/>` : ''}
@@ -311,13 +355,20 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
         }, 0);
       }
 
-      // Draw great circle arc from station -> DX if we have station coords
+      // Draw great circle arc from station -> DX if we have station coords.
+      // Preview arcs are dashed so a tentative contact reads differently from a
+      // logged one at a glance, on top of the colour difference.
       if (station) {
         const arcPoints = getGreatCirclePoints(station.lat, station.lon, lat, lon, 64);
         const segments = replicatePath(arcPoints);
         segments.forEach((seg) => {
           if (seg.length < 2) return;
-          const line = L.polyline(seg, { opacity, color: lineColor, weight: 2 }).addTo(map);
+          const line = L.polyline(seg, {
+            opacity,
+            color,
+            weight: 2,
+            dashArray: isPreview ? '6 6' : null,
+          }).addTo(map);
           newLayers.push(line);
         });
       }
@@ -333,7 +384,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
         } catch {}
       });
     };
-  }, [enabled, qsos, map, opacity, retentionMinutes, displayMinutes, lineColor]);
+  }, [enabled, qsos, map, opacity, retentionMinutes, displayMinutes, lineColor, previewLineColor]);
 
   return {
     qsoCount: qsos.length,

--- a/src/plugins/layers/useSatelliteLayer.js
+++ b/src/plugins/layers/useSatelliteLayer.js
@@ -206,70 +206,22 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
     const activeSats = satellites.filter((s) => selectedSats.includes(s.name));
 
     const titleBar = `
-  <div class="sat-data-window-title"
-       style="
-         display:flex;
-         justify-content:space-between;
-         align-items:center;
-         cursor:grab;
-         user-select:none;
-         border-bottom: 1px solid var(--border-color);
-         background: var(--bg-tertiary);
-         ${
-           winMinimized
-             ? `
-             padding: 2px 6px;
-             width: fit-content;
-             min-width: 0;
-             flex: none;
-           `
-             : `
-             padding: 8px 10px;
-           `
-         }
-       ">
-       
-    <span data-drag-handle="true"
-          style="font-family: var(--font-mono);
-                 font-size:13px;
-                 font-weight:700;
-                 color: var(--accent-blue);
-                 letter-spacing:0.05em;">
-      🛰 ${
-        !winMinimized
-          ? `${activeSats.length} ${
-              activeSats.length !== 1
-                ? t('station.settings.satellites.name_plural')
-                : t('station.settings.satellites.name')
-            }`
-          : ''
-      }
-    </span>
-
-    <button class="sat-data-window-minimize"
-            onclick="window.__satWinToggleMinimize()"
-            title="${winMinimized ? 'Expand' : 'Minimize'}"
-            style="
-              background:none;
-              border:none;
-              color: var(--text-secondary);
-              cursor:pointer;
-              font-size:10px;
-              line-height:1;
-              padding:2px 4px;
-              margin:0;
-            ">
-      ${winMinimized ? '▶' : '▼'}
-    </button>
-
-  </div>
-`;
+      <div class="sat-data-window-title"
+        style="display:flex; justify-content:space-between; align-items:center; cursor:grab; user-select:none; border-bottom:1px solid var(--border-color); background:var(--bg-tertiary);
+          ${winMinimized ? `padding:2px 6px; width:fit-content; min-width:0; max-width:fit-content; height:fit-content; min-height:0; flex:none;` : `padding:8px 10px;`}">
+        <span data-drag-handle="true" style="font-family:var(--font-mono); font-size:13px; font-weight:700; color:var(--accent-blue); letter-spacing:0.05em;">
+          🛰 ${!winMinimized ? `${activeSats.length} ${activeSats.length !== 1 ? t('station.settings.satellites.name_plural') : t('station.settings.satellites.name')}` : ''}
+        </span>
+        <button class="sat-data-window-minimize" onclick="window.__satWinToggleMinimize()" title="${winMinimized ? 'Expand' : 'Minimize'}" style="background:none; border:none; color:var(--text-secondary); cursor:pointer; font-size:10px; line-height:1; padding:2px 4px; margin:0;">
+          ${winMinimized ? '▶' : '▼'}
+        </button>
+      </div>`;
 
     const clearAllBtn = `
       <div style="margin: 10px 12px 8px; display: flex; flex-direction: column; align-items: center; gap: 5px;">
         <button onclick="sessionStorage.removeItem('selected_satellites'); window.location.reload();"
           style="background: var(--bg-primary); border: 1px solid var(--accent-red); color: var(--accent-red); cursor: pointer;
-                       padding: 4px 10px; font-size: 10px; border-radius: 3px; font-weight: bold; width: 100%;">
+            padding: 4px 10px; font-size: 10px; border-radius: 3px; font-weight: bold; width: 100%;">
           ${t('station.settings.satellites.clearFootprints')}
         </button>
         <span style="font-size: 9px; color: var(--text-muted);">${t('station.settings.satellites.dragTitle')}</span>
@@ -301,6 +253,12 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
       return;
     }
 
+    // reset to default size constraints
+    win.style.width = '260px';
+    win.style.minWidth = '';
+    win.style.maxWidth = '';
+    win.style.height = '';
+    win.style.minHeight = '';
     win.style.maxHeight = 'calc(100% - 80px)';
     win.style.overflowY = 'auto';
 

--- a/src/plugins/layers/useSatelliteLayer.js
+++ b/src/plugins/layers/useSatelliteLayer.js
@@ -206,21 +206,64 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
     const activeSats = satellites.filter((s) => selectedSats.includes(s.name));
 
     const titleBar = `
-      <div class="sat-data-window-title" style="display:flex; justify-content:space-between; align-items:center;
-                  cursor:grab; user-select:none;
-                  padding: 8px 10px; border-bottom: 1px solid var(--border-color); background: var(--bg-tertiary);">
-        <span data-drag-handle="true" style="font-family: var(--font-mono); font-size:13px; font-weight:700; color: var(--accent-blue); letter-spacing:0.05em;">
-          🛰 ${activeSats.length} ${activeSats.length !== 1 ? t('station.settings.satellites.name_plural') : t('station.settings.satellites.name')}
-        </span>
-        <button class="sat-data-window-minimize"
-                onclick="window.__satWinToggleMinimize()"
-                title="${winMinimized ? 'Expand' : 'Minimize'}"
-          style="background:none; border:none; color: var(--text-secondary); cursor:pointer;
-                       font-size:10px; line-height:1; padding:2px 4px; margin:0;">
-          ${winMinimized ? '▶' : '▼'}
-        </button>
-      </div>
-    `;
+  <div class="sat-data-window-title"
+       style="
+         display:flex;
+         justify-content:space-between;
+         align-items:center;
+         cursor:grab;
+         user-select:none;
+         border-bottom: 1px solid var(--border-color);
+         background: var(--bg-tertiary);
+         ${
+           winMinimized
+             ? `
+             padding: 2px 6px;
+             width: fit-content;
+             min-width: 0;
+             flex: none;
+           `
+             : `
+             padding: 8px 10px;
+           `
+         }
+       ">
+       
+    <span data-drag-handle="true"
+          style="font-family: var(--font-mono);
+                 font-size:13px;
+                 font-weight:700;
+                 color: var(--accent-blue);
+                 letter-spacing:0.05em;">
+      🛰 ${
+        !winMinimized
+          ? `${activeSats.length} ${
+              activeSats.length !== 1
+                ? t('station.settings.satellites.name_plural')
+                : t('station.settings.satellites.name')
+            }`
+          : ''
+      }
+    </span>
+
+    <button class="sat-data-window-minimize"
+            onclick="window.__satWinToggleMinimize()"
+            title="${winMinimized ? 'Expand' : 'Minimize'}"
+            style="
+              background:none;
+              border:none;
+              color: var(--text-secondary);
+              cursor:pointer;
+              font-size:10px;
+              line-height:1;
+              padding:2px 4px;
+              margin:0;
+            ">
+      ${winMinimized ? '▶' : '▼'}
+    </button>
+
+  </div>
+`;
 
     const clearAllBtn = `
       <div style="margin: 10px 12px 8px; display: flex; flex-direction: column; align-items: center; gap: 5px;">
@@ -236,7 +279,16 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
     if (winMinimized) {
       win.style.maxHeight = '';
       win.style.overflowY = 'hidden';
+
+      // shrink to minimal size
+      win.style.width = 'fit-content';
+      win.style.minWidth = 'unset';
+      win.style.maxWidth = 'fit-content';
+      win.style.height = 'fit-content';
+      win.style.minHeight = 'unset';
+
       win.innerHTML = `${titleBar}<div class="sat-data-window-content"></div>`;
+
       addMinimizeToggle(win, 'sat-data-window', {
         contentClassName: 'sat-data-window-content',
         buttonClassName: 'sat-data-window-minimize',
@@ -245,6 +297,7 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
         persist: false,
         manageButtonEvents: true,
       });
+
       return;
     }
 

--- a/src/utils/callbook.js
+++ b/src/utils/callbook.js
@@ -1,0 +1,37 @@
+/**
+ * Callbook utility — builds the external lookup URL for a clicked callsign.
+ *
+ * The callbook is the online directory opened when a user clicks a callsign in
+ * the UI (DX Cluster, POTA/SOTA, PSK Reporter, map popups, etc.). The choice is
+ * stored per-browser in localStorage under 'ohc_callbook' and defaults to QRZ.com.
+ *
+ * getCallbook()           — current callbook id ('qrz' | 'hamqth' | 'qrzcq')
+ * getCallbookUrl(call)    — full lookup URL for a callsign on the current callbook
+ * CALLBOOKS               — list of selectable callbooks for the settings dropdown
+ */
+
+// ── Selectable callbooks ──
+// {call} is replaced with the URL-encoded base callsign.
+export const CALLBOOKS = [
+  { id: 'qrz', label: 'QRZ.com', urlTemplate: 'https://www.qrz.com/db/{call}' },
+  { id: 'hamqth', label: 'HamQTH', urlTemplate: 'https://www.hamqth.com/{call}' },
+  { id: 'qrzcq', label: 'QRZCQ', urlTemplate: 'https://www.qrzcq.com/call/{call}' },
+];
+
+const DEFAULT_CALLBOOK = 'qrz';
+
+// Read the selected callbook id from localStorage, falling back to the default.
+export function getCallbook() {
+  try {
+    const stored = localStorage.getItem('ohc_callbook');
+    if (stored && CALLBOOKS.some((cb) => cb.id === stored)) return stored;
+  } catch {}
+  return DEFAULT_CALLBOOK;
+}
+
+// Build the lookup URL for a (already base-extracted) callsign.
+export function getCallbookUrl(call) {
+  const id = getCallbook();
+  const cb = CALLBOOKS.find((c) => c.id === id) || CALLBOOKS[0];
+  return cb.urlTemplate.replace('{call}', encodeURIComponent(call));
+}


### PR DESCRIPTION
## What does this PR do?

- fixes https://github.com/accius/openhamclock/issues/987
- shrink satellites dialog to minimal size
- eliminate text when minimized so only satellite icon and right-arrow appear
- doesn't eliminate satellites button altogether like other boxes in the 'Show UI' pattern, but makes satellite less obtrusive

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [X] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## Checklist

- [X] App loads without console errors
- [X] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [X] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [X] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)
before
<img width="318" height="114" alt="image" src="https://github.com/user-attachments/assets/8ae54e4a-8fb7-4f6f-9640-aa68f21e015e" />

after
<img width="84" height="63" alt="image" src="https://github.com/user-attachments/assets/f71b3725-f0e8-483e-8c99-b645eff87cd0" />
<img width="201" height="421" alt="image" src="https://github.com/user-attachments/assets/3f1457e2-4453-4a66-83cd-037c58c464a9" />



