### PR TITLE
Issue987 minimize sat dialog b

### DIFF
--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -2838,7 +2838,7 @@ export const WorldMap = ({
         </div>
       )}
       <style>{`
-        ${mapUiHidden ? '.leaflet-control-container,.grayline-control,.muf-map-control,.voacap-heatmap-control,.rbn-control,.lightning-stats,.lightning-proximity,.wspr-filter-control,.wspr-stats,.wspr-legend,.wspr-chart,.sat-data-window{display:none !important;}' : ''}
+        ${mapUiHidden ? '.leaflet-control-container,.grayline-control,.muf-map-control,.voacap-heatmap-control,.rbn-control,.lightning-stats,.lightning-proximity,.wspr-filter-control,.wspr-stats,.wspr-legend,.wspr-chart{display:none !important;}' : ''}
         .ohc-rotator-bearing {
           stroke-dasharray: 10 10;
           animation: ohcRotDash 2.8s linear infinite, ohcRotPulse 3.2s ease-in-out infinite;

--- a/src/plugins/layers/useSatelliteLayer.js
+++ b/src/plugins/layers/useSatelliteLayer.js
@@ -206,70 +206,22 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
     const activeSats = satellites.filter((s) => selectedSats.includes(s.name));
 
     const titleBar = `
-  <div class="sat-data-window-title"
-       style="
-         display:flex;
-         justify-content:space-between;
-         align-items:center;
-         cursor:grab;
-         user-select:none;
-         border-bottom: 1px solid var(--border-color);
-         background: var(--bg-tertiary);
-         ${
-           winMinimized
-             ? `
-             padding: 2px 6px;
-             width: fit-content;
-             min-width: 0;
-             flex: none;
-           `
-             : `
-             padding: 8px 10px;
-           `
-         }
-       ">
-       
-    <span data-drag-handle="true"
-          style="font-family: var(--font-mono);
-                 font-size:13px;
-                 font-weight:700;
-                 color: var(--accent-blue);
-                 letter-spacing:0.05em;">
-      🛰 ${
-        !winMinimized
-          ? `${activeSats.length} ${
-              activeSats.length !== 1
-                ? t('station.settings.satellites.name_plural')
-                : t('station.settings.satellites.name')
-            }`
-          : ''
-      }
-    </span>
-
-    <button class="sat-data-window-minimize"
-            onclick="window.__satWinToggleMinimize()"
-            title="${winMinimized ? 'Expand' : 'Minimize'}"
-            style="
-              background:none;
-              border:none;
-              color: var(--text-secondary);
-              cursor:pointer;
-              font-size:10px;
-              line-height:1;
-              padding:2px 4px;
-              margin:0;
-            ">
-      ${winMinimized ? '▶' : '▼'}
-    </button>
-
-  </div>
-`;
+      <div class="sat-data-window-title"
+        style="display:flex; justify-content:space-between; align-items:center; cursor:grab; user-select:none; border-bottom:1px solid var(--border-color); background:var(--bg-tertiary);
+          ${winMinimized ? `padding:2px 6px; width:fit-content; min-width:0; max-width:fit-content; height:fit-content; min-height:0; flex:none;` : `padding:8px 10px;`}">
+        <span data-drag-handle="true" style="font-family:var(--font-mono); font-size:13px; font-weight:700; color:var(--accent-blue); letter-spacing:0.05em;">
+          🛰 ${!winMinimized ? `${activeSats.length} ${activeSats.length !== 1 ? t('station.settings.satellites.name_plural') : t('station.settings.satellites.name')}` : ''}
+        </span>
+        <button class="sat-data-window-minimize" onclick="window.__satWinToggleMinimize()" title="${winMinimized ? 'Expand' : 'Minimize'}" style="background:none; border:none; color:var(--text-secondary); cursor:pointer; font-size:10px; line-height:1; padding:2px 4px; margin:0;">
+          ${winMinimized ? '▶' : '▼'}
+        </button>
+      </div>`;
 
     const clearAllBtn = `
       <div style="margin: 10px 12px 8px; display: flex; flex-direction: column; align-items: center; gap: 5px;">
         <button onclick="sessionStorage.removeItem('selected_satellites'); window.location.reload();"
           style="background: var(--bg-primary); border: 1px solid var(--accent-red); color: var(--accent-red); cursor: pointer;
-                       padding: 4px 10px; font-size: 10px; border-radius: 3px; font-weight: bold; width: 100%;">
+            padding: 4px 10px; font-size: 10px; border-radius: 3px; font-weight: bold; width: 100%;">
           ${t('station.settings.satellites.clearFootprints')}
         </button>
         <span style="font-size: 9px; color: var(--text-muted);">${t('station.settings.satellites.dragTitle')}</span>
@@ -301,6 +253,12 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
       return;
     }
 
+    // reset to default size constraints
+    win.style.width = '260px';
+    win.style.minWidth = '';
+    win.style.maxWidth = '';
+    win.style.height = '';
+    win.style.minHeight = '';
     win.style.maxHeight = 'calc(100% - 80px)';
     win.style.overflowY = 'auto';
 

--- a/src/plugins/layers/useSatelliteLayer.js
+++ b/src/plugins/layers/useSatelliteLayer.js
@@ -206,21 +206,64 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
     const activeSats = satellites.filter((s) => selectedSats.includes(s.name));
 
     const titleBar = `
-      <div class="sat-data-window-title" style="display:flex; justify-content:space-between; align-items:center;
-                  cursor:grab; user-select:none;
-                  padding: 8px 10px; border-bottom: 1px solid var(--border-color); background: var(--bg-tertiary);">
-        <span data-drag-handle="true" style="font-family: var(--font-mono); font-size:13px; font-weight:700; color: var(--accent-blue); letter-spacing:0.05em;">
-          🛰 ${activeSats.length} ${activeSats.length !== 1 ? t('station.settings.satellites.name_plural') : t('station.settings.satellites.name')}
-        </span>
-        <button class="sat-data-window-minimize"
-                onclick="window.__satWinToggleMinimize()"
-                title="${winMinimized ? 'Expand' : 'Minimize'}"
-          style="background:none; border:none; color: var(--text-secondary); cursor:pointer;
-                       font-size:10px; line-height:1; padding:2px 4px; margin:0;">
-          ${winMinimized ? '▶' : '▼'}
-        </button>
-      </div>
-    `;
+  <div class="sat-data-window-title"
+       style="
+         display:flex;
+         justify-content:space-between;
+         align-items:center;
+         cursor:grab;
+         user-select:none;
+         border-bottom: 1px solid var(--border-color);
+         background: var(--bg-tertiary);
+         ${
+           winMinimized
+             ? `
+             padding: 2px 6px;
+             width: fit-content;
+             min-width: 0;
+             flex: none;
+           `
+             : `
+             padding: 8px 10px;
+           `
+         }
+       ">
+       
+    <span data-drag-handle="true"
+          style="font-family: var(--font-mono);
+                 font-size:13px;
+                 font-weight:700;
+                 color: var(--accent-blue);
+                 letter-spacing:0.05em;">
+      🛰 ${
+        !winMinimized
+          ? `${activeSats.length} ${
+              activeSats.length !== 1
+                ? t('station.settings.satellites.name_plural')
+                : t('station.settings.satellites.name')
+            }`
+          : ''
+      }
+    </span>
+
+    <button class="sat-data-window-minimize"
+            onclick="window.__satWinToggleMinimize()"
+            title="${winMinimized ? 'Expand' : 'Minimize'}"
+            style="
+              background:none;
+              border:none;
+              color: var(--text-secondary);
+              cursor:pointer;
+              font-size:10px;
+              line-height:1;
+              padding:2px 4px;
+              margin:0;
+            ">
+      ${winMinimized ? '▶' : '▼'}
+    </button>
+
+  </div>
+`;
 
     const clearAllBtn = `
       <div style="margin: 10px 12px 8px; display: flex; flex-direction: column; align-items: center; gap: 5px;">
@@ -236,7 +279,16 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
     if (winMinimized) {
       win.style.maxHeight = '';
       win.style.overflowY = 'hidden';
+
+      // shrink to minimal size
+      win.style.width = 'fit-content';
+      win.style.minWidth = 'unset';
+      win.style.maxWidth = 'fit-content';
+      win.style.height = 'fit-content';
+      win.style.minHeight = 'unset';
+
       win.innerHTML = `${titleBar}<div class="sat-data-window-content"></div>`;
+
       addMinimizeToggle(win, 'sat-data-window', {
         contentClassName: 'sat-data-window-content',
         buttonClassName: 'sat-data-window-minimize',
@@ -245,6 +297,7 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
         persist: false,
         manageButtonEvents: true,
       });
+
       return;
     }
 


### PR DESCRIPTION
- recreated and resubmit from closed PR https://github.com/accius/openhamclock/pull/1008 refer also to previous review there

## What does this PR do?

- fixes https://github.com/accius/openhamclock/issues/987
- shrink satellites dialog to minimal size
- eliminate text when minimized so only satellite icon and right-arrow appear
- doesn't eliminate satellites button altogether like other boxes in the 'Show UI' pattern, but makes satellite less obtrusive

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [X] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## Checklist

- [X] App loads without console errors
- [X] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [X] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [X] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)
before
<img width="318" height="114" alt="image" src="https://github.com/user-attachments/assets/8ae54e4a-8fb7-4f6f-9640-aa68f21e015e" />

after
<img width="84" height="63" alt="image" src="https://github.com/user-attachments/assets/f71b3725-f0e8-483e-8c99-b645eff87cd0" />
<img width="201" height="421" alt="image" src="https://github.com/user-attachments/assets/3f1457e2-4453-4a66-83cd-037c58c464a9" />
