### PR TITLE
[fix] utils/geo.js minor updates and unit test for sub-solar point, modify accuracy in WorldMap

### DIFF
--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -1318,7 +1318,7 @@ export const WorldMap = ({
           iconAnchor: [14, 14],
         });
         const m = L.marker([sunPos.lat, sunPos.lon + offset], { icon: sunIcon })
-          .bindPopup(`<b>Subsolar Point</b><br>${sunPos.lat.toFixed(2)}°, ${sunPos.lon.toFixed(2)}°`)
+          .bindPopup(`<b>Subsolar Point</b><br>${sunPos.lat.toFixed(1)}°, ${sunPos.lon.toFixed(1)}°`)
           .addTo(map);
         sunMarkerRef.current.push(m);
       }

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -172,7 +172,7 @@ export const calculateDistance = (lat1, lon1, lat2, lon2) => {
  * @returns {string} Formatted distance with unit label (e.g. "1,234 km" or "767 mi")
  */
 export const formatDistance = (km, units) => {
-  if (units === 'imperial') {
+  if (units !== 'metric') {
     const mi = km * 0.621371;
     return `${Math.round(mi).toLocaleString()} mi`;
   }
@@ -181,6 +181,8 @@ export const formatDistance = (km, units) => {
 
 /**
  * Get subsolar point (position where sun is directly overhead)
+ * Note, this is a crude approximation but within estimated +/- 0.75 deg lat, +/- 1.0 deg lon,
+ * variation within this range is seasonal
  */
 export const getSunPosition = (date) => {
   const dayOfYear = Math.floor((date - new Date(date.getFullYear(), 0, 0)) / 86400000);
@@ -389,10 +391,10 @@ export const calculateSunTimes = (lat, lon, date) => {
 };
 
 /**
- * Normalize longitude to -180..180 range
+ * Normalize longitude to [−180,+180) degrees
  */
 export const normalizeLon = (lon) => {
-  while (lon > 180) lon -= 360;
+  while (lon >= 180) lon -= 360;
   while (lon < -180) lon += 360;
   return lon;
 };

--- a/src/utils/geo.test.js
+++ b/src/utils/geo.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { validateGridLocator, latLonToMaidenhead, maidenheadToLatLon, maidenheadToBoundingBox } from './geo.js';
+import { getSunPosition } from './geo.js';
+import { normalizeLon } from './geo.js';
 
 describe('Maidenhead Grid tests', () => {
   const gridCases = [
@@ -164,5 +166,113 @@ describe('Maidenhead Grid tests', () => {
         },
       );
     }
+  }
+});
+
+describe('Sun/Moon tests', () => {
+  const sunEphemerisCases = [
+    // based on https://eclipse.gsfc.nasa.gov/TYPE/sun1.html#su2000
+    {
+      date: '1999-12-22T00:00:00.000Z',
+      gast: 6 + 0 / 60 + 26.7 / 3600,
+      dec: -(23 + 26 / 60 + 14.1 / 3600),
+      ra: 17 + 58 / 60 + 34.03 / 3600,
+    },
+
+    // based on https://eclipse.gsfc.nasa.gov/TYPE/sun1.html#su2000
+    {
+      date: '2000-01-01T00:00:00.000Z',
+      gast: 6 + 39 / 60 + 52.3 / 3600,
+      dec: -(23 + 4 / 60 + 16.2 / 3600),
+      ra: 18 + 42 / 60 + 54.05 / 3600,
+    },
+
+    // based on https://eclipse.gsfc.nasa.gov/TYPE/sun1.html#su2000
+    {
+      date: '2000-06-21T00:00:00.000Z',
+      gast: 17 + 57 / 60 + 59.8 / 3600,
+      dec: 23 + 26 / 60 + 16.2 / 3600,
+      ra: 5 + 59 / 60 + 41.15 / 3600,
+    },
+
+    // based on https://www.astropixels.com/ephemeris/sun/sun2026.html
+    {
+      date: '2026-01-01T00:00:00.000Z',
+      gast: 6 + 42 / 60 + 38.8 / 3600,
+      dec: -(23 + 1 / 60 + 2.1 / 3600),
+      ra: 18 + 45 / 60 + 58.74 / 3600,
+    },
+
+    // based on https://www.astropixels.com/ephemeris/sun/sun2026.html
+    {
+      date: '2026-04-29T00:00:00.000Z',
+      gast: 14 + 27 / 60 + 52.3 / 3600,
+      dec: 14 + 24 / 60 + 3.3 / 3600,
+      ra: 2 + 25 / 60 + 16.69 / 3600,
+    },
+  ];
+
+  for (const ephemeris of sunEphemerisCases) {
+    it('should validate getSunPosition() for known position', () => {
+      const date = new Date(ephemeris.date);
+
+      const subSolarPointFromGST = (raHours, decDeg, gstHours) => {
+        // Hours → radians
+        const TWO_PI = 2 * Math.PI;
+        const ra = (raHours * TWO_PI) / 24;
+        const gast = (gstHours * TWO_PI) / 24;
+
+        // Latitude = Dec (unchanged)
+        const lat = decDeg;
+
+        // Longitude = RA - GAST (radians → degrees)
+        let lon = normalizeDegrees180(((ra - gast) * 180) / Math.PI);
+
+        return { lat, lon };
+      };
+
+      const sunPosition = getSunPosition(date); // target code
+      const point = subSolarPointFromGST(ephemeris.ra, ephemeris.dec, ephemeris.gast);
+
+      // check absolute difference in tested and calculated values does not exceed maximum allowed
+      const maxAllowedDeltaLat = 0.75;
+      const maxAllowedDeltaLon = 1.0;
+      expect(Math.abs(normalizeDegrees180(sunPosition.lat - point.lat))).toBeLessThan(maxAllowedDeltaLat);
+      expect(Math.abs(normalizeDegrees180(sunPosition.lon - point.lon))).toBeLessThan(maxAllowedDeltaLon);
+    });
+  }
+
+  function normalizeDegrees360(d) {
+    return ((d % 360) + 360) % 360;
+  }
+  function normalizeDegrees180(d) {
+    return ((((d + 180) % 360) + 360) % 360) - 180;
+  }
+  function normalizeRadians(r) {
+    return ((r % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI);
+  }
+  function deg2rad(d) {
+    return (d * Math.PI) / 180;
+  }
+  function rad2deg(r) {
+    return (r * 180) / Math.PI;
+  }
+});
+
+describe('miscellaneous functionality tests', () => {
+  for (const [lon, expected] of [
+    [-720, 0],
+    [-360, 0],
+    [-180, -180],
+    [-90, -90],
+    [0, 0],
+    [90, 90],
+    [180, -180],
+    [360, 0],
+    [720, 0],
+  ]) {
+    it('should validate normalizeLon()', () => {
+      expect(normalizeLon(lon)).toBe(expected);
+    });
   }
 });


### PR DESCRIPTION
## What does this PR do?

- The sub-solar point was reported to two decimal places yet the calculation `getSunPosition` in `utils/geo.js` is only a fast crude approximation. Experimentally based on ephemeris the calculation has seasonal variation with accuracy within +/- 0.75 deg lat, +/- 1.0 deg lon (i.e. not better than zero-decimal places more appropriate).
- Zero decimal places isn't, in my opinion, visually appealing so I changed it from two to one decimal places.

`geo.js`
- units test from `=== 'imperial'` to `!== 'metric'`
- correct `normalizeLon` so that +180 deg is corrected to -180 deg (i.e. 180degE -> 180degW)
- add comment to `getSunPosition` noting that this is a crude approximation with seasonal variation within +/- 0.75 deg lat, +/- 1.0 deg lon

`geo.test.js`
- add unit test for `normalizeLon`
- add unit test for `getSunPosition` based on NASA ephemeris

`WorldMap.jsx`
- subsolar point from two to one decimal places [deg]

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## Checklist

- [X] App loads without console errors
- [X] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [X] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)
before PR
<img width="159" height="114" alt="image" src="https://github.com/user-attachments/assets/d03b36a7-44b0-4996-8e03-9a7a26e07d16" />

applied in this PR
<img width="151" height="117" alt="image" src="https://github.com/user-attachments/assets/59bd6342-0144-4bfe-97d8-1f828dee9911" />

not applied though determined most appropriate
<img width="140" height="91" alt="image" src="https://github.com/user-attachments/assets/29a0f557-37ec-4c45-adb1-469da360cc32" />

## miscellaneous

- If accurate subsolar point were ever needed the following code works. I ran this code in the same ephemeris unit test and it was within +/- 0.01 deg both alt / lon. I didn't add the code to `utils/geo.js` however.

``` js
export const getSubsolarPoint = (date) => {
  const rad = Math.PI / 180;
  const deg = 180 / Math.PI;

  // Julian Day
  const JD = date.getTime() / 86400000 + 2440587.5;
  const T = (JD - 2451545.0) / 36525;

  // Mean anomaly of the Sun (deg)
  const M = 357.52911 + T * (35999.05029 - 0.0001537 * T);

  // Mean longitude (deg)
  const L0 = 280.46646 + T * (36000.76983 + 0.0003032 * T);

  // Equation of center (deg)
  const C =
    (1.914602 - T * (0.004817 + 0.000014 * T)) * Math.sin(M * rad) +
    (0.019993 - 0.000101 * T) * Math.sin(2 * M * rad) +
    0.000289 * Math.sin(3 * M * rad);

  // True longitude (deg)
  const trueLong = L0 + C;

  // Obliquity of the ecliptic (deg)
  const eps = 23.439291 - 0.0130042 * T;

  // Declination (deg)
  const lat = Math.asin(Math.sin(eps * rad) * Math.sin(trueLong * rad)) * deg;

  // Equation of time (minutes)
  const y = Math.tan((eps * rad) / 2) ** 2;
  const Etime =
    4 *
    deg *
    (y * Math.sin(2 * L0 * rad) -
      2 * 0.016708634 * Math.sin(M * rad) +
      4 * 0.016708634 * y * Math.sin(M * rad) * Math.cos(2 * L0 * rad) -
      0.5 * y * y * Math.sin(4 * L0 * rad) -
      1.25 * 0.016708634 * 0.016708634 * Math.sin(2 * M * rad));

  // Solar time offset (hours)
  const offsetHours = Etime / 60;

  // Subsolar longitude (deg)
  const UT = date.getUTCHours() + date.getUTCMinutes() / 60 + date.getUTCSeconds() / 3600;
  let lon = 180 - (UT + offsetHours) * 15;

  // Normalize to [-180, 180)
  lon = ((lon + 180) % 360 + 360) % 360 - 180;

  return { lat, lon };
}
```