### PR TITLE
feature(docker): iturhfprop container image workflow

### DIFF
--- a/.github/workflows/docker-image-iturhfprop.yml
+++ b/.github/workflows/docker-image-iturhfprop.yml
@@ -1,0 +1,81 @@
+name: Build and Publish ITURHFProp Docker Image
+
+on:
+  push:
+    branches: ['main']
+    paths:
+      - 'iturhfprop-service/**'
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: iturhfprop-service
+
+jobs:
+  build-and-push:
+    if: github.repository == 'accius/openhamclock'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix={{branch}}-,enable=${{ github.event_name != 'release' }}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./iturhfprop-service
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=${{ github.workflow }}
+          cache-to: type=gha,scope=${{ github.workflow }},mode=max
+          provenance: true
+          sbom: true
+
+      - name: Generate artifact attestation
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/dxspider-proxy/server.js
+++ b/dxspider-proxy/server.js
@@ -30,9 +30,13 @@ const CONFIG = {
   reconnectDelayMs: 10000, // 10 seconds between reconnect attempts
   maxReconnectAttempts: 3,
   cleanupIntervalMs: 60000, // 1 minute
-  keepAliveIntervalMs: 120000, // 2 minutes - send keepalive
+  keepAliveIntervalMs: 60000, // 1 minute - send keepalive (must stay < socketTimeoutMs)
   activityTimeoutMs: 180000, // 3 minutes - if no spots, assume dead and failover
   authTimeoutMs: 30000, // 30 seconds - if no prompt after login, try next node
+  // Last-resort TCP backstop. Must be LONGER than activityTimeoutMs so the
+  // graceful node-failover watchdog acts first. A 60s value here used to
+  // preempt it and tear down healthy connections during quiet-band gaps.
+  socketTimeoutMs: 300000, // 5 minutes
 };
 
 // State
@@ -242,7 +246,7 @@ const connect = () => {
   log('CONNECT', `Attempting connection to ${node.name} (${node.host}:${node.port})`);
 
   client = new net.Socket();
-  client.setTimeout(60000); // 60 second timeout
+  client.setTimeout(CONFIG.socketTimeoutMs);
 
   client.connect(node.port, node.host, () => {
     connected = true;
@@ -313,6 +317,13 @@ const connect = () => {
         if (spot) {
           addSpot(spot);
           resetActivityWatchdog(); // Got a spot, connection is healthy
+          // A flowing spot is definitive proof login succeeded. The DXSpider
+          // prompt has no trailing newline so it never arrives as a complete
+          // line — prompt-based detection alone is unreliable.
+          if (!authenticated) {
+            authenticated = true;
+            log('AUTH', 'Login confirmed (spot stream active)');
+          }
           // Only reset failover counter if connection has been stable for 60s+
           // A few spots before a timeout isn't truly healthy — it traps us
           // on a flaky node that connects briefly then drops
@@ -328,8 +339,10 @@ const connect = () => {
         continue;
       }
 
-      // Detect auth completion - DX Spider sends "callsign de NODE >" prompt
-      if (!authenticated && /\sde\s+\S+\s*>/.test(trimmed)) {
+      // Detect auth completion - DX Spider sends "callsign de NODE >" prompt.
+      // Exclude lines containing '<' — sh/dx output (e.g. "...de Helmut<DF4IY>")
+      // otherwise false-matches this pattern.
+      if (!authenticated && !trimmed.includes('<') && /\sde\s+\S+\s*>/.test(trimmed)) {
         authenticated = true;
         log('AUTH', `Login confirmed: ${trimmed.substring(0, 80)}`);
         resetActivityWatchdog(); // Auth done, start watching for spots
@@ -344,6 +357,16 @@ const connect = () => {
   client.on('timeout', () => {
     log('TIMEOUT', 'Connection timed out');
     connecting = false;
+    // Node does NOT auto-close a socket on timeout. Without this teardown the
+    // old socket keeps emitting 'data' until the next connect(), spuriously
+    // logging "Connection stable" and resetting the failover counter.
+    if (client) {
+      try {
+        client.removeAllListeners();
+        client.destroy();
+      } catch (e) {}
+      client = null;
+    }
     handleDisconnect();
   });
 

--- a/dxspider-proxy/server.js
+++ b/dxspider-proxy/server.js
@@ -30,13 +30,9 @@ const CONFIG = {
   reconnectDelayMs: 10000, // 10 seconds between reconnect attempts
   maxReconnectAttempts: 3,
   cleanupIntervalMs: 60000, // 1 minute
-  keepAliveIntervalMs: 60000, // 1 minute - send keepalive (must stay < socketTimeoutMs)
+  keepAliveIntervalMs: 120000, // 2 minutes - send keepalive
   activityTimeoutMs: 180000, // 3 minutes - if no spots, assume dead and failover
   authTimeoutMs: 30000, // 30 seconds - if no prompt after login, try next node
-  // Last-resort TCP backstop. Must be LONGER than activityTimeoutMs so the
-  // graceful node-failover watchdog acts first. A 60s value here used to
-  // preempt it and tear down healthy connections during quiet-band gaps.
-  socketTimeoutMs: 300000, // 5 minutes
 };
 
 // State
@@ -246,7 +242,7 @@ const connect = () => {
   log('CONNECT', `Attempting connection to ${node.name} (${node.host}:${node.port})`);
 
   client = new net.Socket();
-  client.setTimeout(CONFIG.socketTimeoutMs);
+  client.setTimeout(60000); // 60 second timeout
 
   client.connect(node.port, node.host, () => {
     connected = true;
@@ -317,13 +313,6 @@ const connect = () => {
         if (spot) {
           addSpot(spot);
           resetActivityWatchdog(); // Got a spot, connection is healthy
-          // A flowing spot is definitive proof login succeeded. The DXSpider
-          // prompt has no trailing newline so it never arrives as a complete
-          // line — prompt-based detection alone is unreliable.
-          if (!authenticated) {
-            authenticated = true;
-            log('AUTH', 'Login confirmed (spot stream active)');
-          }
           // Only reset failover counter if connection has been stable for 60s+
           // A few spots before a timeout isn't truly healthy — it traps us
           // on a flaky node that connects briefly then drops
@@ -339,10 +328,8 @@ const connect = () => {
         continue;
       }
 
-      // Detect auth completion - DX Spider sends "callsign de NODE >" prompt.
-      // Exclude lines containing '<' — sh/dx output (e.g. "...de Helmut<DF4IY>")
-      // otherwise false-matches this pattern.
-      if (!authenticated && !trimmed.includes('<') && /\sde\s+\S+\s*>/.test(trimmed)) {
+      // Detect auth completion - DX Spider sends "callsign de NODE >" prompt
+      if (!authenticated && /\sde\s+\S+\s*>/.test(trimmed)) {
         authenticated = true;
         log('AUTH', `Login confirmed: ${trimmed.substring(0, 80)}`);
         resetActivityWatchdog(); // Auth done, start watching for spots
@@ -357,16 +344,6 @@ const connect = () => {
   client.on('timeout', () => {
     log('TIMEOUT', 'Connection timed out');
     connecting = false;
-    // Node does NOT auto-close a socket on timeout. Without this teardown the
-    // old socket keeps emitting 'data' until the next connect(), spuriously
-    // logging "Connection stable" and resetting the failover counter.
-    if (client) {
-      try {
-        client.removeAllListeners();
-        client.destroy();
-      } catch (e) {}
-      client = null;
-    }
     handleDisconnect();
   });
 

--- a/iturhfprop-service/README.md
+++ b/iturhfprop-service/README.md
@@ -111,8 +111,14 @@ The Dockerfile will:
 
 ### Docker
 
+A container image is provided in the github container registry
+
 ```bash
-# Build
+
+# Pull
+docker pull ghcr.io/accius/iturhfprop-service:latest
+
+# or Build
 docker build -t iturhfprop-service .
 
 # Run
@@ -122,16 +128,16 @@ docker run -p 3000:3000 iturhfprop-service
 curl http://localhost:3000/api/health
 ```
 
-If using a compose file, you can also add it as an additional service:
+If using a compose file for OpenHamClock, you can also add it as an additional service:
 
 ```yaml
 services:
   openhamclock:
-    ...
-
+    # [...]
   iturhfprop:
     build:
       context: ./iturhfprop-service # path to this subdirectory in the openhamclock repo
+    image: ghcr.io/accius/iturhfprop-service:latest
     restart: unless-stopped
     container_name: iturhfprop
 ```


### PR DESCRIPTION
## What does this PR do?

This PR adds a github workflow to automatically build and publish a container image for the iturhfprop microservice.

It also changes the documentation and associated snippets to reference this image. (It also fixes the snippet linting issue I missed earlier 🥲 )

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

Github workflow should auto-trigger on similar conditions as the existing `docker-build` one.

## Extra thoughts

I wonder if this microservice should have its own repo, would that make sense?
