### PR TITLE
[performance] Satellite - use filters, only calculate selected satellites

### DIFF
--- a/iturhfprop-service/README.md
+++ b/iturhfprop-service/README.md
@@ -126,8 +126,7 @@ If using a compose file, you can also add it as an additional service:
 
 ```yaml
 services:
-  openhamclock:
-    ...
+  openhamclock: ...
 
   iturhfprop:
     build:

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,7 +44,7 @@ import useAppConfig from './hooks/app/useAppConfig';
 import useDXLocation from './hooks/app/useDXLocation';
 import useMapLayers from './hooks/app/useMapLayers';
 import useFilters from './hooks/app/useFilters';
-import useSatellitesFilters from './hooks/app/useSatellitesFilters';
+import useSatellitesFilters, { useSatelliteFilterState } from './hooks/app/useSatellitesFilters';
 import useTimeState from './hooks/app/useTimeState';
 import useFullscreen from './hooks/app/useFullscreen';
 import useScreenWakeLock from './hooks/app/useScreenWakeLock';
@@ -323,7 +323,9 @@ const App = () => {
 
   const propagation = usePropagation(config.location, dxLocation, config.propagation);
   const mySpots = useMySpots(config.callsign);
-  const satellites = useSatellites(config.location, config.satellite);
+  const filterState = useSatelliteFilterState();
+  const { satelliteFilters, setSatelliteFilters } = filterState;
+  const satellites = useSatellites(config.location, config.satellite, satelliteFilters);
   const localWeather = useWeather(config.location, config.allUnits);
   const dxWeather = useWeather(dxLocation, config.allUnits);
   const localAlerts = useWeatherAlerts(config.location);
@@ -396,7 +398,7 @@ const App = () => {
     return () => window.removeEventListener('ohc-n3fjp-dx-target', handler);
   }, [handleDXChange]);
 
-  const { satelliteFilters, setSatelliteFilters, filteredSatellites } = useSatellitesFilters(satellites.data);
+  const { filteredSatellites } = useSatellitesFilters(satellites.data, filterState);
 
   const {
     currentTime,

--- a/src/hooks/app/useSatellitesFilters.js
+++ b/src/hooks/app/useSatellitesFilters.js
@@ -24,8 +24,11 @@ export function useSatelliteFilterState() {
 }
 
 export default function useSatellitesFilters(satellitesData, externalState) {
-  const state = externalState || useSatelliteFilterState();
-  const { satelliteFilters, setSatelliteFilters } = state;
+  if (!externalState) {
+    throw new Error('useSatellitesFilters requires externalState to be provided');
+  }
+
+  const { satelliteFilters, setSatelliteFilters } = externalState;
 
   const filteredSatellites = useMemo(() => {
     // If no satellites are selected in the filter, show NONE (empty array)

--- a/src/hooks/app/useSatellitesFilters.js
+++ b/src/hooks/app/useSatellitesFilters.js
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { syncAllSettingsToServer } from '../../utils';
 
-export default function useSatellitesFilters(satellitesData) {
+export function useSatelliteFilterState() {
   const [satelliteFilters, setSatelliteFilters] = useState(() => {
     try {
       const saved = localStorage.getItem('openhamclock_satelliteFilters');
@@ -19,6 +19,13 @@ export default function useSatellitesFilters(satellitesData) {
       syncAllSettingsToServer();
     } catch (e) {}
   }, [satelliteFilters]);
+
+  return { satelliteFilters, setSatelliteFilters };
+}
+
+export default function useSatellitesFilters(satellitesData, externalState) {
+  const state = externalState || useSatelliteFilterState();
+  const { satelliteFilters, setSatelliteFilters } = state;
 
   const filteredSatellites = useMemo(() => {
     // If no satellites are selected in the filter, show NONE (empty array)

--- a/src/hooks/useSatellites.js
+++ b/src/hooks/useSatellites.js
@@ -13,7 +13,7 @@ function round(value, decimals) {
   return Math.round(value * factor) / factor;
 }
 
-export const useSatellites = (observerLocation, satelliteConfig, filteredNames = []) => {
+export const useSatellites = (observerLocation, satelliteConfig, filteredNames = null) => {
   const [data, setData] = useState([]);
   const [nextPassData, setNextPassData] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -195,32 +195,13 @@ export const useSatellites = (observerLocation, satelliteConfig, filteredNames =
             // Skip satellites with invalid data, continue processing others
           }
         } else {
+          // Case where isCalcNeeded() is false, satellite location calculation is not needed.
+          // Note that data set is consumed by OHC settings panel which displays all satellites
+          // with data that has been downloaded from server.
+          // Satellite needs to appear there to be selectable but that panel requires name only
+          // for all known satellites and not their full details.
           positions.push({
             name: satData.name || name,
-            omm: satData.omm,
-            lat: 0,
-            lon: 0,
-            alt: 0,
-            speedKmH: 0,
-            azimuth: 0,
-            elevation: 0,
-            range: 0,
-            rangeRate: 0,
-            dopplerFactor: 1,
-            isVisible: false,
-            nextPassStartTimes: startTimes,
-            nextPassEndTimes: endTimes,
-            isPopular: satData.priority <= 2,
-            track: [],
-            footprintRadius: 0,
-            mode: satData.mode || 'Unknown',
-            color: satData.color || '#00ffff',
-            // Radio metadata from satellites.json
-            downlink: satData.downlink || '',
-            uplink: satData.uplink || '',
-            tone: satData.tone || '',
-            beacon: satData.beacon || '',
-            notes: satData.notes || '',
           });
         }
       });

--- a/src/hooks/useSatellites.js
+++ b/src/hooks/useSatellites.js
@@ -13,7 +13,7 @@ function round(value, decimals) {
   return Math.round(value * factor) / factor;
 }
 
-export const useSatellites = (observerLocation, satelliteConfig) => {
+export const useSatellites = (observerLocation, satelliteConfig, filteredNames = []) => {
   const [data, setData] = useState([]);
   const [nextPassData, setNextPassData] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -87,6 +87,9 @@ export const useSatellites = (observerLocation, satelliteConfig) => {
       };
 
       Object.entries(satelliteData).forEach(([name, satData]) => {
+        // calculation needed only if satellite appears in filter, or if filter is missing completely
+        const isCalcNeeded = (satData) => !(filteredNames && satData?.name && !filteredNames.includes(satData.name));
+
         // Find corresponding next pass data for this satellite
         const nextPass = nextPassData.find(
           (pass) => pass.keyName === (satData.name || '') || pass.keyName === (name || ''),
@@ -94,90 +97,122 @@ export const useSatellites = (observerLocation, satelliteConfig) => {
         const startTimes = nextPass?.startTimes || [];
         const endTimes = nextPass?.endTimes || [];
 
-        try {
-          const satrec = satellite.json2satrec(satData.omm);
-          const positionAndVelocity = satellite.propagate(satrec, now);
-          const positionEci = positionAndVelocity.position;
-          const velocityEci = positionAndVelocity.velocity;
+        if (isCalcNeeded(satData)) {
+          try {
+            const satrec = satellite.json2satrec(satData.omm);
+            const positionAndVelocity = satellite.propagate(satrec, now);
+            const positionEci = positionAndVelocity.position;
+            const velocityEci = positionAndVelocity.velocity;
 
-          if (!positionEci) return;
+            if (!positionEci) return;
 
-          const positionGd = satellite.eciToGeodetic(positionEci, gmst);
+            const positionGd = satellite.eciToGeodetic(positionEci, gmst);
 
-          // Convert to degrees
-          const lat = satellite.degreesLat(positionGd.latitude);
-          const lon = satellite.degreesLong(positionGd.longitude);
-          const alt = positionGd.height;
+            // Convert to degrees
+            const lat = satellite.degreesLat(positionGd.latitude);
+            const lon = satellite.degreesLong(positionGd.longitude);
+            const alt = positionGd.height;
 
-          // Calculate look angles
-          const positionEcf = satellite.eciToEcf(positionEci, gmst);
-          const lookAngles = satellite.ecfToLookAngles(observerGd, positionEcf);
-          const azimuth = satellite.radiansToDegrees(lookAngles.azimuth);
-          const elevation = satellite.radiansToDegrees(lookAngles.elevation);
-          const rangeSat = lookAngles.rangeSat;
+            // Calculate look angles
+            const positionEcf = satellite.eciToEcf(positionEci, gmst);
+            const lookAngles = satellite.ecfToLookAngles(observerGd, positionEcf);
+            const azimuth = satellite.radiansToDegrees(lookAngles.azimuth);
+            const elevation = satellite.radiansToDegrees(lookAngles.elevation);
+            const rangeSat = lookAngles.rangeSat;
 
-          const isVisible = elevation >= (satelliteConfig?.minElev ?? 5.0); // visible only if above minimum elevation
+            const isVisible = elevation >= (satelliteConfig?.minElev ?? 5.0); // visible only if above minimum elevation
 
-          // Calculate range-rate and doppler factor, only if satellite is visible
-          let dopplerFactor = 1;
-          let rangeRate = 0;
+            // Calculate range-rate and doppler factor, only if satellite is visible
+            let dopplerFactor = 1;
+            let rangeRate = 0;
 
-          if (isVisible) {
-            const observerEcf = satellite.geodeticToEcf(observerGd);
-            const velocityEcf = satellite.eciToEcf(velocityEci, gmst);
-            dopplerFactor = satellite.dopplerFactor(observerEcf, positionEcf, velocityEcf);
-            const c = 299792.458; // Speed of light [km/s]
-            rangeRate = (1 - dopplerFactor) * c; // [km/s]
-          }
-
-          // Calculate speed from ECI velocity vector [km/s]
-          let speedKmH = 0;
-          if (velocityEci) {
-            const v = velocityEci;
-            speedKmH = Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z) * 3600; // [km/s] → [km/h]
-          }
-
-          // Calculate orbit track (past 45 min and future 45 min = 90 min total)
-          const track = [];
-          const trackMinutes = 90;
-          const stepMinutes = 1;
-
-          for (let m = -trackMinutes / 2; m <= trackMinutes / 2; m += stepMinutes) {
-            const trackTime = new Date(now.getTime() + m * 60 * 1000);
-            const trackPV = satellite.propagate(satrec, trackTime);
-
-            if (trackPV.position) {
-              const trackGmst = satellite.gstime(trackTime);
-              const trackGd = satellite.eciToGeodetic(trackPV.position, trackGmst);
-              const trackLat = satellite.degreesLat(trackGd.latitude);
-              const trackLon = satellite.degreesLong(trackGd.longitude);
-              track.push([trackLat, trackLon]);
+            if (isVisible) {
+              const observerEcf = satellite.geodeticToEcf(observerGd);
+              const velocityEcf = satellite.eciToEcf(velocityEci, gmst);
+              dopplerFactor = satellite.dopplerFactor(observerEcf, positionEcf, velocityEcf);
+              const c = 299792.458; // Speed of light [km/s]
+              rangeRate = (1 - dopplerFactor) * c; // [km/s]
             }
+
+            // Calculate speed from ECI velocity vector [km/s]
+            let speedKmH = 0;
+            if (velocityEci) {
+              const v = velocityEci;
+              speedKmH = Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z) * 3600; // [km/s] → [km/h]
+            }
+
+            // Calculate orbit track (past 45 min and future 45 min = 90 min total)
+            const track = [];
+            const trackMinutes = 90;
+            const stepMinutes = 1;
+
+            for (let m = -trackMinutes / 2; m <= trackMinutes / 2; m += stepMinutes) {
+              const trackTime = new Date(now.getTime() + m * 60 * 1000);
+              const trackPV = satellite.propagate(satrec, trackTime);
+
+              if (trackPV.position) {
+                const trackGmst = satellite.gstime(trackTime);
+                const trackGd = satellite.eciToGeodetic(trackPV.position, trackGmst);
+                const trackLat = satellite.degreesLat(trackGd.latitude);
+                const trackLon = satellite.degreesLong(trackGd.longitude);
+                track.push([trackLat, trackLon]);
+              }
+            }
+
+            // Calculate footprint radius (visibility circle)
+            // Formula: radius = Earth_radius * arccos(Earth_radius / (Earth_radius + altitude))
+            const earthRadius = 6371; // [km]
+            const footprintRadius = earthRadius * Math.acos(earthRadius / (earthRadius + alt));
+
+            positions.push({
+              name: satData.name || name,
+              omm: satData.omm,
+              lat,
+              lon,
+              alt: round(alt, 1),
+              speedKmH: round(speedKmH, 1),
+              azimuth: round(azimuth, 0),
+              elevation: round(elevation, 0),
+              range: round(rangeSat, 1),
+              rangeRate: round(rangeRate, 3),
+              dopplerFactor: round(dopplerFactor, 9),
+              isVisible, // visible if above minimum elevation
+              nextPassStartTimes: startTimes,
+              nextPassEndTimes: endTimes,
+              isPopular: satData.priority <= 2,
+              track,
+              footprintRadius: Math.round(footprintRadius),
+              mode: satData.mode || 'Unknown',
+              color: satData.color || '#00ffff',
+              // Radio metadata from satellites.json
+              downlink: satData.downlink || '',
+              uplink: satData.uplink || '',
+              tone: satData.tone || '',
+              beacon: satData.beacon || '',
+              notes: satData.notes || '',
+            });
+          } catch (e) {
+            // Skip satellites with invalid data, continue processing others
           }
-
-          // Calculate footprint radius (visibility circle)
-          // Formula: radius = Earth_radius * arccos(Earth_radius / (Earth_radius + altitude))
-          const earthRadius = 6371; // [km]
-          const footprintRadius = earthRadius * Math.acos(earthRadius / (earthRadius + alt));
-
+        } else {
           positions.push({
             name: satData.name || name,
             omm: satData.omm,
-            lat,
-            lon,
-            alt: round(alt, 1),
-            speedKmH: round(speedKmH, 1),
-            azimuth: round(azimuth, 0),
-            elevation: round(elevation, 0),
-            range: round(rangeSat, 1),
-            rangeRate: round(rangeRate, 3),
-            dopplerFactor: round(dopplerFactor, 9),
-            isVisible, // visible if above minimum elevation
+            lat: 0,
+            lon: 0,
+            alt: 0,
+            speedKmH: 0,
+            azimuth: 0,
+            elevation: 0,
+            range: 0,
+            rangeRate: 0,
+            dopplerFactor: 1,
+            isVisible: false,
             nextPassStartTimes: startTimes,
             nextPassEndTimes: endTimes,
             isPopular: satData.priority <= 2,
-            track,
-            footprintRadius: Math.round(footprintRadius),
+            track: [],
+            footprintRadius: 0,
             mode: satData.mode || 'Unknown',
             color: satData.color || '#00ffff',
             // Radio metadata from satellites.json
@@ -187,8 +222,6 @@ export const useSatellites = (observerLocation, satelliteConfig) => {
             beacon: satData.beacon || '',
             notes: satData.notes || '',
           });
-        } catch (e) {
-          // Skip satellites with invalid data, continue processing others
         }
       });
 
@@ -201,7 +234,7 @@ export const useSatellites = (observerLocation, satelliteConfig) => {
       console.error('Satellite calculation error:', err);
       setLoading(false);
     }
-  }, [observerLocation, satelliteData, nextPassData]);
+  }, [observerLocation, satelliteData, nextPassData, filteredNames]);
 
   // Calculate satellite next passes, finds the start/end times of the next 2 passes for each satellite that are above the minimum elevation
   // Loops every hour since passes don't change often
@@ -286,7 +319,6 @@ export const useSatellites = (observerLocation, satelliteConfig) => {
 
   // Update positions every 5 seconds
   useEffect(() => {
-    calculatePositions();
     const interval = setInterval(calculatePositions, 5000);
     return () => clearInterval(interval);
   }, [calculatePositions]);
@@ -294,7 +326,7 @@ export const useSatellites = (observerLocation, satelliteConfig) => {
   // Update next passes every hour
   useEffect(() => {
     calculateNextPasses();
-    const interval = setInterval(calculateNextPasses, 3600000); // 1 hour
+    const interval = setInterval(calculateNextPasses, 60 * 60 * 1000); // 1 hour
     return () => clearInterval(interval);
   }, [calculateNextPasses]);
 

--- a/src/plugins/layers/useSatelliteLayer.js
+++ b/src/plugins/layers/useSatelliteLayer.js
@@ -262,15 +262,31 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
     win.style.maxHeight = 'calc(100% - 80px)';
     win.style.overflowY = 'auto';
 
+    // --- SAFE HELPERS ---------------------------------------------------------
+    const safeNum = (v, digits = null) => {
+      if (!Number.isFinite(v)) return '';
+      return digits === null ? v : v.toFixed(digits);
+    };
+
+    const safeStr = (v) =>
+      String(v ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;');
+
+    const safeArr = (v) => (Array.isArray(v) ? v : []);
+    // --------------------------------------------------------------------------
+
     win.innerHTML =
       titleBar +
       `<div class="sat-data-window-content">` +
       clearAllBtn +
       `<div style="padding: 0 12px 8px;">` +
       activeSats
-        .map((sat) => {
+        .map((satRaw) => {
+          const sat = satRaw ?? {}; // ensure sat is always an object
+
           const isVisible = sat.isVisible === true;
-          const isAboveHorizon = sat.elevation >= 0;
+          const isAboveHorizon = Number.isFinite(sat.elevation) && sat.elevation >= 0;
 
           const isMetric = allUnits.dist === 'metric';
           const distanceUnitsStr = isMetric ? 'km' : 'miles';
@@ -278,158 +294,177 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
           const rangeRateUnitsStr = isMetric ? 'km/s' : 'miles/s';
           const km_to_miles_factor = 0.621371;
 
-          let speed = Math.round((sat.speedKmH || 0) * (isMetric ? 1 : km_to_miles_factor));
-          let speedStr = `${speed.toLocaleString()} ${speedUnitsStr}`;
-          speedStr = `${sat.speedKmH ? speedStr : 'N/A'}`;
+          const speedKmH = Number.isFinite(sat.speedKmH) ? sat.speedKmH : null;
+          const speed = speedKmH !== null ? Math.round(speedKmH * (isMetric ? 1 : km_to_miles_factor)) : null;
+          const speedStr = speed !== null ? `${speed.toLocaleString()} ${speedUnitsStr}` : 'N/A';
 
-          let altitude = Math.round(sat.alt * (isMetric ? 1 : km_to_miles_factor));
-          let altitudeStr = `${altitude.toLocaleString()} ${distanceUnitsStr}`;
+          const alt = Number.isFinite(sat.alt) ? sat.alt : null;
+          const altitude = alt !== null ? Math.round(alt * (isMetric ? 1 : km_to_miles_factor)) : null;
+          const altitudeStr = altitude !== null ? `${altitude.toLocaleString()} ${distanceUnitsStr}` : 'N/A';
 
-          const nextPassStartTimes = sat.nextPassStartTimes || [];
+          const nextPassStartTimes = safeArr(sat.nextPassStartTimes);
+          const nextPassEndTimes = safeArr(sat.nextPassEndTimes);
 
           let nextPassSecsFromNow = null;
           let nextPassEndingSecsFromNow = null;
           nextPassStartTimes.forEach((startTime, i) => {
-            const secsFromNow = Math.floor((new Date(startTime) - new Date()) / 1000);
-            const secsEndingFromNow = Math.floor((new Date(sat.nextPassEndTimes?.[i]) - new Date()) / 1000);
+            const endTime = nextPassEndTimes[i];
+            const secsFromNow = Number.isFinite(new Date(startTime).getTime())
+              ? Math.floor((new Date(startTime) - new Date()) / 1000)
+              : null;
+            const secsEndingFromNow = Number.isFinite(new Date(endTime).getTime())
+              ? Math.floor((new Date(endTime) - new Date()) / 1000)
+              : null;
             if (secsEndingFromNow > 0 && nextPassSecsFromNow === null) {
               nextPassSecsFromNow = secsFromNow;
               nextPassEndingSecsFromNow = secsEndingFromNow;
             }
           });
 
-          const attrEscape = (s) =>
-            String(s ?? '')
-              .replace(/&/g, '&amp;')
-              .replace(/"/g, '&quot;');
-
           return `
-          <div class="sat-card" style="border-bottom: 1px solid var(--border-color); margin-bottom: 10px; padding-bottom: 8px;">
-          <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:4px;">
-            <strong style="color: var(--text-primary); font-size: 14px;">${sat.name}</strong>
-            <button
-              class="sat-toggle"
-              data-action="toggle-satellite"
-              data-sat-name="${sat.name}"
-              style="background:none; border:none; color: var(--accent-red); cursor:pointer; font-weight:bold; font-size:20px; padding: 0 5px;">
-              ✕
-            </button>
-          </div>
+      <div class="sat-card" style="border-bottom: 1px solid var(--border-color); margin-bottom: 10px; padding-bottom: 8px;">
+      <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:4px;">
+        <strong style="color: var(--text-primary); font-size: 14px;">${safeStr(sat.name)}</strong>
+        <button
+          class="sat-toggle"
+          data-action="toggle-satellite"
+          data-sat-name="${safeStr(sat.name)}"
+          style="background:none; border:none; color: var(--accent-red); cursor:pointer; font-weight:bold; font-size:20px; padding: 0 5px;">
+          ✕
+        </button>
+      </div>
 
-          <table style="width:100%; font-size:11px; border-collapse: collapse;">
+      <table style="width:100%; font-size:11px; border-collapse: collapse;">
 
-            <!-- section 1: satellite position and motion -->
-            <tr style="background-color: var(--bg-tertiary); color: var(--text-secondary);">
-              <td style="padding: 0 2px;">${t('station.settings.satellites.latitude')}:</td>
-              <td align="right" style="padding: 0 2px;">${sat.lat.toFixed(2)}°</td>
-            </tr>
-            <tr style="background-color: var(--bg-tertiary); color: var(--text-secondary);">
-              <td style="padding: 0 2px;">${t('station.settings.satellites.longitude')}:</td>
-              <td align="right" style="padding: 0 2px;">${sat.lon.toFixed(2)}°</td>
-            </tr>
-            <tr style="background-color: var(--bg-tertiary); color: var(--text-secondary);">
-              <td style="padding: 0 2px;">${t('station.settings.satellites.altitude')}:</td>
-              <td align="right" style="padding: 0 2px;">${altitudeStr}</td>
-            </tr>
-            <tr style="background-color: var(--bg-tertiary); color: var(--text-secondary);">
-              <td style="padding: 0 2px;">${t('station.settings.satellites.speed')}:</td>
-              <td align="right" style="padding: 0 2px;">${speedStr}</td>
-            </tr>
+        <!-- section 1: satellite position and motion -->
+        <tr style="background-color: var(--bg-tertiary); color: var(--text-secondary);">
+          <td style="padding: 0 2px;">${t('station.settings.satellites.latitude')}:</td>
+          <td align="right" style="padding: 0 2px;">${safeNum(sat.lat, 2)}°</td>
+        </tr>
+        <tr style="background-color: var(--bg-tertiary); color: var(--text-secondary);">
+          <td style="padding: 0 2px;">${t('station.settings.satellites.longitude')}:</td>
+          <td align="right" style="padding: 0 2px;">${safeNum(sat.lon, 2)}°</td>
+        </tr>
+        <tr style="background-color: var(--bg-tertiary); color: var(--text-secondary);">
+          <td style="padding: 0 2px;">${t('station.settings.satellites.altitude')}:</td>
+          <td align="right" style="padding: 0 2px;">${altitudeStr}</td>
+        </tr>
+        <tr style="background-color: var(--bg-tertiary); color: var(--text-secondary);">
+          <td style="padding: 0 2px;">${t('station.settings.satellites.speed')}:</td>
+          <td align="right" style="padding: 0 2px;">${speedStr}</td>
+        </tr>
 
-            <!-- section 2: relative location and visibility -->
-            <tr style="background-color: ${isVisible ? 'var(--accent-green)' : 'var(--bg-primary)'}; color: ${isVisible ? '#000' : 'var(--text-secondary)'};">
-              <td style="padding: 0 2px;">${t('station.settings.satellites.azimuth_elevation')}:</td>
-              <td align="right" style="padding: 0 2px;">${sat.azimuth}° / ${sat.elevation}°</td>
-            </tr>
+        <!-- section 2: relative location and visibility -->
+        <tr style="background-color: ${isVisible ? 'var(--accent-green)' : 'var(--bg-primary)'}; color: ${isVisible ? '#000' : 'var(--text-secondary)'};">
+          <td style="padding: 0 2px;">${t('station.settings.satellites.azimuth_elevation')}:</td>
+          <td align="right" style="padding: 0 2px;">${safeNum(sat.azimuth)}° / ${safeNum(sat.elevation)}°</td>
+        </tr>
 
+        ${
+          isVisible
+            ? `
+          <tr style="background-color: var(--accent-green); color:#000;">
+            <td style="padding: 0 2px;">${t('station.settings.satellites.range')}:</td>
+            <td align="right" style="padding: 0 2px;">${safeNum(sat.range * (isMetric ? 1 : km_to_miles_factor), 0)} ${distanceUnitsStr}</td>
+          </tr>
+          <tr style="background-color: var(--accent-green); color:#000;">
+            <td style="padding: 0 2px;">${t('station.settings.satellites.rangeRate')}:</td>
+            <td align="right" style="padding: 0 2px;">${safeNum(sat.rangeRate * (isMetric ? 1 : km_to_miles_factor), 2)} ${rangeRateUnitsStr}</td>
+          </tr>
+          <tr style="background-color: var(--accent-green); color:#000;">
+            <td style="padding: 0 2px;">${t('station.settings.satellites.dopplerFactor')}:</td>
+            <td align="right" style="padding: 0 2px;">${safeNum(sat.dopplerFactor, 7)}</td>
+          </tr>
+        `
+            : ``
+        }
+
+        <tr style="background-color: ${isVisible ? 'var(--accent-green)' : 'var(--bg-primary)'}; color: ${isVisible ? '#000' : 'var(--text-secondary)'};">
+          <td style="padding: 0 2px;">${t('station.settings.satellites.status')}:</td>
+          <td align="right" style="padding: 0 2px;">
             ${
               isVisible
-                ? `
-              <tr style="background-color: ${isVisible ? 'var(--accent-green)' : 'var(--bg-primary)'}; color: ${isVisible ? '#000' : 'var(--text-secondary)'};">
-                <td style="padding: 0 2px;">${t('station.settings.satellites.range')}:</td>
-                <td align="right" style="padding: 0 2px;">${(sat.range * (isMetric ? 1 : km_to_miles_factor)).toFixed(0)} ${distanceUnitsStr}</td>
-              </tr>
-              <tr style="background-color: ${isVisible ? 'var(--accent-green)' : 'var(--bg-primary)'}; color: ${isVisible ? '#000' : 'var(--text-secondary)'};">
-                <td style="padding: 0 2px;">${t('station.settings.satellites.rangeRate')}:</td>
-                <td align="right" style="padding: 0 2px;">${(sat.rangeRate * (isMetric ? 1 : km_to_miles_factor)).toFixed(2)} ${rangeRateUnitsStr}</td>
-              </tr>
-              <tr style="background-color: ${isVisible ? 'var(--accent-green)' : 'var(--bg-primary)'}; color: ${isVisible ? '#000' : 'var(--text-secondary)'};">
-                <td style="padding: 0 2px;">${t('station.settings.satellites.dopplerFactor')}:</td>
-                <td align="right" style="padding: 0 2px;">${sat.dopplerFactor.toFixed(7)}</td>
-              </tr>
+                ? t('station.settings.satellites.visible')
+                : isAboveHorizon
+                  ? t('station.settings.satellites.belowMinElev')
+                  : t('station.settings.satellites.belowHorizon')
+            }
+          </td>
+        </tr>
+
+        ${
+          !isVisible && nextPassSecsFromNow !== null
+            ? `
+            <tr style="background-color: var(--bg-primary); color: var(--text-secondary);">
+              <td style="padding: 0 2px;">${t('station.settings.satellites.nextPass')}:</td>
+              <td align="right" style="padding: 0 2px;">${formatSecsFromNow(nextPassSecsFromNow)}</td>
+            </tr>
             `
-                : ``
-            }
+            : ``
+        }
 
-            <tr style="background-color: ${isVisible ? 'var(--accent-green)' : 'var(--bg-primary)'}; color: ${isVisible ? '#000' : 'var(--text-secondary)'};">
-              <td style="padding: 0 2px;">${t('station.settings.satellites.status')}:</td>
-              <td align="right" style="padding: 0 2px;">
-                ${
-                  isVisible
-                    ? `${t('station.settings.satellites.visible')}`
-                    : isAboveHorizon
-                      ? `${t('station.settings.satellites.belowMinElev')}`
-                      : `${t('station.settings.satellites.belowHorizon')}`
-                }
-              </td>
+        ${
+          isVisible && nextPassEndingSecsFromNow !== null
+            ? `
+            <tr style="background-color: var(--accent-green); color:#000;">
+              <td style="padding: 0 2px;">Ending:</td>
+              <td align="right" style="padding: 0 2px;">${formatSecsFromNow(nextPassEndingSecsFromNow)}</td>
             </tr>
+            `
+            : ``
+        }
 
-            ${
-              !isVisible && nextPassSecsFromNow !== null
-                ? `
-                <tr style="background-color: var(--bg-primary); color: var(--text-secondary);">
-                  <td style="padding: 0 2px;">${t('station.settings.satellites.nextPass')}:</td>
-                  <td align="right" style="padding: 0 2px;">${formatSecsFromNow(nextPassSecsFromNow)}</td>
-                </tr>
-                `
-                : ``
-            }
+        <!-- section 3: miscellaneous satellite information -->
+        <tr style="background-color: var(--bg-secondary); color: var(--text-muted);">
+          <td style="padding: 0 2px;">${t('station.settings.satellites.mode')}:</td>
+          <td align="right" style="padding: 0 2px;">${safeStr(sat.mode || 'N/A')}</td>
+        </tr>
+        ${
+          sat.downlink
+            ? `<tr style="background-color: var(--bg-secondary); color: var(--text-muted);"><td style="padding: 0 2px;">${t('station.settings.satellites.downlink')}:</td><td align="right" style="padding: 0 2px;">${safeStr(sat.downlink)}</td></tr>`
+            : ''
+        }
+        ${
+          sat.uplink
+            ? `<tr style="background-color: var(--bg-secondary); color: var(--text-muted);"><td style="padding: 0 2px;">${t('station.settings.satellites.uplink')}:</td><td align="right" style="padding: 0 2px;">${safeStr(sat.uplink)}</td></tr>`
+            : ''
+        }
+        ${
+          sat.tone
+            ? `<tr style="background-color: var(--bg-secondary); color: var(--text-muted);"><td style="padding: 0 2px;">${t('station.settings.satellites.tone')}:</td><td align="right" style="padding: 0 2px;">${safeStr(sat.tone)}</td></tr>`
+            : ''
+        }
 
-            ${
-              isVisible && nextPassEndingSecsFromNow !== null
-                ? `
-                <tr style="background-color: var(--accent-green); color: #000;">
-                  <td style="padding: 0 2px;">Ending:</td>
-                  <td align="right" style="padding: 0 2px;">${formatSecsFromNow(nextPassEndingSecsFromNow)}</td>
-                </tr>
-                `
-                : ``
-            }
+        <tr><td colSpan="2">
+          <button
+            class="sat-open-predict"
+            data-action="open-predict"
+            data-sat-name="${safeStr(sat.name)}"
+            data-omm="${safeStr(sat.omm ? JSON.stringify(sat.omm) : '')}"
+            style="
+              width: 100%;
+              padding: 2px 0;
+              min-height: 0;
+              background: var(--bg-primary);
+              border: 1px solid var(--accent-red);
+              border-radius: 3px;
+              color: var(--accent-red);
+              font-size: 10px;
+              font-weight: bold;
+              text-align: center;
+              cursor: pointer;">${t('station.settings.satellites.predict')}</button>
+        </td></tr>
 
-            <!-- section 3: miscellaneous satellite information -->
-            <tr style="background-color: var(--bg-secondary); color: var(--text-muted);">
-              <td style="padding: 0 2px;">${t('station.settings.satellites.mode')}:</td>
-              <td align="right" style="padding: 0 2px;">${attrEscape(sat.mode || 'N/A')}</td>
-            </tr>
-            ${sat.downlink ? `<tr style="background-color: var(--bg-secondary); color: var(--text-muted);"><td style="padding: 0 2px;">${t('station.settings.satellites.downlink')}:</td><td align="right" style="padding: 0 2px;">${attrEscape(sat.downlink)}</td></tr>` : ''}
-            ${sat.uplink ? `<tr style="background-color: var(--bg-secondary); color: var(--text-muted);"><td style="padding: 0 2px;">${t('station.settings.satellites.uplink')}:</td><td align="right" style="padding: 0 2px;">${attrEscape(sat.uplink)}</td></tr>` : ''}
-            ${sat.tone ? `<tr style="background-color: var(--bg-secondary); color: var(--text-muted);"><td style="padding: 0 2px;">${t('station.settings.satellites.tone')}:</td><td align="right" style="padding: 0 2px;">${attrEscape(sat.tone)}</td></tr>` : ''}
+      </table>
 
-            <tr><td colSpan="2">
-              <button
-                class="sat-open-predict"
-                data-action="open-predict"
-                data-sat-name="${attrEscape(sat.name)}"
-                data-omm="${attrEscape(sat.omm ? JSON.stringify(sat.omm) : '')}"
-                style="
-                  width: 100%;
-                  padding: 2px 0;
-                  min-height: 0;
-                  background: var(--bg-primary);
-                  border: 1px solid var(--accent-red);
-                  border-radius: 3px;
-                  color: var(--accent-red);
-                  font-size: 10px;
-                  font-weight: bold;
-                  text-align: center;
-                  cursor: pointer;">${t('station.settings.satellites.predict')}</button>
-            </td></tr>
+      ${
+        sat.notes
+          ? `<div style="font-size:9px; color: var(--text-muted); margin-top:4px; font-style:italic;">${safeStr(sat.notes)}</div>`
+          : ''
+      }
 
-            </table>
-
-            ${sat.notes ? `<div style="font-size:9px; color: var(--text-muted); margin-top:4px; font-style:italic;">${attrEscape(sat.notes)}</div>` : ''}
-          </div>
-      `;
+      </div>
+    `;
         })
         .join('') +
       `</div></div>`;
@@ -523,27 +558,31 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
         }
       }
 
-      replicatePoint(sat.lat, sat.lon).forEach((pos) => {
-        const marker = window.L.marker(pos, {
-          icon: window.L.divIcon({
-            className: 'sat-marker',
-            html: `<div style="display:flex; flex-direction:column; align-items:center; opacity: ${globalOpacity};">
+      const isSafeLatLon = (sat) => Number.isFinite(sat?.lat) && Number.isFinite(sat?.lon);
+
+      if (isSafeLatLon(sat)) {
+        replicatePoint(sat.lat, sat.lon).forEach((pos) => {
+          const marker = window.L.marker(pos, {
+            icon: window.L.divIcon({
+              className: 'sat-marker',
+              html: `<div style="display:flex; flex-direction:column; align-items:center; opacity: ${globalOpacity};">
                      <div style="font-size:${isSelected ? '32px' : '22px'}; filter:${isSelected ? 'drop-shadow(0 0 10px rgba(0, 255, 255, 1))' : 'none'}; cursor: pointer;">🛰</div>
                      <div class="sat-label" style="${isSelected ? 'color: rgba(255, 255, 255, 1); font-weight: bold;' : ''}">${sat.name}</div>
                    </div>`,
-            iconSize: [80, 50],
-            iconAnchor: [40, 25],
-          }),
-          zIndexOffset: isSelected ? 10000 : 1000,
-        });
+              iconSize: [80, 50],
+              iconAnchor: [40, 25],
+            }),
+            zIndexOffset: isSelected ? 10000 : 1000,
+          });
 
-        marker.on('click', (e) => {
-          window.L.DomEvent.stopPropagation(e);
-          toggleSatellite(sat.name);
-        });
+          marker.on('click', (e) => {
+            window.L.DomEvent.stopPropagation(e);
+            toggleSatellite(sat.name);
+          });
 
-        marker.addTo(layerGroupRef.current);
-      });
+          marker.addTo(layerGroupRef.current);
+        });
+      }
     });
 
     updateInfoWindow();


### PR DESCRIPTION
## What does this PR do?

- refactors satellite filters,
- passes filters to `useSatellites.js` and enables calculations only for those selected

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1. enable all satellites, confirm all satellites appear, choose at least one to confirm satellite details window is functional
2. browser devtools -> Performance add 4xCPU throttling
3. compare none vs all satellites selected

## Checklist

- [X] App loads without console errors
- [X] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [X] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [X] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)
