### PR TITLE
[fix] Maidenhead special case, duplicate to server util grid, add unit test

### DIFF
--- a/server/utils/grid.js
+++ b/server/utils/grid.js
@@ -103,7 +103,10 @@ const latLonToMaidenhead = ({ lat, lon }, precision = 6) => {
   if (lon < -180 || lon > 180) throw new Error('invalid longitude, it should be between -180 and 180');
 
   const latNorm = lat + 90;
-  const lonNorm = lon + 180;
+
+  // Handle case where longitude is given as +180, which should be treated as -180,
+  // by normalizing to 0-360 range first then applying modulus again to get back to -180..180 range.
+  const lonNorm = (((lon + 180) % 360) + 360) % 360;
 
   // Field (2 chars): 20° lon x 10° lat
   const field1 = String.fromCharCode(65 + Math.floor(lonNorm / 20)); // A-R

--- a/server/utils/grid.test.js
+++ b/server/utils/grid.test.js
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { validateGridLocator, latLonToMaidenhead, maidenheadToLatLon, maidenheadToBoundingBox } from './grid.js';
+
+describe('Maidenhead Grid tests', () => {
+  const gridCases = [
+    // note that 'grid' fields entered in the test cases are all 8 characters long,
+    // as tests will also validate the first 2, 4, 6 and 8 characters.
+
+    // location in San Diego, CA, USA
+    {
+      grid: 'DM12kv99',
+      actualLatLon: { lat: 32.91254, lon: -117.08409 },
+      latLonSWCornerGrid6: [32.875, -117.167],
+      latLonNECornerGrid6: [32.917, -117.083],
+    },
+
+    // location in Sydney, Australia
+    {
+      grid: 'QF56od55',
+      actualLatLon: { lat: -33.8519, lon: 151.210886 },
+    },
+
+    // location at equator / prime meridian
+    {
+      grid: 'JJ00aa00',
+      actualLatLon: { lat: 0, lon: 0 },
+    },
+
+    // location at equator just west of antimeridian
+    {
+      grid: 'RJ90XA90',
+      actualLatLon: { lat: 0, lon: 179.999 },
+    },
+
+    // location at equator on antimeridian
+    // note that this is not strictly valid as longitude should be given as -180 rather than +180,
+    // however some sources may expected +180 to be functional so it should be tested
+    {
+      grid: 'AJ00AA00',
+      actualLatLon: { lat: 0, lon: 180.0 },
+    },
+
+    // location at equator on antimeridian
+    {
+      grid: 'AJ00AA00',
+      actualLatLon: { lat: 0, lon: -180.0 },
+    },
+  ];
+
+  it('should invalidate empty grid locator', () => {
+    expect(validateGridLocator('')).toBe(false);
+  });
+
+  it('should invalidate grid locator with invalid length', () => {
+    expect(validateGridLocator('DM1')).toBe(false);
+  });
+
+  it('should invalidate grid locator with invalid characters', () => {
+    expect(validateGridLocator('DM12zz')).toBe(false);
+  });
+
+  for (const { grid, actualLatLon, latLonSWCornerGrid6, latLonNECornerGrid6 } of gridCases) {
+    it(
+      ('should validate test case grid locator has size 8',
+      () => {
+        expect(grid.length).toEqual(8);
+      }),
+    );
+
+    const defaultSize = 6;
+    const sizes = [2, 4, 6, 8];
+    for (const size of sizes) {
+      it("should validate grid locator '" + grid.substring(0, size) + "'", () => {
+        const subGrid = grid.substring(0, size);
+        expect(validateGridLocator(subGrid)).toBe(true);
+      });
+    }
+
+    for (const size of sizes) {
+      it('should convert Lat/Lon to Maidenhead Grid of requested size ' + size, () => {
+        const result = latLonToMaidenhead(actualLatLon, size);
+        expect(result.toUpperCase()).toBe(grid.substring(0, size).toUpperCase());
+      });
+    }
+
+    it('should convert Lat/Lon to Maidenhead Grid with default size 6 when no size is specified', () => {
+      const result = latLonToMaidenhead(actualLatLon);
+      expect(result.toUpperCase()).toBe(grid.substring(0, defaultSize).toUpperCase());
+    });
+
+    for (const size of sizes) {
+      it("should convert Maidenhead Grid '" + grid.substring(0, size) + "' to Lat/Lon", () => {
+        const { lat, lon } = maidenheadToLatLon(grid.substring(0, size));
+        // handle case where longitude is given as +180 or -180, although +180 is strictly invalid it can sometimes be used so should be tested
+        const { lat: expectedLat, lon: rawLon } = actualLatLon,
+          expectedLon = ((rawLon + 180) % 360) - 180;
+        let latBucketSize, lonBucketSize, latBucketStart, latBucketEnd, lonBucketStart, lonBucketEnd;
+
+        switch (size) {
+          case 2:
+            latBucketSize = 10; // degrees
+            latBucketStart = Math.floor(expectedLat / latBucketSize) * latBucketSize;
+            latBucketEnd = latBucketStart + latBucketSize;
+
+            lonBucketSize = 20; // degrees
+            lonBucketStart = Math.floor(expectedLon / lonBucketSize) * lonBucketSize;
+            lonBucketEnd = lonBucketStart + lonBucketSize;
+            break;
+
+          case 4:
+            latBucketSize = 1; // degrees
+            latBucketStart = Math.floor(expectedLat / latBucketSize) * latBucketSize;
+            latBucketEnd = latBucketStart + latBucketSize;
+
+            lonBucketSize = 2; // degrees
+            lonBucketStart = Math.floor(expectedLon / lonBucketSize) * lonBucketSize;
+            lonBucketEnd = lonBucketStart + lonBucketSize;
+            break;
+
+          case 6:
+            latBucketSize = 2.5; // minutes
+            latBucketStart = (Math.floor((60 * expectedLat) / latBucketSize) * latBucketSize) / 60;
+            latBucketEnd = latBucketStart + latBucketSize / 60;
+
+            lonBucketSize = 5; // minutes
+            lonBucketStart = (Math.floor((60 * expectedLon) / lonBucketSize) * lonBucketSize) / 60;
+            lonBucketEnd = lonBucketStart + lonBucketSize / 60;
+            break;
+
+          case 8:
+            latBucketSize = 0.25; // minutes
+            latBucketStart = (Math.floor((10 * 60 * expectedLat) / latBucketSize) * latBucketSize) / 60 / 10;
+            latBucketEnd = latBucketStart + latBucketSize / 60;
+
+            lonBucketSize = 0.5; // minutes
+            lonBucketStart = (Math.floor((60 * expectedLon) / lonBucketSize) * lonBucketSize) / 60;
+            lonBucketEnd = lonBucketStart + lonBucketSize / 60;
+            break;
+
+          default:
+            throw new Error('invalid size');
+        }
+
+        expect(lat).toBeGreaterThanOrEqual(latBucketStart);
+        expect(lat).toBeLessThan(latBucketEnd);
+        expect(lon).toBeGreaterThanOrEqual(lonBucketStart);
+        expect(lon).toBeLessThan(lonBucketEnd);
+      });
+    }
+
+    if (latLonSWCornerGrid6 && latLonNECornerGrid6) {
+      it(
+        "should convert Maidenhead Grid '" + grid.substring(0, defaultSize) + "' to Lat/Lon bounding box coordinates",
+        () => {
+          const result = maidenheadToBoundingBox(grid.substring(0, defaultSize));
+          expect(result).toHaveLength(2);
+          expect(result[0]).toHaveLength(2);
+          expect(result[1]).toHaveLength(2);
+
+          expect(result[0][0]).toBeCloseTo(latLonSWCornerGrid6[0], 3);
+          expect(result[0][1]).toBeCloseTo(latLonSWCornerGrid6[1], 3);
+          expect(result[1][0]).toBeCloseTo(latLonNECornerGrid6[0], 3);
+          expect(result[1][1]).toBeCloseTo(latLonNECornerGrid6[1], 3);
+        },
+      );
+    }
+  }
+});


### PR DESCRIPTION
## What does this PR do?

- apply special case to normalization of longitude. +180 (180degE) becomes -180 (180degW), copied from `src/utils/geo.js`
- create `grid.test.js` based on `src/utils/geo.test.js`

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [X] No `.bak`, `.old`, `console.log` debug lines, or test scripts included
