### PR TITLE
fix(rig-bridge): stop auth retry storm and rate-limit server log warnings

### DIFF
--- a/rig-bridge/package.json
+++ b/rig-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhamclock-rig-bridge",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Universal rig control bridge for OpenHamClock — plugin architecture supporting USB, flrig, rigctld, and more",
   "main": "rig-bridge.js",
   "bin": "rig-bridge.js",

--- a/rig-bridge/plugins/cloud-relay.js
+++ b/rig-bridge/plugins/cloud-relay.js
@@ -62,6 +62,7 @@ const descriptor = {
     let stateChangeHandler = null;
     let lastPttState = null; // Track PTT separately to detect PTT-specific changes
     let serverReachable = false;
+    let credentialsInvalid = false; // Set permanently on 401/403 — stops all retry loops
     let totalPushed = 0;
     let totalCommands = 0;
     let totalDecodes = 0;
@@ -112,8 +113,43 @@ const descriptor = {
       req.end();
     }
 
+    // Called on 401/403 — permanently stops all relay loops so the user isn't
+    // spammed with auth errors. They must re-run "Connect Cloud Relay" in OHC
+    // Settings to generate fresh credentials.
+    function handleCredentialsInvalid(status, data) {
+      if (credentialsInvalid) return;
+      credentialsInvalid = true;
+      try {
+        const msg = JSON.parse(data)?.error || data;
+        console.error(`[CloudRelay] Authentication failed (${status}): ${msg}`);
+      } catch {
+        console.error(
+          `[CloudRelay] Authentication failed (${status}) — re-run Connect Cloud Relay in OHC Settings → Rig Bridge`,
+        );
+      }
+      console.error(
+        '[CloudRelay] Stopping relay — re-run Connect Cloud Relay in OHC Settings → Rig Bridge to get fresh credentials',
+      );
+      // Stop push timer
+      if (pushTimer) {
+        clearInterval(pushTimer);
+        pushTimer = null;
+      }
+      // Stop long-poll loop
+      pollAborted = true;
+      if (pollRetryTimer) {
+        clearTimeout(pollRetryTimer);
+        pollRetryTimer = null;
+      }
+      if (immediatePushTimer) {
+        clearTimeout(immediatePushTimer);
+        immediatePushTimer = null;
+      }
+    }
+
     // Push current rig state + batched decodes to cloud
     function pushState() {
+      if (credentialsInvalid) return;
       const currentState = {
         freq: state.freq,
         mode: state.mode,
@@ -169,12 +205,7 @@ const descriptor = {
             console.log(`[CloudRelay] Pushed state (${currentState.freq} Hz ${currentState.mode}${decodeInfo})`);
           }
         } else if (status === 401 || status === 403) {
-          try {
-            const msg = JSON.parse(data)?.error || data;
-            console.error(`[CloudRelay] Authentication failed (${status}): ${msg}`);
-          } catch {
-            console.error(`[CloudRelay] Authentication failed (${status}) — check relay API key and session`);
-          }
+          handleCredentialsInvalid(status, data);
         }
       });
     }
@@ -206,6 +237,9 @@ const descriptor = {
             } catch (e) {}
             // Restart immediately — no delay when things are healthy
             longPollCommands();
+          } else if (!err && (status === 401 || status === 403)) {
+            // Invalid credentials — stop permanently, no retry
+            handleCredentialsInvalid(status, data);
           } else {
             // Network error or unexpected status — back off 1 s before retry
             pollRetryTimer = setTimeout(longPollCommands, 1000);

--- a/rig-bridge/rig-bridge.js
+++ b/rig-bridge/rig-bridge.js
@@ -19,7 +19,7 @@
 
 'use strict';
 
-const VERSION = '2.2.0';
+const VERSION = '2.2.1';
 
 const { config, loadConfig, applyCliArgs } = require('./core/config');
 const {

--- a/server/routes/rig-bridge.js
+++ b/server/routes/rig-bridge.js
@@ -63,6 +63,9 @@ module.exports = function (app, ctx) {
 
   // Per-IP long-poll connection counter — caps concurrent waiters to bound resource use.
   const MAX_LONG_POLL_PER_IP = 10;
+  // Rate-limit MeshCom ingest warnings to avoid spam when the ingest endpoint is down.
+  const MESHCOM_WARN_INTERVAL = 60 * 1000; // 1 minute per subtype
+  const meshcomWarnLastLogged = new Map(); // subtype → timestamp
   const relayPollCountByIP = new Map(); // ip → count
 
   // Issued relay tokens — sessionId → { token, lastUsed }.
@@ -189,6 +192,12 @@ module.exports = function (app, ctx) {
   }, 300000); // Every 5 minutes
 
   // ─── Relay Auth ───────────────────────────────────────────────────────
+  // Rate-limit auth failure warnings: log once immediately, then at most once
+  // per 5 minutes per sessionId. Prevents log spam when rig-bridge retries
+  // with stale credentials (e.g. after a server restart invalidates tokens).
+  const AUTH_WARN_INTERVAL = 5 * 60 * 1000; // 5 minutes
+  const authWarnLastLogged = new Map(); // sessionId (or '(none)') → timestamp
+
   function requireRelayAuth(req, res, next) {
     if (!RIG_BRIDGE_RELAY_KEY) {
       return res.status(503).json({ error: 'Cloud relay not configured — set RIG_BRIDGE_RELAY_KEY in .env' });
@@ -197,10 +206,16 @@ module.exports = function (app, ctx) {
     const token = (req.headers.authorization || '').replace(/^Bearer\s+/i, '');
     const entry = sessionId ? relayIssuedTokens.get(sessionId) : undefined;
     if (!sessionId || !token || !entry || token !== entry.token) {
-      logWarn(
-        `[RigBridge] relay auth failed — sessionId: ${sessionId ? sessionId.slice(0, 8) + '…' : '(none)'}, ` +
-          `token ${token ? 'present' : 'missing'}, issued token ${entry ? 'found' : 'not found in store'}`,
-      );
+      const warnKey = sessionId ? sessionId.slice(0, 8) : '(none)';
+      const now = Date.now();
+      const lastLogged = authWarnLastLogged.get(warnKey) ?? 0;
+      if (now - lastLogged >= AUTH_WARN_INTERVAL) {
+        authWarnLastLogged.set(warnKey, now);
+        logWarn(
+          `[RigBridge] relay auth failed — sessionId: ${sessionId ? sessionId.slice(0, 8) + '…' : '(none)'}, ` +
+            `token ${token ? 'present' : 'missing'}, issued token ${entry ? 'found' : 'not found in store'}`,
+        );
+      }
       return res.status(401).json({
         error:
           'Invalid relay credentials — re-run Connect Cloud Relay in OHC Settings → Rig Bridge to generate fresh credentials',
@@ -306,11 +321,19 @@ module.exports = function (app, ctx) {
             })
             .then((r) => {
               if (!r.ok) {
-                logWarn(`[RigBridge] MeshCom ingest rejected subtype=${subtype} status=${r.status}`);
+                const now = Date.now();
+                if (now - (meshcomWarnLastLogged.get(subtype) ?? 0) >= MESHCOM_WARN_INTERVAL) {
+                  meshcomWarnLastLogged.set(subtype, now);
+                  logWarn(`[RigBridge] MeshCom ingest rejected subtype=${subtype} status=${r.status}`);
+                }
               }
             })
             .catch((e) => {
-              logWarn(`[RigBridge] MeshCom ingest forward failed subtype=${subtype}: ${e.message}`);
+              const now = Date.now();
+              if (now - (meshcomWarnLastLogged.get(subtype) ?? 0) >= MESHCOM_WARN_INTERVAL) {
+                meshcomWarnLastLogged.set(subtype, now);
+                logWarn(`[RigBridge] MeshCom ingest forward failed subtype=${subtype}: ${e.message}`);
+              }
             });
 
           // 2. Fan out to SSE stream clients — same { type:'plugin' } envelope


### PR DESCRIPTION
## Summary

- **rig-bridge client** (`plugins/cloud-relay.js`): on a 401/403 response, a new `handleCredentialsInvalid()` helper permanently stops both the push timer and the long-poll loop, logging once with a clear action for the user. Previously, `pushState` kept retrying every 2 s and `longPollCommands` retried every 1 s on any non-200 — flooding the server log at ~1 warn/s indefinitely.
- **Server** (`server/routes/rig-bridge.js`): `requireRelayAuth` now rate-limits `logWarn` to once per 5 minutes per sessionId. MeshCom ingest failure warnings are similarly throttled to once per minute per subtype.

## Test plan

- [ ] Configure rig-bridge with a stale/wrong session token and confirm the server log shows only one auth warning, then silence for 5 minutes
- [ ] Confirm rig-bridge logs a single clear error message and stops retrying after receiving a 401
- [ ] Re-run Connect Cloud Relay in OHC Settings → Rig Bridge, confirm normal relay operation resumes with fresh credentials
- [ ] Verify no regression in normal relay auth (valid credentials still pass through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)