### PR TITLE
feat(a11y): implement ARIA tablist pattern across all tab strips (#1031)

### DIFF
--- a/src/components/ActivateFilterManager.jsx
+++ b/src/components/ActivateFilterManager.jsx
@@ -2,7 +2,8 @@
  * ActivateFilterManager Component
  * Filter modal for ActivatePanel type spots - Bands, Grids, Modes
  */
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
+import { ariaTabKeyDown } from '../utils/ariaTabKeyDown.js';
 
 const BANDS = ['160m', '80m', '60m', '40m', '30m', '20m', '17m', '15m', '12m', '10m', '6m', '2m', '70cm'];
 const MODES = [
@@ -84,6 +85,8 @@ const GRID_REGIONS = [
 ];
 
 export const ActivateFilterManager = ({ filters, onFilterChange, isOpen, onClose, name }) => {
+  const ACTIVATE_TABS = ['bands', 'grids', 'modes'];
+  const activateTabRefs = useRef({});
   const [activeTab, setActiveTab] = useState('bands');
   const [customGrid, setCustomGrid] = useState('');
 
@@ -415,25 +418,58 @@ export const ActivateFilterManager = ({ filters, onFilterChange, isOpen, onClose
 
         {/* Tabs */}
         <div
+          role="tablist"
+          aria-label={`${name} filter tabs`}
           style={{
             display: 'flex',
             borderBottom: '1px solid var(--border-color)',
             background: 'var(--bg-secondary)',
           }}
+          onKeyDown={(e) => ariaTabKeyDown(e, ACTIVATE_TABS, activeTab, setActiveTab, activateTabRefs)}
         >
-          <button onClick={() => setActiveTab('bands')} style={tabStyle(activeTab === 'bands')}>
+          <button
+            role="tab"
+            id="tab-activate-bands"
+            aria-selected={activeTab === 'bands'}
+            aria-controls="panel-activate-bands"
+            tabIndex={activeTab === 'bands' ? 0 : -1}
+            ref={(el) => (activateTabRefs.current['bands'] = el)}
+            onClick={() => setActiveTab('bands')}
+            style={tabStyle(activeTab === 'bands')}
+          >
             Bands {filters?.bands?.length ? `(${filters.bands.length})` : ''}
           </button>
-          <button onClick={() => setActiveTab('grids')} style={tabStyle(activeTab === 'grids')}>
+          <button
+            role="tab"
+            id="tab-activate-grids"
+            aria-selected={activeTab === 'grids'}
+            aria-controls="panel-activate-grids"
+            tabIndex={activeTab === 'grids' ? 0 : -1}
+            ref={(el) => (activateTabRefs.current['grids'] = el)}
+            onClick={() => setActiveTab('grids')}
+            style={tabStyle(activeTab === 'grids')}
+          >
             Grids {filters?.grids?.length ? `(${filters.grids.length})` : ''}
           </button>
-          <button onClick={() => setActiveTab('modes')} style={tabStyle(activeTab === 'modes')}>
+          <button
+            role="tab"
+            id="tab-activate-modes"
+            aria-selected={activeTab === 'modes'}
+            aria-controls="panel-activate-modes"
+            tabIndex={activeTab === 'modes' ? 0 : -1}
+            ref={(el) => (activateTabRefs.current['modes'] = el)}
+            onClick={() => setActiveTab('modes')}
+            style={tabStyle(activeTab === 'modes')}
+          >
             Modes {filters?.modes?.length ? `(${filters.modes.length})` : ''}
           </button>
         </div>
 
         {/* Tab Content */}
         <div
+          role="tabpanel"
+          id={`panel-activate-${activeTab}`}
+          aria-labelledby={`tab-activate-${activeTab}`}
           style={{
             flex: 1,
             overflow: 'auto',

--- a/src/components/DXFilterManager.jsx
+++ b/src/components/DXFilterManager.jsx
@@ -2,9 +2,12 @@
  * DXFilterManager Component
  * Filter modal with tabs for Zones, Bands, Modes, Watchlist, Exclude, Settings
  */
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
+import { ariaTabKeyDown } from '../utils/ariaTabKeyDown.js';
 
 export const DXFilterManager = ({ filters, onFilterChange, isOpen, onClose, onClearSpots }) => {
+  const DX_TABS = ['zones', 'bands', 'modes', 'watchlist', 'text', 'exclude', 'settings'];
+  const dxTabRefs = useRef({});
   const [activeTab, setActiveTab] = useState('zones');
   const [newWatchlistCall, setNewWatchlistCall] = useState('');
   const [newDXExcludeCall, setNewDXExcludeCall] = useState('');
@@ -1040,32 +1043,44 @@ export const DXFilterManager = ({ filters, onFilterChange, isOpen, onClose, onCl
         </div>
 
         {/* Tabs */}
-        <div style={{ display: 'flex', borderBottom: '1px solid var(--border-color)' }}>
-          <button onClick={() => setActiveTab('zones')} style={tabStyle(activeTab === 'zones')}>
-            Zones
-          </button>
-          <button onClick={() => setActiveTab('bands')} style={tabStyle(activeTab === 'bands')}>
-            Bands
-          </button>
-          <button onClick={() => setActiveTab('modes')} style={tabStyle(activeTab === 'modes')}>
-            Modes
-          </button>
-          <button onClick={() => setActiveTab('watchlist')} style={tabStyle(activeTab === 'watchlist')}>
-            Watchlist
-          </button>
-          <button onClick={() => setActiveTab('text')} style={tabStyle(activeTab === 'text')}>
-            Text
-          </button>
-          <button onClick={() => setActiveTab('exclude')} style={tabStyle(activeTab === 'exclude')}>
-            Exclude
-          </button>
-          <button onClick={() => setActiveTab('settings')} style={tabStyle(activeTab === 'settings')}>
-            ⊙ Settings
-          </button>
+        <div
+          role="tablist"
+          aria-label="DX filter tabs"
+          style={{ display: 'flex', borderBottom: '1px solid var(--border-color)' }}
+          onKeyDown={(e) => ariaTabKeyDown(e, DX_TABS, activeTab, setActiveTab, dxTabRefs)}
+        >
+          {[
+            ['zones', 'Zones'],
+            ['bands', 'Bands'],
+            ['modes', 'Modes'],
+            ['watchlist', 'Watchlist'],
+            ['text', 'Text'],
+            ['exclude', 'Exclude'],
+            ['settings', '⊙ Settings'],
+          ].map(([id, label]) => (
+            <button
+              key={id}
+              role="tab"
+              id={`tab-dxfilter-${id}`}
+              aria-selected={activeTab === id}
+              aria-controls={`panel-dxfilter-${id}`}
+              tabIndex={activeTab === id ? 0 : -1}
+              ref={(el) => (dxTabRefs.current[id] = el)}
+              onClick={() => setActiveTab(id)}
+              style={tabStyle(activeTab === id)}
+            >
+              {label}
+            </button>
+          ))}
         </div>
 
         {/* Tab Content */}
-        <div style={{ padding: '20px', overflowY: 'auto', flex: 1 }}>
+        <div
+          role="tabpanel"
+          id={`panel-dxfilter-${activeTab}`}
+          aria-labelledby={`tab-dxfilter-${activeTab}`}
+          style={{ padding: '20px', overflowY: 'auto', flex: 1 }}
+        >
           {activeTab === 'zones' && renderZonesTab()}
           {activeTab === 'bands' && renderBandsTab()}
           {activeTab === 'modes' && renderModesTab()}

--- a/src/components/MeshComPanel.jsx
+++ b/src/components/MeshComPanel.jsx
@@ -6,6 +6,7 @@
  * Three tabs: Nodes | Messages | Info
  */
 import { useState, useCallback, useRef, useEffect } from 'react';
+import { ariaTabKeyDown } from '../utils/ariaTabKeyDown.js';
 import { useTranslation } from 'react-i18next';
 import { useMeshCom } from '../hooks/useMeshCom.js';
 import { useRig } from '../contexts/RigContext.jsx';
@@ -525,6 +526,7 @@ const TAB_IDS = ['nodes', 'messages', 'info'];
 const MeshComPanel = ({ showOnMap, onToggleMap, onSpotClick, onHoverSpot }) => {
   const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState('nodes');
+  const meshcomTabRefs = useRef({});
 
   // In local/direct mode the OHC server cannot proxy send requests to rig-bridge
   // (they may be on different machines). Pass the rig-bridge URL so useMeshCom
@@ -622,6 +624,8 @@ const MeshComPanel = ({ showOnMap, onToggleMap, onSpotClick, onHoverSpot }) => {
 
       {/* Tab bar */}
       <div
+        role="tablist"
+        aria-label={t('meshcomPanel.tablistLabel', 'MeshCom tabs')}
         style={{
           display: 'flex',
           gap: '2px',
@@ -630,12 +634,18 @@ const MeshComPanel = ({ showOnMap, onToggleMap, onSpotClick, onHoverSpot }) => {
           background: 'var(--bg-secondary)',
           flexShrink: 0,
         }}
+        onKeyDown={(e) => ariaTabKeyDown(e, TAB_IDS, activeTab, setActiveTab, meshcomTabRefs)}
       >
         {TAB_IDS.map((tabId) => (
           <button
             key={tabId}
+            role="tab"
+            id={`tab-meshcom-${tabId}`}
+            aria-selected={activeTab === tabId}
+            aria-controls={`panel-meshcom-${tabId}`}
+            tabIndex={activeTab === tabId ? 0 : -1}
+            ref={(el) => (meshcomTabRefs.current[tabId] = el)}
             onClick={() => setActiveTab(tabId)}
-            aria-pressed={activeTab === tabId}
             style={{
               padding: '3px 10px',
               fontSize: '10px',
@@ -668,11 +678,50 @@ const MeshComPanel = ({ showOnMap, onToggleMap, onSpotClick, onHoverSpot }) => {
 
       {/* Tab content */}
       <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-        {activeTab === 'nodes' && (
-          <NodesTab nodes={nodes} loading={loading} onSpotClick={onSpotClick} onHoverSpot={onHoverSpot} />
-        )}
-        {activeTab === 'messages' && <MessagesTab messages={messages} nodes={nodes} sendMessage={sendMessage} />}
-        {activeTab === 'info' && <InfoTab connected={connected} nodes={nodes} messages={messages} />}
+        <div
+          role="tabpanel"
+          id="panel-meshcom-nodes"
+          aria-labelledby="tab-meshcom-nodes"
+          hidden={activeTab !== 'nodes'}
+          style={{
+            flex: 1,
+            overflow: 'hidden',
+            display: activeTab === 'nodes' ? 'flex' : 'none',
+            flexDirection: 'column',
+          }}
+        >
+          {activeTab === 'nodes' && (
+            <NodesTab nodes={nodes} loading={loading} onSpotClick={onSpotClick} onHoverSpot={onHoverSpot} />
+          )}
+        </div>
+        <div
+          role="tabpanel"
+          id="panel-meshcom-messages"
+          aria-labelledby="tab-meshcom-messages"
+          hidden={activeTab !== 'messages'}
+          style={{
+            flex: 1,
+            overflow: 'hidden',
+            display: activeTab === 'messages' ? 'flex' : 'none',
+            flexDirection: 'column',
+          }}
+        >
+          {activeTab === 'messages' && <MessagesTab messages={messages} nodes={nodes} sendMessage={sendMessage} />}
+        </div>
+        <div
+          role="tabpanel"
+          id="panel-meshcom-info"
+          aria-labelledby="tab-meshcom-info"
+          hidden={activeTab !== 'info'}
+          style={{
+            flex: 1,
+            overflow: 'hidden',
+            display: activeTab === 'info' ? 'flex' : 'none',
+            flexDirection: 'column',
+          }}
+        >
+          {activeTab === 'info' && <InfoTab connected={connected} nodes={nodes} messages={messages} />}
+        </div>
       </div>
     </div>
   );

--- a/src/components/PSKFilterManager.jsx
+++ b/src/components/PSKFilterManager.jsx
@@ -2,7 +2,8 @@
  * PSKFilterManager Component
  * Filter modal for PSKReporter spots - Bands, Grids, Modes
  */
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
+import { ariaTabKeyDown } from '../utils/ariaTabKeyDown.js';
 
 const BANDS = ['160m', '80m', '60m', '40m', '30m', '20m', '17m', '15m', '12m', '10m', '8m', '6m', '4m', '2m', '70cm'];
 const MODES = [
@@ -84,6 +85,8 @@ const GRID_REGIONS = [
 ];
 
 export const PSKFilterManager = ({ filters, onFilterChange, isOpen, onClose, callsign, locator }) => {
+  const PSK_FILTER_TABS = ['bands', 'grids', 'modes', 'map', 'source'];
+  const pskFilterTabRefs = useRef({});
   const [activeTab, setActiveTab] = useState('bands');
   const [customGrid, setCustomGrid] = useState('');
 
@@ -604,31 +607,82 @@ export const PSKFilterManager = ({ filters, onFilterChange, isOpen, onClose, cal
 
         {/* Tabs */}
         <div
+          role="tablist"
+          aria-label="PSK Reporter filter tabs"
           style={{
             display: 'flex',
             borderBottom: '1px solid var(--border-color)',
             background: 'var(--bg-secondary)',
           }}
+          onKeyDown={(e) => ariaTabKeyDown(e, PSK_FILTER_TABS, activeTab, setActiveTab, pskFilterTabRefs)}
         >
-          <button onClick={() => setActiveTab('bands')} style={tabStyle(activeTab === 'bands')}>
+          <button
+            role="tab"
+            id="tab-pskfilter-bands"
+            aria-selected={activeTab === 'bands'}
+            aria-controls="panel-pskfilter-bands"
+            tabIndex={activeTab === 'bands' ? 0 : -1}
+            ref={(el) => (pskFilterTabRefs.current['bands'] = el)}
+            onClick={() => setActiveTab('bands')}
+            style={tabStyle(activeTab === 'bands')}
+          >
             Bands {filters?.bands?.length ? `(${filters.bands.length})` : ''}
           </button>
-          <button onClick={() => setActiveTab('grids')} style={tabStyle(activeTab === 'grids')}>
+          <button
+            role="tab"
+            id="tab-pskfilter-grids"
+            aria-selected={activeTab === 'grids'}
+            aria-controls="panel-pskfilter-grids"
+            tabIndex={activeTab === 'grids' ? 0 : -1}
+            ref={(el) => (pskFilterTabRefs.current['grids'] = el)}
+            onClick={() => setActiveTab('grids')}
+            style={tabStyle(activeTab === 'grids')}
+          >
             Grids {filters?.grids?.length ? `(${filters.grids.length})` : ''}
           </button>
-          <button onClick={() => setActiveTab('modes')} style={tabStyle(activeTab === 'modes')}>
+          <button
+            role="tab"
+            id="tab-pskfilter-modes"
+            aria-selected={activeTab === 'modes'}
+            aria-controls="panel-pskfilter-modes"
+            tabIndex={activeTab === 'modes' ? 0 : -1}
+            ref={(el) => (pskFilterTabRefs.current['modes'] = el)}
+            onClick={() => setActiveTab('modes')}
+            style={tabStyle(activeTab === 'modes')}
+          >
             Modes {filters?.modes?.length ? `(${filters.modes.length})` : ''}
           </button>
-          <button onClick={() => setActiveTab('map')} style={tabStyle(activeTab === 'map')}>
+          <button
+            role="tab"
+            id="tab-pskfilter-map"
+            aria-selected={activeTab === 'map'}
+            aria-controls="panel-pskfilter-map"
+            tabIndex={activeTab === 'map' ? 0 : -1}
+            ref={(el) => (pskFilterTabRefs.current['map'] = el)}
+            onClick={() => setActiveTab('map')}
+            style={tabStyle(activeTab === 'map')}
+          >
             Map {filters?.direction && filters.direction !== 'both' ? '(1)' : ''}
           </button>
-          <button onClick={() => setActiveTab('source')} style={tabStyle(activeTab === 'source')}>
+          <button
+            role="tab"
+            id="tab-pskfilter-source"
+            aria-selected={activeTab === 'source'}
+            aria-controls="panel-pskfilter-source"
+            tabIndex={activeTab === 'source' ? 0 : -1}
+            ref={(el) => (pskFilterTabRefs.current['source'] = el)}
+            onClick={() => setActiveTab('source')}
+            style={tabStyle(activeTab === 'source')}
+          >
             Source {filters?.filterMode === 'grid' ? '(⊞)' : ''}
           </button>
         </div>
 
         {/* Tab Content */}
         <div
+          role="tabpanel"
+          id={`panel-pskfilter-${activeTab}`}
+          aria-labelledby={`tab-pskfilter-${activeTab}`}
           style={{
             flex: 1,
             overflow: 'auto',

--- a/src/components/PSKReporterPanel.jsx
+++ b/src/components/PSKReporterPanel.jsx
@@ -7,9 +7,10 @@
  *   Row 2: Sub-tabs (Being Heard / Hearing  or  Decodes / QSOs)
  *   Content: Scrolling spot/decode list
  */
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getBandColor } from '../utils/callsign.js';
+import { ariaTabKeyDown } from '../utils/ariaTabKeyDown.js';
 import { IconSearch, IconRefresh, IconMap, IconTrash } from './Icons.jsx';
 import CallsignLink from './CallsignLink.jsx';
 
@@ -51,6 +52,8 @@ const PSKReporterPanel = ({
       return 'psk';
     }
   });
+  const PSK_TABS = ['tx', 'rx'];
+  const pskTabRefs = useRef({});
   const [activeTab, setActiveTab] = useState(() => {
     try {
       const s = localStorage.getItem('openhamclock_pskActiveTab');
@@ -500,8 +503,19 @@ const PSKReporterPanel = ({
       {/* ── Row 2: Sub-tabs ── */}
       <div style={{ display: 'flex', gap: '4px', marginBottom: '5px', flexShrink: 0 }}>
         {panelMode === 'psk' ? (
-          <>
+          <div
+            role="tablist"
+            aria-label={t('pskReporterPanel.tabs.tablistLabel', 'PSK Reporter tabs')}
+            style={{ display: 'flex', gap: '4px' }}
+            onKeyDown={(e) => ariaTabKeyDown(e, PSK_TABS, activeTab, setActiveTabPersist, pskTabRefs)}
+          >
             <button
+              role="tab"
+              id="tab-psk-tx"
+              aria-selected={activeTab === 'tx'}
+              aria-controls="panel-psk-content"
+              tabIndex={activeTab === 'tx' ? 0 : -1}
+              ref={(el) => (pskTabRefs.current['tx'] = el)}
               onClick={() => setActiveTabPersist('tx')}
               style={subTabBtn(activeTab === 'tx', '#4ade80')}
               title={
@@ -516,6 +530,12 @@ const PSKReporterPanel = ({
                 : t('pskReporterPanel.tabs.heard', { count: pskFilterCount > 0 ? filteredTx.length : txCount })}
             </button>
             <button
+              role="tab"
+              id="tab-psk-rx"
+              aria-selected={activeTab === 'rx'}
+              aria-controls="panel-psk-content"
+              tabIndex={activeTab === 'rx' ? 0 : -1}
+              ref={(el) => (pskTabRefs.current['rx'] = el)}
               onClick={() => setActiveTabPersist('rx')}
               style={subTabBtn(activeTab === 'rx', '#60a5fa')}
               title={
@@ -529,7 +549,7 @@ const PSKReporterPanel = ({
                 ? `Rcvd (${pskFilterCount > 0 ? filteredRx.length : rxCount})`
                 : t('pskReporterPanel.tabs.hearing', { count: pskFilterCount > 0 ? filteredRx.length : rxCount })}
             </button>
-          </>
+          </div>
         ) : (
           <>
             <button
@@ -560,7 +580,12 @@ const PSKReporterPanel = ({
       </div>
 
       {/* ── Content area ── */}
-      <div style={{ flex: 1, overflow: 'auto', fontSize: '11px', fontFamily: 'var(--font-mono)' }}>
+      <div
+        role={panelMode === 'psk' ? 'tabpanel' : undefined}
+        id={panelMode === 'psk' ? 'panel-psk-content' : undefined}
+        aria-labelledby={panelMode === 'psk' ? `tab-psk-${activeTab}` : undefined}
+        style={{ flex: 1, overflow: 'auto', fontSize: '11px', fontFamily: 'var(--font-mono)' }}
+      >
         {/* === PSKReporter content === */}
         {panelMode === 'psk' && (
           <>

--- a/src/components/PotaSotaPanel.jsx
+++ b/src/components/PotaSotaPanel.jsx
@@ -3,7 +3,8 @@
  * Tabbed panel that switches between POTA, WWFF, SOTA and WWBOTA views.
  * Used in Classic and Modern layouts. In Dockable layout, each is a separate panel.
  */
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
+import { ariaTabKeyDown } from '../utils/ariaTabKeyDown.js';
 import { POTAPanel } from './POTAPanel.jsx';
 import { WWFFPanel } from './WWFFPanel.jsx';
 import { SOTAPanel } from './SOTAPanel.jsx';
@@ -68,6 +69,7 @@ export const PotaSotaPanel = ({
   setShowWwbotaFilters,
   filteredWwbotaSpots,
 }) => {
+  const potaSotaTabRefs = useRef({});
   const [activeTab, setActiveTab] = useState(() => {
     try {
       const saved = localStorage.getItem('openhamclock_potaSotaTab');
@@ -133,31 +135,70 @@ export const PotaSotaPanel = ({
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       {/* Tab bar */}
       <div
+        role="tablist"
+        aria-label="POTA/SOTA tabs"
         style={{
           display: 'flex',
           borderBottom: '1px solid var(--border-color)',
           flexShrink: 0,
         }}
+        onKeyDown={(e) => ariaTabKeyDown(e, TABS, activeTab, handleTabChange, potaSotaTabRefs)}
       >
-        <button style={tabStyle('pota')} onClick={() => handleTabChange('pota')}>
+        <button
+          role="tab"
+          id="tab-potasota-pota"
+          aria-selected={activeTab === 'pota'}
+          aria-controls="panel-potasota-pota"
+          tabIndex={activeTab === 'pota' ? 0 : -1}
+          ref={(el) => (potaSotaTabRefs.current['pota'] = el)}
+          style={tabStyle('pota')}
+          onClick={() => handleTabChange('pota')}
+        >
           {tabBadge('pota')} POTA {potaData?.length > 0 ? `(${potaData.length})` : ''}
           {potaStaleMin >= 5 && (
             <span style={{ color: potaStaleMin >= 10 ? '#ff4444' : '#ffaa00' }}>{staleWarning(potaStaleMin)}</span>
           )}
         </button>
-        <button style={tabStyle('wwff')} onClick={() => handleTabChange('wwff')}>
+        <button
+          role="tab"
+          id="tab-potasota-wwff"
+          aria-selected={activeTab === 'wwff'}
+          aria-controls="panel-potasota-wwff"
+          tabIndex={activeTab === 'wwff' ? 0 : -1}
+          ref={(el) => (potaSotaTabRefs.current['wwff'] = el)}
+          style={tabStyle('wwff')}
+          onClick={() => handleTabChange('wwff')}
+        >
           {tabBadge('wwff')} WWFF {wwffData?.length > 0 ? `(${wwffData.length})` : ''}
           {wwffStaleMin >= 5 && (
             <span style={{ color: wwffStaleMin >= 10 ? '#ff4444' : '#ffaa00' }}>{staleWarning(wwffStaleMin)}</span>
           )}
         </button>
-        <button style={tabStyle('sota')} onClick={() => handleTabChange('sota')}>
+        <button
+          role="tab"
+          id="tab-potasota-sota"
+          aria-selected={activeTab === 'sota'}
+          aria-controls="panel-potasota-sota"
+          tabIndex={activeTab === 'sota' ? 0 : -1}
+          ref={(el) => (potaSotaTabRefs.current['sota'] = el)}
+          style={tabStyle('sota')}
+          onClick={() => handleTabChange('sota')}
+        >
           {tabBadge('sota')} SOTA {sotaData?.length > 0 ? `(${sotaData.length})` : ''}
           {sotaStaleMin >= 5 && (
             <span style={{ color: sotaStaleMin >= 10 ? '#ff4444' : '#ffaa00' }}>{staleWarning(sotaStaleMin)}</span>
           )}
         </button>
-        <button style={tabStyle('wwbota')} onClick={() => handleTabChange('wwbota')}>
+        <button
+          role="tab"
+          id="tab-potasota-wwbota"
+          aria-selected={activeTab === 'wwbota'}
+          aria-controls="panel-potasota-wwbota"
+          tabIndex={activeTab === 'wwbota' ? 0 : -1}
+          ref={(el) => (potaSotaTabRefs.current['wwbota'] = el)}
+          style={tabStyle('wwbota')}
+          onClick={() => handleTabChange('wwbota')}
+        >
           {tabBadge('wwbota')} WWBOTA {wwbotaData?.length > 0 ? `(${wwbotaData.length})` : ''}
           <span style={{ color: wwbotaConnected ? '#44cc44' : '#ff4444', marginLeft: '4px' }}>
             {wwbotaConnected ? '' : '✗'}
@@ -167,71 +208,106 @@ export const PotaSotaPanel = ({
 
       {/* Active panel */}
       <div style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
-        {activeTab === 'pota' ? (
-          <POTAPanel
-            data={potaData}
-            loading={potaLoading}
-            lastUpdated={potaLastUpdated}
-            lastChecked={potaLastChecked}
-            showOnMap={showPOTA}
-            onToggleMap={onTogglePOTA}
-            onSpotClick={onPOTASpotClick}
-            onHoverSpot={onPOTAHoverSpot}
-            showLabelsOnMap={showPOTALabels}
-            onToggleLabelsOnMap={togglePOTALabels}
-            filters={potaFilters}
-            onOpenFilters={setShowPotaFilters}
-            filteredData={filteredPotaSpots}
-          />
-        ) : activeTab === 'sota' ? (
-          <SOTAPanel
-            data={sotaData}
-            loading={sotaLoading}
-            lastUpdated={sotaLastUpdated}
-            lastChecked={sotaLastChecked}
-            showOnMap={showSOTA}
-            onToggleMap={onToggleSOTA}
-            onSpotClick={onSOTASpotClick}
-            onHoverSpot={onSOTAHoverSpot}
-            showLabelsOnMap={showSOTALabels}
-            onToggleLabelsOnMap={toggleSOTALabels}
-            filters={sotaFilters}
-            onOpenFilters={setShowSotaFilters}
-            filteredData={filteredSotaSpots}
-          />
-        ) : activeTab === 'wwbota' ? (
-          <WWBOTAPanel
-            data={wwbotaData}
-            loading={wwbotaLoading}
-            lastUpdated={wwbotaLastUpdated}
-            connected={wwbotaConnected}
-            showOnMap={showWWBOTA}
-            onToggleMap={onToggleWWBOTA}
-            onSpotClick={onWWBOTASpotClick}
-            onHoverSpot={onWWBOTAHoverSpot}
-            showLabelsOnMap={showWWBOTALabels}
-            onToggleLabelsOnMap={toggleWWBOTALabels}
-            filters={wwbotaFilters}
-            onOpenFilters={setShowWwbotaFilters}
-            filteredData={filteredWwbotaSpots}
-          />
-        ) : (
-          <WWFFPanel
-            data={wwffData}
-            loading={wwffLoading}
-            lastUpdated={wwffLastUpdated}
-            lastChecked={wwffLastChecked}
-            showOnMap={showWWFF}
-            onToggleMap={onToggleWWFF}
-            onSpotClick={onWWFFSpotClick}
-            onHoverSpot={onWWFFHoverSpot}
-            showLabelsOnMap={showWWFFLabels}
-            onToggleLabelsOnMap={toggleWWFFLabels}
-            filters={wwffFilters}
-            onOpenFilters={setShowWwffFilters}
-            filteredData={filteredWwffSpots}
-          />
-        )}
+        <div
+          role="tabpanel"
+          id="panel-potasota-pota"
+          aria-labelledby="tab-potasota-pota"
+          hidden={activeTab !== 'pota'}
+          style={{ height: '100%' }}
+        >
+          {activeTab === 'pota' && (
+            <POTAPanel
+              data={potaData}
+              loading={potaLoading}
+              lastUpdated={potaLastUpdated}
+              lastChecked={potaLastChecked}
+              showOnMap={showPOTA}
+              onToggleMap={onTogglePOTA}
+              onSpotClick={onPOTASpotClick}
+              onHoverSpot={onPOTAHoverSpot}
+              showLabelsOnMap={showPOTALabels}
+              onToggleLabelsOnMap={togglePOTALabels}
+              filters={potaFilters}
+              onOpenFilters={setShowPotaFilters}
+              filteredData={filteredPotaSpots}
+            />
+          )}
+        </div>
+        <div
+          role="tabpanel"
+          id="panel-potasota-wwff"
+          aria-labelledby="tab-potasota-wwff"
+          hidden={activeTab !== 'wwff'}
+          style={{ height: '100%' }}
+        >
+          {activeTab === 'wwff' && (
+            <WWFFPanel
+              data={wwffData}
+              loading={wwffLoading}
+              lastUpdated={wwffLastUpdated}
+              lastChecked={wwffLastChecked}
+              showOnMap={showWWFF}
+              onToggleMap={onToggleWWFF}
+              onSpotClick={onWWFFSpotClick}
+              onHoverSpot={onWWFFHoverSpot}
+              showLabelsOnMap={showWWFFLabels}
+              onToggleLabelsOnMap={toggleWWFFLabels}
+              filters={wwffFilters}
+              onOpenFilters={setShowWwffFilters}
+              filteredData={filteredWwffSpots}
+            />
+          )}
+        </div>
+        <div
+          role="tabpanel"
+          id="panel-potasota-sota"
+          aria-labelledby="tab-potasota-sota"
+          hidden={activeTab !== 'sota'}
+          style={{ height: '100%' }}
+        >
+          {activeTab === 'sota' && (
+            <SOTAPanel
+              data={sotaData}
+              loading={sotaLoading}
+              lastUpdated={sotaLastUpdated}
+              lastChecked={sotaLastChecked}
+              showOnMap={showSOTA}
+              onToggleMap={onToggleSOTA}
+              onSpotClick={onSOTASpotClick}
+              onHoverSpot={onSOTAHoverSpot}
+              showLabelsOnMap={showSOTALabels}
+              onToggleLabelsOnMap={toggleSOTALabels}
+              filters={sotaFilters}
+              onOpenFilters={setShowSotaFilters}
+              filteredData={filteredSotaSpots}
+            />
+          )}
+        </div>
+        <div
+          role="tabpanel"
+          id="panel-potasota-wwbota"
+          aria-labelledby="tab-potasota-wwbota"
+          hidden={activeTab !== 'wwbota'}
+          style={{ height: '100%' }}
+        >
+          {activeTab === 'wwbota' && (
+            <WWBOTAPanel
+              data={wwbotaData}
+              loading={wwbotaLoading}
+              lastUpdated={wwbotaLastUpdated}
+              connected={wwbotaConnected}
+              showOnMap={showWWBOTA}
+              onToggleMap={onToggleWWBOTA}
+              onSpotClick={onWWBOTASpotClick}
+              onHoverSpot={onWWBOTAHoverSpot}
+              showLabelsOnMap={showWWBOTALabels}
+              onToggleLabelsOnMap={toggleWWBOTALabels}
+              filters={wwbotaFilters}
+              onOpenFilters={setShowWwbotaFilters}
+              filteredData={filteredWwbotaSpots}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -3,6 +3,7 @@
  * Full settings modal with map layer controls
  */
 import { useState, useEffect, useRef } from 'react';
+import { ariaTabKeyDown } from '../utils/ariaTabKeyDown.js';
 import { latLonToMaidenhead, maidenheadToLatLon } from '../utils/geo.js';
 import { useTranslation, Trans } from 'react-i18next';
 import { LANGUAGES } from '../lang/i18n.js';
@@ -170,6 +171,18 @@ export const SettingsPanel = ({
   // Layer controls
   const [layers, setLayers] = useState([]);
   const [activeTab, setActiveTab] = useState(defaultTab || 'station');
+  const SETTINGS_TABS = [
+    'station',
+    'integrations',
+    'display',
+    'layers',
+    'satellites',
+    'profiles',
+    'community',
+    'alerts',
+    'rig-bridge',
+  ];
+  const settingsTabRefs = useRef({});
   const [ctrlPressed, setCtrlPressed] = useState(false);
 
   // Switch to requested tab when opened from sidebar
@@ -628,6 +641,8 @@ export const SettingsPanel = ({
 
         {/* Tab Navigation */}
         <div
+          role="tablist"
+          aria-label={t('station.settings.tablist.label', 'Settings tabs')}
           style={{
             display: 'flex',
             flexWrap: 'wrap',
@@ -636,8 +651,15 @@ export const SettingsPanel = ({
             borderBottom: '1px solid var(--border-color)',
             paddingBottom: '12px',
           }}
+          onKeyDown={(e) => ariaTabKeyDown(e, SETTINGS_TABS, activeTab, setActiveTab, settingsTabRefs)}
         >
           <button
+            role="tab"
+            id="tab-settings-station"
+            aria-selected={activeTab === 'station'}
+            aria-controls="panel-settings-station"
+            tabIndex={activeTab === 'station' ? 0 : -1}
+            ref={(el) => (settingsTabRefs.current['station'] = el)}
             onClick={() => setActiveTab('station')}
             style={{
               flex: 1,
@@ -656,6 +678,12 @@ export const SettingsPanel = ({
           </button>
 
           <button
+            role="tab"
+            id="tab-settings-integrations"
+            aria-selected={activeTab === 'integrations'}
+            aria-controls="panel-settings-integrations"
+            tabIndex={activeTab === 'integrations' ? 0 : -1}
+            ref={(el) => (settingsTabRefs.current['integrations'] = el)}
             onClick={() => setActiveTab('integrations')}
             style={{
               flex: 1,
@@ -674,6 +702,12 @@ export const SettingsPanel = ({
           </button>
 
           <button
+            role="tab"
+            id="tab-settings-display"
+            aria-selected={activeTab === 'display'}
+            aria-controls="panel-settings-display"
+            tabIndex={activeTab === 'display' ? 0 : -1}
+            ref={(el) => (settingsTabRefs.current['display'] = el)}
             onClick={() => setActiveTab('display')}
             style={{
               flex: 1,
@@ -692,6 +726,12 @@ export const SettingsPanel = ({
           </button>
 
           <button
+            role="tab"
+            id="tab-settings-layers"
+            aria-selected={activeTab === 'layers'}
+            aria-controls="panel-settings-layers"
+            tabIndex={activeTab === 'layers' ? 0 : -1}
+            ref={(el) => (settingsTabRefs.current['layers'] = el)}
             onClick={() => setActiveTab('layers')}
             style={{
               flex: 1,
@@ -710,6 +750,12 @@ export const SettingsPanel = ({
           </button>
 
           <button
+            role="tab"
+            id="tab-settings-satellites"
+            aria-selected={activeTab === 'satellites'}
+            aria-controls="panel-settings-satellites"
+            tabIndex={activeTab === 'satellites' ? 0 : -1}
+            ref={(el) => (settingsTabRefs.current['satellites'] = el)}
             onClick={() => setActiveTab('satellites')}
             style={{
               flex: 1,
@@ -728,6 +774,12 @@ export const SettingsPanel = ({
           </button>
 
           <button
+            role="tab"
+            id="tab-settings-profiles"
+            aria-selected={activeTab === 'profiles'}
+            aria-controls="panel-settings-profiles"
+            tabIndex={activeTab === 'profiles' ? 0 : -1}
+            ref={(el) => (settingsTabRefs.current['profiles'] = el)}
             onClick={() => {
               setActiveTab('profiles');
               refreshProfiles();
@@ -749,6 +801,12 @@ export const SettingsPanel = ({
           </button>
 
           <button
+            role="tab"
+            id="tab-settings-community"
+            aria-selected={activeTab === 'community'}
+            aria-controls="panel-settings-community"
+            tabIndex={activeTab === 'community' ? 0 : -1}
+            ref={(el) => (settingsTabRefs.current['community'] = el)}
             onClick={() => setActiveTab('community')}
             style={{
               flex: 1,
@@ -767,6 +825,12 @@ export const SettingsPanel = ({
           </button>
 
           <button
+            role="tab"
+            id="tab-settings-alerts"
+            aria-selected={activeTab === 'alerts'}
+            aria-controls="panel-settings-alerts"
+            tabIndex={activeTab === 'alerts' ? 0 : -1}
+            ref={(el) => (settingsTabRefs.current['alerts'] = el)}
             onClick={() => setActiveTab('alerts')}
             style={{
               flex: 1,
@@ -785,6 +849,12 @@ export const SettingsPanel = ({
           </button>
 
           <button
+            role="tab"
+            id="tab-settings-rig-bridge"
+            aria-selected={activeTab === 'rig-bridge'}
+            aria-controls="panel-settings-rig-bridge"
+            tabIndex={activeTab === 'rig-bridge' ? 0 : -1}
+            ref={(el) => (settingsTabRefs.current['rig-bridge'] = el)}
             onClick={() => setActiveTab('rig-bridge')}
             style={{
               flex: 1,
@@ -804,10 +874,4259 @@ export const SettingsPanel = ({
         </div>
 
         {/* Station Settings Tab */}
-        {activeTab === 'station' && (
-          <>
-            {/* First-time setup banner */}
-            {(config?.configIncomplete || config?.callsign === 'N0CALL' || !config?.locator) && (
+        <div
+          role="tabpanel"
+          id="panel-settings-station"
+          aria-labelledby="tab-settings-station"
+          hidden={activeTab !== 'station'}
+        >
+          {activeTab === 'station' && (
+            <>
+              {/* First-time setup banner */}
+              {(config?.configIncomplete || config?.callsign === 'N0CALL' || !config?.locator) && (
+                <div
+                  style={{
+                    background: 'rgba(255, 193, 7, 0.15)',
+                    border: '1px solid var(--accent-amber)',
+                    borderRadius: '8px',
+                    padding: '12px 16px',
+                    marginBottom: '20px',
+                    fontSize: '13px',
+                  }}
+                >
+                  <div style={{ color: 'var(--accent-amber)', fontWeight: '700', marginBottom: '6px' }}>
+                    {t('station.settings.welcome')}
+                  </div>
+                  <div style={{ color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+                    {t('station.settings.describe')}
+                  </div>
+                  <div style={{ color: 'var(--text-muted)', fontSize: '11px', marginTop: '8px' }}>
+                    <Trans i18nKey="station.settings.tip.env" components={{ envExample: <Code />, env: <Code /> }} />
+                  </div>
+                </div>
+              )}
+
+              {/* Integrations moved to dedicated tab */}
+              <div
+                style={{
+                  background: 'rgba(0, 255, 255, 0.04)',
+                  border: '1px solid var(--border-color)',
+                  borderRadius: '8px',
+                  padding: '10px 14px',
+                  marginBottom: '20px',
+                  fontSize: 12,
+                  color: 'var(--text-secondary)',
+                }}
+              >
+                Looking for Rotator / N3FJP / other add-ons? See{' '}
+                <b>Settings → {t('station.settings.tab.title.integrations')}</b>.
+              </div>
+
+              {/* Callsign */}
+              <div style={{ marginBottom: '20px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    marginBottom: '6px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  {t('station.settings.callsign')}
+                </label>
+                <input
+                  type="text"
+                  value={callsign}
+                  onChange={(e) => setCallsign(e.target.value.toUpperCase())}
+                  style={{
+                    width: '100%',
+                    padding: '12px',
+                    background: 'var(--bg-tertiary)',
+                    border: '1px solid var(--border-color)',
+                    borderRadius: '6px',
+                    color: 'var(--accent-amber)',
+                    fontSize: '18px',
+                    fontFamily: 'var(--font-mono)',
+                    fontWeight: '700',
+                    boxSizing: 'border-box',
+                  }}
+                />
+              </div>
+
+              {/* Grid Square */}
+              <div style={{ marginBottom: '20px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    marginBottom: '6px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  {t('station.settings.locator')}
+                </label>
+                <input
+                  type="text"
+                  value={gridSquare}
+                  onChange={(e) => handleGridChange(e.target.value)}
+                  onBlur={handleGridBlur}
+                  placeholder={t('station.settings.locator.placeholder')}
+                  maxLength={6}
+                  style={{
+                    width: '100%',
+                    padding: '12px',
+                    background: 'var(--bg-tertiary)',
+                    border: '1px solid var(--border-color)',
+                    borderRadius: '6px',
+                    color: 'var(--accent-amber)',
+                    fontSize: '18px',
+                    fontFamily: 'var(--font-mono)',
+                    fontWeight: '700',
+                    boxSizing: 'border-box',
+                  }}
+                />
+              </div>
+
+              {/* Lat/Lon */}
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px', marginBottom: '12px' }}>
+                <div>
+                  <label
+                    style={{
+                      display: 'block',
+                      marginBottom: '6px',
+                      color: 'var(--text-muted)',
+                      fontSize: '11px',
+                      textTransform: 'uppercase',
+                    }}
+                  >
+                    {t('station.settings.latitude')}
+                  </label>
+                  <input
+                    type="number"
+                    step="0.000001"
+                    value={isNaN(lat) ? '' : lat}
+                    onChange={(e) => setLat(parseFloat(e.target.value) || 0)}
+                    style={{
+                      width: '100%',
+                      padding: '10px',
+                      background: 'var(--bg-tertiary)',
+                      border: '1px solid var(--border-color)',
+                      borderRadius: '6px',
+                      color: 'var(--text-primary)',
+                      fontSize: '14px',
+                      fontFamily: 'var(--font-mono)',
+                      boxSizing: 'border-box',
+                    }}
+                  />
+                </div>
+                <div>
+                  <label
+                    style={{
+                      display: 'block',
+                      marginBottom: '6px',
+                      color: 'var(--text-muted)',
+                      fontSize: '11px',
+                      textTransform: 'uppercase',
+                    }}
+                  >
+                    {t('station.settings.longitude')}
+                  </label>
+                  <input
+                    type="number"
+                    step="0.000001"
+                    value={isNaN(lon) ? '' : lon}
+                    onChange={(e) => setLon(parseFloat(e.target.value) || 0)}
+                    style={{
+                      width: '100%',
+                      padding: '10px',
+                      background: 'var(--bg-tertiary)',
+                      border: '1px solid var(--border-color)',
+                      borderRadius: '6px',
+                      color: 'var(--text-primary)',
+                      fontSize: '14px',
+                      fontFamily: 'var(--font-mono)',
+                      boxSizing: 'border-box',
+                    }}
+                  />
+                </div>
+              </div>
+
+              <button
+                onClick={handleUseLocation}
+                style={{
+                  width: '100%',
+                  padding: '10px',
+                  background: 'var(--bg-tertiary)',
+                  border: '1px solid var(--border-color)',
+                  borderRadius: '6px',
+                  color: 'var(--text-secondary)',
+                  fontSize: '13px',
+                  cursor: 'pointer',
+                  marginBottom: '20px',
+                }}
+              >
+                📍 {t('station.settings.useLocation')}
+              </button>
+
+              {/* Mouse wheel zoom factor */}
+              <div style={{ marginBottom: '31px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  {t('station.settings.mouseZoom')}
+                  <input
+                    type="range"
+                    min="1"
+                    max="100"
+                    value={mouseZoom}
+                    onChange={(e) => setMouseZoom(e.target.value)}
+                    style={{
+                      width: '100%',
+                      cursor: 'pointer',
+                      marginTop: '3px',
+                    }}
+                  />
+                </label>
+                <span style={{ float: 'left', fontSize: '11px', color: 'var(--text-muted)' }}>
+                  {t('station.settings.mouseZoom.describeMin')}
+                </span>
+                <span style={{ float: 'right', fontSize: '11px', color: 'var(--text-muted)' }}>
+                  {t('station.settings.mouseZoom.describeMax')}
+                </span>
+              </div>
+
+              {/* DX Cluster Source */}
+              <div style={{ marginBottom: '20px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  🕐 {t('station.settings.timezone')}
+                </label>
+                <select
+                  value={timezone}
+                  onChange={(e) => setTimezone(e.target.value)}
+                  style={{
+                    width: '100%',
+                    padding: '12px',
+                    background: 'var(--bg-tertiary)',
+                    border: '1px solid var(--border-color)',
+                    borderRadius: '6px',
+                    color: timezone ? 'var(--accent-green)' : 'var(--text-muted)',
+                    fontSize: '14px',
+                    fontFamily: 'var(--font-mono)',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <option value="">{t('station.settings.timezone.auto')}</option>
+                  <optgroup label={t('station.settings.timezone.group.northAmerica')}>
+                    <option value="America/New_York">Eastern (New York)</option>
+                    <option value="America/Chicago">Central (Chicago)</option>
+                    <option value="America/Denver">Mountain (Denver)</option>
+                    <option value="America/Los_Angeles">Pacific (Los Angeles)</option>
+                    <option value="America/Anchorage">Alaska</option>
+                    <option value="Pacific/Honolulu">Hawaii</option>
+                    <option value="America/Phoenix">Arizona (no DST)</option>
+                    <option value="America/Regina">Saskatchewan (no DST)</option>
+                    <option value="America/Halifax">Atlantic (Halifax)</option>
+                    <option value="America/St_Johns">Newfoundland</option>
+                    <option value="America/Toronto">Ontario (Toronto)</option>
+                    <option value="America/Winnipeg">Manitoba (Winnipeg)</option>
+                    <option value="America/Edmonton">Alberta (Edmonton)</option>
+                    <option value="America/Vancouver">BC (Vancouver)</option>
+                    <option value="America/Mexico_City">Mexico City</option>
+                  </optgroup>
+                  <optgroup label={t('station.settings.timezone.group.europe')}>
+                    <option value="Europe/London">UK (London)</option>
+                    <option value="Europe/Dublin">Ireland (Dublin)</option>
+                    <option value="Europe/Paris">Central Europe (Paris)</option>
+                    <option value="Europe/Berlin">Germany (Berlin)</option>
+                    <option value="Europe/Rome">Italy (Rome)</option>
+                    <option value="Europe/Madrid">Spain (Madrid)</option>
+                    <option value="Europe/Amsterdam">Netherlands (Amsterdam)</option>
+                    <option value="Europe/Brussels">Belgium (Brussels)</option>
+                    <option value="Europe/Stockholm">Sweden (Stockholm)</option>
+                    <option value="Europe/Helsinki">Finland (Helsinki)</option>
+                    <option value="Europe/Athens">Greece (Athens)</option>
+                    <option value="Europe/Bucharest">Romania (Bucharest)</option>
+                    <option value="Europe/Moscow">Russia (Moscow)</option>
+                    <option value="Europe/Warsaw">Poland (Warsaw)</option>
+                    <option value="Europe/Zurich">Switzerland (Zurich)</option>
+                    <option value="Europe/Lisbon">Portugal (Lisbon)</option>
+                  </optgroup>
+                  <optgroup label={t('station.settings.timezone.group.asiaPacific')}>
+                    <option value="Asia/Tokyo">Japan (Tokyo)</option>
+                    <option value="Asia/Seoul">Korea (Seoul)</option>
+                    <option value="Asia/Shanghai">China (Shanghai)</option>
+                    <option value="Asia/Hong_Kong">Hong Kong</option>
+                    <option value="Asia/Taipei">Taiwan (Taipei)</option>
+                    <option value="Asia/Singapore">Singapore</option>
+                    <option value="Asia/Kolkata">India (Kolkata)</option>
+                    <option value="Asia/Dubai">UAE (Dubai)</option>
+                    <option value="Asia/Riyadh">Saudi Arabia (Riyadh)</option>
+                    <option value="Asia/Tehran">Iran (Tehran)</option>
+                    <option value="Asia/Bangkok">Thailand (Bangkok)</option>
+                    <option value="Asia/Jakarta">Indonesia (Jakarta)</option>
+                    <option value="Asia/Manila">Philippines (Manila)</option>
+                    <option value="Australia/Brisbane">Australia Eastern (Brisbane)</option>
+                    <option value="Australia/Sydney">Australia Eastern (Sydney, Canberra, Melbourne, Hobart)</option>
+                    <option value="Australia/Adelaide">Australia Central (Adelaide)</option>
+                    <option value="Australia/Perth">Australia Western (Perth)</option>
+                    <option value="Pacific/Auckland">New Zealand (Auckland)</option>
+                    <option value="Pacific/Fiji">Fiji</option>
+                  </optgroup>
+                  <optgroup label={t('station.settings.timezone.group.southAmerica')}>
+                    <option value="America/Sao_Paulo">Brazil (São Paulo)</option>
+                    <option value="America/Argentina/Buenos_Aires">Argentina (Buenos Aires)</option>
+                    <option value="America/Santiago">Chile (Santiago)</option>
+                    <option value="America/Bogota">Colombia (Bogotá)</option>
+                    <option value="America/Lima">Peru (Lima)</option>
+                    <option value="America/Caracas">Venezuela (Caracas)</option>
+                  </optgroup>
+                  <optgroup label={t('station.settings.timezone.group.africa')}>
+                    <option value="Africa/Cairo">Egypt (Cairo)</option>
+                    <option value="Africa/Johannesburg">South Africa (Johannesburg)</option>
+                    <option value="Africa/Lagos">Nigeria (Lagos)</option>
+                    <option value="Africa/Nairobi">Kenya (Nairobi)</option>
+                    <option value="Africa/Casablanca">Morocco (Casablanca)</option>
+                  </optgroup>
+                  <optgroup label={t('station.settings.timezone.group.other')}>
+                    <option value="UTC">UTC</option>
+                    <option value="Atlantic/Reykjavik">Iceland (Reykjavik)</option>
+                    <option value="Atlantic/Azores">Azores</option>
+                    <option value="Indian/Maldives">Maldives</option>
+                    <option value="Indian/Mauritius">Mauritius</option>
+                  </optgroup>
+                </select>
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
+                  {t('station.settings.timezone.describe')}
+                  {timezone ? '' : ' ' + t('station.settings.timezone.currentDefault')}
+                </div>
+              </div>
+
+              {/* Units (Distance, Temperature and Pressure ) */}
+              <div style={{ marginBottom: '20px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  📏 {t('station.settings.units.title')}
+                </label>
+                <div style={{ display: 'flex', gap: '8px' }}>
+                  <button
+                    onClick={() => toggleDistUnits()}
+                    style={{
+                      flex: 1,
+                      padding: '10px',
+                      background: 'var(--bg-tertiary)',
+                      border: '1px solid var(--border-color)',
+                      borderRadius: '6px',
+                      color: 'var(--accent-green)',
+                      fontSize: '13px',
+                      cursor: 'pointer',
+                      fontWeight: '600',
+                    }}
+                  >
+                    {t('station.settings.units.distance')}: {unitString(distUnits)}
+                  </button>
+                  <button
+                    onClick={() => toggleTempUnits()}
+                    style={{
+                      flex: 1,
+                      padding: '10px',
+                      background: 'var(--bg-tertiary)',
+                      border: '1px solid var(--border-color)',
+                      borderRadius: '6px',
+                      color: 'var(--accent-green)',
+                      fontSize: '13px',
+                      cursor: 'pointer',
+                      fontWeight: '600',
+                    }}
+                  >
+                    {t('station.settings.units.temperature')}: {unitString(tempUnits)}
+                  </button>
+                  <button
+                    onClick={() => togglePressUnits()}
+                    style={{
+                      flex: 1,
+                      padding: '10px',
+                      background: 'var(--bg-tertiary)',
+                      border: '1px solid var(--border-color)',
+                      borderRadius: '6px',
+                      color: 'var(--accent-green)',
+                      fontSize: '13px',
+                      cursor: 'pointer',
+                      fontWeight: '600',
+                    }}
+                  >
+                    {t('station.settings.units.pressure')}: {unitString(pressUnits)}
+                  </button>
+                </div>
+              </div>
+
+              {/* WSJTX Relay Multicast Options */}
+              <div style={{ marginBottom: '20px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  🔁 WSJTX Relay Multicast Options
+                </label>
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '8px', lineHeight: 1.4 }}>
+                  <input
+                    type="checkbox"
+                    checked={wsjtxMulticastEnabled}
+                    onChange={(e) => setWsjtxMulticastEnabled(e.target.checked)}
+                    style={{ marginRight: '8px' }}
+                  />
+                  <span style={{ color: 'var(--text-primary)', fontSize: '14px' }}>Use multicast address &nbsp;</span>
+                  <input
+                    type="text"
+                    value={wsjtxMulticastAddress}
+                    onChange={(e) => setWsjtxMulticastAddress(e.target.value.toUpperCase())}
+                    style={{
+                      width: '10%',
+                      marginLeft: '8px',
+                      padding: '8px 12px',
+                      background: 'var(--bg-primary)',
+                      border: '1px solid var(--border-color)',
+                      borderRadius: '4px',
+                      color: wsjtxMulticastEnabled ? 'var(--text-primary)' : 'var(--text-secondary',
+                      fontSize: '12px',
+                      fontFamily: 'var(--font-mono)',
+                      boxSizing: 'border-box',
+                    }}
+                  />
+                  If you are going to run a wsjt-x relay, define here if you need a multicast listener and what address
+                  it should be using.
+                </div>
+              </div>
+
+              {/* Rig Control Settings */}
+              <div style={{ marginBottom: '20px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  {t('station.settings.rigControl.title')} (Beta)
+                </label>
+
+                <div
+                  style={{
+                    background: 'var(--bg-tertiary)',
+                    padding: '12px',
+                    borderRadius: '6px',
+                    border: '1px solid var(--border-color)',
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', marginBottom: '12px' }}>
+                    <input
+                      type="checkbox"
+                      checked={rigEnabled}
+                      onChange={(e) => setRigEnabled(e.target.checked)}
+                      style={{ marginRight: '8px' }}
+                    />
+                    <span style={{ color: 'var(--text-primary)', fontSize: '14px' }}>
+                      {t('station.settings.rigControl.enabled')}
+                    </span>
+                  </div>
+
+                  {rigEnabled && (
+                    <>
+                      {/* Download Rig Listener */}
+                      <div
+                        style={{
+                          background: 'rgba(99,102,241,0.08)',
+                          border: '1px solid rgba(99,102,241,0.2)',
+                          borderRadius: '6px',
+                          padding: '10px',
+                          marginBottom: '12px',
+                        }}
+                      >
+                        <div
+                          style={{
+                            fontSize: '11px',
+                            color: 'var(--text-secondary)',
+                            marginBottom: '8px',
+                            lineHeight: 1.4,
+                          }}
+                        >
+                          📻 Download the Rig Listener for your computer. Double-click to run — it connects your radio
+                          to OpenHamClock via USB.
+                        </div>
+                        <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+                          <a
+                            href="/api/rig/download/windows"
+                            style={{
+                              padding: '5px 12px',
+                              borderRadius: '4px',
+                              fontSize: '11px',
+                              fontWeight: '600',
+                              background: 'rgba(99,102,241,0.15)',
+                              border: '1px solid rgba(99,102,241,0.3)',
+                              color: '#818cf8',
+                              textDecoration: 'none',
+                              cursor: 'pointer',
+                            }}
+                          >
+                            ⊞ Windows
+                          </a>
+                          <a
+                            href="/api/rig/download/mac"
+                            style={{
+                              padding: '5px 12px',
+                              borderRadius: '4px',
+                              fontSize: '11px',
+                              fontWeight: '600',
+                              background: 'rgba(99,102,241,0.15)',
+                              border: '1px solid rgba(99,102,241,0.3)',
+                              color: '#818cf8',
+                              textDecoration: 'none',
+                              cursor: 'pointer',
+                            }}
+                          >
+                            {' '}
+                            Mac
+                          </a>
+                          <a
+                            href="/api/rig/download/linux"
+                            style={{
+                              padding: '5px 12px',
+                              borderRadius: '4px',
+                              fontSize: '11px',
+                              fontWeight: '600',
+                              background: 'rgba(99,102,241,0.15)',
+                              border: '1px solid rgba(99,102,241,0.3)',
+                              color: '#818cf8',
+                              textDecoration: 'none',
+                              cursor: 'pointer',
+                            }}
+                          >
+                            🐧 Linux
+                          </a>
+                        </div>
+                        <div style={{ fontSize: '9px', color: 'var(--text-muted)', marginTop: '6px', opacity: 0.7 }}>
+                          Supports Yaesu, Kenwood, Elecraft, and Icom radios. No extra software needed.
+                        </div>
+                      </div>
+
+                      <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: '10px' }}>
+                        <div>
+                          <label
+                            style={{
+                              display: 'block',
+                              marginBottom: '4px',
+                              color: 'var(--text-muted)',
+                              fontSize: '10px',
+                            }}
+                          >
+                            {t('station.settings.rigControl.host')}
+                          </label>
+                          <input
+                            type="text"
+                            value={rigHost}
+                            onChange={(e) => setRigHost(e.target.value)}
+                            placeholder="http://localhost"
+                            style={{
+                              width: '100%',
+                              padding: '8px',
+                              background: 'var(--bg-primary)',
+                              border: '1px solid var(--border-color)',
+                              borderRadius: '4px',
+                              color: 'var(--accent-cyan)',
+                              fontSize: '13px',
+                              fontFamily: 'var(--font-mono)',
+                              boxSizing: 'border-box',
+                            }}
+                          />
+                        </div>
+                        <div>
+                          <label
+                            style={{
+                              display: 'block',
+                              marginBottom: '4px',
+                              color: 'var(--text-muted)',
+                              fontSize: '10px',
+                            }}
+                          >
+                            {t('station.settings.rigControl.port')}
+                          </label>
+                          <input
+                            type="number"
+                            value={rigPort}
+                            onChange={(e) => setRigPort(e.target.value)}
+                            placeholder="5555"
+                            style={{
+                              width: '100%',
+                              padding: '8px',
+                              background: 'var(--bg-primary)',
+                              border: '1px solid var(--border-color)',
+                              borderRadius: '4px',
+                              color: 'var(--accent-cyan)',
+                              fontSize: '13px',
+                              fontFamily: 'var(--font-mono)',
+                              boxSizing: 'border-box',
+                            }}
+                          />
+                        </div>
+                      </div>
+
+                      <div style={{ marginTop: '10px', display: 'flex', alignItems: 'center' }}>
+                        <input
+                          type="checkbox"
+                          checked={tuneEnabled}
+                          onChange={(e) => setTuneEnabled(e.target.checked)}
+                          style={{ marginRight: '8px' }}
+                        />
+                        <div>
+                          <span style={{ color: 'var(--text-primary)', fontSize: '13px' }}>
+                            {t('station.settings.rigControl.tuneEnabled')}
+                          </span>
+                          <div style={{ fontSize: '10px', color: 'var(--text-muted)' }}>
+                            {t('station.settings.rigControl.tuneEnabled.hint')}
+                          </div>
+                        </div>
+                      </div>
+
+                      <div style={{ marginTop: '10px', display: 'flex', alignItems: 'center' }}>
+                        <input
+                          type="checkbox"
+                          checked={autoMode}
+                          onChange={(e) => setAutoMode(e.target.checked)}
+                          style={{ marginRight: '8px' }}
+                        />
+                        <div>
+                          <span style={{ color: 'var(--text-primary)', fontSize: '13px' }}>
+                            {t('station.settings.rigControl.autoMode')}
+                          </span>
+                          <div style={{ fontSize: '10px', color: 'var(--text-muted)' }}>
+                            {t('station.settings.rigControl.autoMode.hint')}
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* API Token */}
+                      <div style={{ marginTop: '12px' }}>
+                        <label
+                          style={{
+                            display: 'block',
+                            fontSize: '11px',
+                            color: 'var(--text-muted)',
+                            marginBottom: '4px',
+                          }}
+                        >
+                          {t('station.settings.rigControl.apiToken')}
+                        </label>
+                        <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+                          <input
+                            type={showRigToken ? 'text' : 'password'}
+                            value={rigApiToken}
+                            onChange={(e) => setRigApiToken(e.target.value)}
+                            placeholder={t('station.settings.rigControl.apiToken.placeholder')}
+                            style={{
+                              flex: 1,
+                              padding: '6px 10px',
+                              background: 'var(--bg-primary)',
+                              border: '1px solid var(--border-color)',
+                              borderRadius: '4px',
+                              color: 'var(--text-primary)',
+                              fontSize: '12px',
+                              fontFamily: 'monospace',
+                            }}
+                          />
+                          <button
+                            type="button"
+                            onClick={() => setShowRigToken((v) => !v)}
+                            style={{
+                              padding: '6px 10px',
+                              background: 'var(--bg-tertiary)',
+                              border: '1px solid var(--border-color)',
+                              borderRadius: '4px',
+                              color: 'var(--text-secondary)',
+                              fontSize: '11px',
+                              cursor: 'pointer',
+                              whiteSpace: 'nowrap',
+                            }}
+                          >
+                            {showRigToken ? '🙈 Hide' : '👁 Show'}
+                          </button>
+                        </div>
+                        <div
+                          style={{ fontSize: '10px', color: 'var(--text-muted)', marginTop: '4px', lineHeight: 1.4 }}
+                        >
+                          {t('station.settings.rigControl.apiToken.hint')}
+                        </div>
+                      </div>
+
+                      {/* WSJT-X Relay */}
+                      <div
+                        style={{
+                          marginTop: '16px',
+                          paddingTop: '12px',
+                          borderTop: '1px solid var(--border-color)',
+                        }}
+                      >
+                        <div
+                          style={{
+                            fontSize: '11px',
+                            color: 'var(--text-muted)',
+                            textTransform: 'uppercase',
+                            letterSpacing: '1px',
+                            marginBottom: '6px',
+                          }}
+                        >
+                          {t('station.settings.rigControl.wsjtxRelay.title')}
+                        </div>
+                        <div
+                          style={{
+                            fontSize: '11px',
+                            color: 'var(--text-secondary)',
+                            marginBottom: '10px',
+                            lineHeight: 1.4,
+                          }}
+                        >
+                          {t('station.settings.rigControl.wsjtxRelay.hint')}
+                        </div>
+
+                        {/* Session ID display */}
+                        {wsjtxSessionId && (
+                          <div style={{ marginBottom: '10px' }}>
+                            <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}>
+                              {t('station.settings.rigControl.wsjtxRelay.sessionId')}
+                            </div>
+                            <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+                              <input
+                                type="text"
+                                readOnly
+                                value={wsjtxSessionId}
+                                style={{
+                                  flex: 1,
+                                  padding: '6px 10px',
+                                  background: 'var(--bg-primary)',
+                                  border: '1px solid var(--border-color)',
+                                  borderRadius: '4px',
+                                  color: 'var(--text-secondary)',
+                                  fontSize: '12px',
+                                  fontFamily: 'monospace',
+                                }}
+                              />
+                              <button
+                                type="button"
+                                onClick={() => navigator.clipboard?.writeText(wsjtxSessionId)}
+                                style={{
+                                  padding: '6px 10px',
+                                  background: 'var(--bg-tertiary)',
+                                  border: '1px solid var(--border-color)',
+                                  borderRadius: '4px',
+                                  color: 'var(--text-secondary)',
+                                  fontSize: '11px',
+                                  cursor: 'pointer',
+                                  whiteSpace: 'nowrap',
+                                }}
+                              >
+                                📋 Copy
+                              </button>
+                            </div>
+                            <div
+                              style={{
+                                fontSize: '10px',
+                                color: 'var(--text-muted)',
+                                marginTop: '4px',
+                                lineHeight: 1.4,
+                              }}
+                            >
+                              {t('station.settings.rigControl.wsjtxRelay.sessionId.hint')}
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Configure button */}
+                        <button
+                          type="button"
+                          onClick={handleConfigureWsjtxRelay}
+                          disabled={wsjtxRelayStatus === 'pushing'}
+                          style={{
+                            width: '100%',
+                            padding: '8px',
+                            background: 'rgba(99,102,241,0.15)',
+                            border: '1px solid rgba(99,102,241,0.3)',
+                            borderRadius: '4px',
+                            color: '#818cf8',
+                            fontSize: '12px',
+                            fontWeight: '600',
+                            cursor: wsjtxRelayStatus === 'pushing' ? 'wait' : 'pointer',
+                          }}
+                        >
+                          {wsjtxRelayStatus === 'pushing'
+                            ? t('station.settings.rigControl.wsjtxRelay.status.pushing')
+                            : t('station.settings.rigControl.wsjtxRelay.configure')}
+                        </button>
+
+                        {/* Status feedback */}
+                        {wsjtxRelayStatus && wsjtxRelayStatus !== 'pushing' && (
+                          <div
+                            style={{
+                              marginTop: '6px',
+                              fontSize: '11px',
+                              color:
+                                wsjtxRelayStatus === 'ok'
+                                  ? 'var(--accent-green, #4ade80)'
+                                  : 'var(--accent-red, #f87171)',
+                              lineHeight: 1.4,
+                            }}
+                          >
+                            {wsjtxRelayStatus === 'ok' ? '✅ ' : '❌ '}
+                            {wsjtxRelayMsg}
+                          </div>
+                        )}
+                      </div>
+                    </>
+                  )}
+                </div>
+              </div>
+
+              {/* Propagation Settings */}
+              <div style={{ marginBottom: '20px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  ⌇ {t('station.settings.operatingMode.title')}
+                </label>
+
+                {/* Mode */}
+                <div style={{ marginBottom: '8px' }}>
+                  <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}>
+                    {t('station.settings.operatingMode')}
+                  </div>
+                  <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '4px' }}>
+                    {[
+                      { id: 'SSB', label: 'SSB', desc: 'Voice' },
+                      { id: 'CW', label: 'CW', desc: 'Morse' },
+                      { id: 'FT8', label: 'FT8', desc: 'Weak sig' },
+                      { id: 'FT4', label: 'FT4', desc: 'Weak sig' },
+                      { id: 'WSPR', label: 'WSPR', desc: 'Beacon' },
+                      { id: 'JS8', label: 'JS8', desc: 'Chat' },
+                      { id: 'RTTY', label: 'RTTY', desc: 'Teletype' },
+                      { id: 'PSK31', label: 'PSK31', desc: 'PSK' },
+                    ].map((m) => (
+                      <button
+                        key={m.id}
+                        onClick={() => setPropMode(m.id)}
+                        aria-pressed={propMode === m.id}
+                        style={{
+                          padding: '6px 4px',
+                          background: propMode === m.id ? 'var(--accent-amber)' : 'var(--bg-tertiary)',
+                          border: `1px solid ${propMode === m.id ? 'var(--accent-amber)' : 'var(--border-color)'}`,
+                          borderRadius: '4px',
+                          color: propMode === m.id ? '#000' : 'var(--text-secondary)',
+                          fontSize: '11px',
+                          cursor: 'pointer',
+                          fontWeight: propMode === m.id ? '700' : '400',
+                          fontFamily: 'var(--font-mono)',
+                          lineHeight: 1.2,
+                          textAlign: 'center',
+                        }}
+                        title={m.desc}
+                      >
+                        {m.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Power */}
+                <div style={{ marginBottom: '6px' }}>
+                  <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}>
+                    {t('station.settings.operatingMode.txPower')}
+                  </div>
+                  <div
+                    style={{
+                      display: 'grid',
+                      gridTemplateColumns: 'repeat(4, 1fr)',
+                      gap: '4px',
+                      alignItems: 'center',
+                    }}
+                  >
+                    {[
+                      { w: 5, label: '5W', tip: 'QRP' },
+                      { w: 25, label: '25W', tip: 'Low' },
+                      { w: 100, label: '100W', tip: 'Std' },
+                      { w: 1500, label: '1.5kW', tip: 'Max' },
+                    ].map((p) => (
+                      <button
+                        key={p.w}
+                        onClick={() => setPropPower(p.w)}
+                        aria-pressed={propPower === p.w}
+                        style={{
+                          padding: '6px 4px',
+                          background: propPower === p.w ? 'var(--accent-amber)' : 'var(--bg-tertiary)',
+                          border: `1px solid ${propPower === p.w ? 'var(--accent-amber)' : 'var(--border-color)'}`,
+                          borderRadius: '4px',
+                          color: propPower === p.w ? '#000' : 'var(--text-secondary)',
+                          fontSize: '11px',
+                          cursor: 'pointer',
+                          fontWeight: propPower === p.w ? '700' : '400',
+                          fontFamily: 'var(--font-mono)',
+                        }}
+                        title={p.tip}
+                      >
+                        {p.label}
+                      </button>
+                    ))}
+                  </div>
+                  {/* Non-preset value (set from Propagation panel's Custom… input) — show, but read-only here */}
+                  {![5, 25, 100, 1500].includes(propPower) && (
+                    <div
+                      style={{
+                        marginTop: '4px',
+                        fontSize: '10px',
+                        color: 'var(--text-muted)',
+                        fontFamily: 'var(--font-mono)',
+                      }}
+                    >
+                      Custom: {propPower}W <span style={{ opacity: 0.7 }}>(set from Propagation panel)</span>
+                    </div>
+                  )}
+                </div>
+
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
+                  {(() => {
+                    const modeAdv = { SSB: 0, CW: 10, RTTY: 8, PSK31: 10, FT8: 34, FT4: 30, WSPR: 41, JS8: 37 };
+                    const adv = modeAdv[propMode] || 0;
+                    const pwrDb = 10 * Math.log10((propPower || 100) / 100);
+                    const margin = adv + pwrDb;
+                    return `Signal margin: ${margin >= 0 ? '+' : ''}${margin.toFixed(1)} dB vs SSB@100W — ${
+                      margin >= 30
+                        ? 'extreme weak-signal advantage'
+                        : margin >= 15
+                          ? 'strong advantage — marginal bands may open'
+                          : margin >= 5
+                            ? 'moderate advantage'
+                            : margin >= -5
+                              ? 'baseline conditions'
+                              : margin >= -15
+                                ? 'reduced margin — some bands may close'
+                                : 'significant disadvantage — only strong openings'
+                    }`;
+                  })()}
+                </div>
+              </div>
+
+              {/* Low Memory Mode */}
+              <div style={{ marginBottom: '20px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  🧠 Performance Mode
+                </label>
+                <div style={{ display: 'flex', gap: '8px' }}>
+                  <button
+                    onClick={() => setLowMemoryMode(false)}
+                    style={{
+                      flex: 1,
+                      padding: '10px',
+                      background: !lowMemoryMode ? 'var(--accent-amber)' : 'var(--bg-tertiary)',
+                      border: `1px solid ${!lowMemoryMode ? 'var(--accent-amber)' : 'var(--border-color)'}`,
+                      borderRadius: '6px',
+                      color: !lowMemoryMode ? '#000' : 'var(--text-secondary)',
+                      fontSize: '13px',
+                      cursor: 'pointer',
+                      fontWeight: !lowMemoryMode ? '600' : '400',
+                    }}
+                  >
+                    🚀 Full
+                  </button>
+                  <button
+                    onClick={() => setLowMemoryMode(true)}
+                    style={{
+                      flex: 1,
+                      padding: '10px',
+                      background: lowMemoryMode ? 'var(--accent-green)' : 'var(--bg-tertiary)',
+                      border: `1px solid ${lowMemoryMode ? 'var(--accent-green)' : 'var(--border-color)'}`,
+                      borderRadius: '6px',
+                      color: lowMemoryMode ? '#000' : 'var(--text-secondary)',
+                      fontSize: '13px',
+                      cursor: 'pointer',
+                      fontWeight: lowMemoryMode ? '600' : '400',
+                    }}
+                  >
+                    🪶 Low Memory
+                  </button>
+                </div>
+                <div
+                  style={{
+                    fontSize: '11px',
+                    color: lowMemoryMode ? 'var(--accent-green)' : 'var(--text-muted)',
+                    marginTop: '6px',
+                  }}
+                >
+                  {lowMemoryMode
+                    ? '✓ Low Memory Mode: Reduced animations, fewer map markers, smaller spot limits. Recommended for systems with <8GB RAM.'
+                    : 'Full Mode: All features enabled. Requires 8GB+ RAM for best performance.'}
+                </div>
+              </div>
+              <div style={{ marginBottom: '20px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  {t('station.settings.preventSleep')}
+                </label>
+                <div style={{ display: 'flex', gap: '10px' }}>
+                  <button
+                    onClick={() => setPreventSleep(false)}
+                    style={{
+                      flex: 1,
+                      padding: '10px',
+                      background: !preventSleep ? 'var(--accent-amber)' : 'var(--bg-tertiary)',
+                      border: `1px solid ${!preventSleep ? 'var(--accent-amber)' : 'var(--border-color)'}`,
+                      borderRadius: '6px',
+                      color: !preventSleep ? '#000' : 'var(--text-secondary)',
+                      fontSize: '13px',
+                      cursor: 'pointer',
+                      fontWeight: !preventSleep ? '600' : '400',
+                    }}
+                  >
+                    💤 {t('station.settings.preventSleep.off')}
+                  </button>
+                  <button
+                    onClick={() => setPreventSleep(true)}
+                    style={{
+                      flex: 1,
+                      padding: '10px',
+                      background: preventSleep ? 'var(--accent-green)' : 'var(--bg-tertiary)',
+                      border: `1px solid ${preventSleep ? 'var(--accent-green)' : 'var(--border-color)'}`,
+                      borderRadius: '6px',
+                      color: preventSleep ? '#000' : 'var(--text-secondary)',
+                      fontSize: '13px',
+                      cursor: 'pointer',
+                      fontWeight: preventSleep ? '600' : '400',
+                    }}
+                  >
+                    🖥️ {t('station.settings.preventSleep.on')}
+                  </button>
+                </div>
+                <div style={{ marginTop: '8px' }}>
+                  {preventSleep && wakeLockStatus && (
+                    <div
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: '5px',
+                        padding: '3px 8px',
+                        borderRadius: '4px',
+                        fontSize: '11px',
+                        fontFamily: 'var(--font-mono)',
+                        fontWeight: '600',
+                        marginBottom: '6px',
+                        background: wakeLockStatus.active ? 'rgba(0,200,100,0.15)' : 'rgba(255,160,0,0.15)',
+                        border: `1px solid ${wakeLockStatus.active ? 'var(--accent-green)' : 'var(--accent-amber)'}`,
+                        color: wakeLockStatus.active ? 'var(--accent-green)' : 'var(--accent-amber)',
+                      }}
+                    >
+                      {wakeLockStatus.active ? '🔒' : '⚠'}
+                      {wakeLockStatus.active
+                        ? t('station.settings.preventSleep.status.active')
+                        : t(`station.settings.preventSleep.status.${wakeLockStatus.reason}`, {
+                            defaultValue: t('station.settings.preventSleep.status.error'),
+                          })}
+                    </div>
+                  )}
+                  <div
+                    style={{
+                      fontSize: '11px',
+                      color: preventSleep && wakeLockStatus?.active ? 'var(--accent-green)' : 'var(--text-muted)',
+                    }}
+                  >
+                    {t(
+                      preventSleep
+                        ? 'station.settings.preventSleep.describe.on'
+                        : 'station.settings.preventSleep.describe.off',
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {/* Active Users Presence */}
+              <div style={{ marginBottom: '20px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  {t('station.settings.sharePresence')}
+                </label>
+                <div style={{ display: 'flex', gap: '10px' }}>
+                  <button
+                    onClick={() => setSharePresence(false)}
+                    style={{
+                      flex: 1,
+                      padding: '10px',
+                      background: !sharePresence ? 'var(--accent-amber)' : 'var(--bg-tertiary)',
+                      border: `1px solid ${!sharePresence ? 'var(--accent-amber)' : 'var(--border-color)'}`,
+                      borderRadius: '6px',
+                      color: !sharePresence ? '#000' : 'var(--text-secondary)',
+                      fontSize: '13px',
+                      cursor: 'pointer',
+                      fontWeight: !sharePresence ? '600' : '400',
+                    }}
+                  >
+                    {t('station.settings.sharePresence.off')}
+                  </button>
+                  <button
+                    onClick={() => setSharePresence(true)}
+                    style={{
+                      flex: 1,
+                      padding: '10px',
+                      background: sharePresence ? 'var(--accent-green)' : 'var(--bg-tertiary)',
+                      border: `1px solid ${sharePresence ? 'var(--accent-green)' : 'var(--border-color)'}`,
+                      borderRadius: '6px',
+                      color: sharePresence ? '#000' : 'var(--text-secondary)',
+                      fontSize: '13px',
+                      cursor: 'pointer',
+                      fontWeight: sharePresence ? '600' : '400',
+                    }}
+                  >
+                    {t('station.settings.sharePresence.on')}
+                  </button>
+                </div>
+                <div
+                  style={{
+                    fontSize: '11px',
+                    color: 'var(--text-muted)',
+                    marginTop: '8px',
+                  }}
+                >
+                  {t(
+                    sharePresence
+                      ? 'station.settings.sharePresence.describe.on'
+                      : 'station.settings.sharePresence.describe.off',
+                  )}
+                </div>
+              </div>
+
+              {/* Display Schedule */}
+              <div style={{ marginBottom: '20px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  Display Schedule
+                </label>
+                <label
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '10px',
+                    cursor: 'pointer',
+                    fontSize: '13px',
+                    color: 'var(--text-primary)',
+                    marginBottom: '10px',
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={displaySchedule.enabled}
+                    onChange={(e) => setDisplaySchedule({ ...displaySchedule, enabled: e.target.checked })}
+                    style={{ accentColor: 'var(--accent-amber)' }}
+                  />
+                  Enable scheduled display sleep
+                </label>
+                {displaySchedule.enabled && (
+                  <div style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '8px' }}>
+                    <div>
+                      <label
+                        style={{ display: 'block', fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}
+                      >
+                        Sleep at
+                      </label>
+                      <input
+                        type="time"
+                        value={displaySchedule.sleepTime}
+                        onChange={(e) => setDisplaySchedule({ ...displaySchedule, sleepTime: e.target.value })}
+                        style={{
+                          background: 'var(--bg-tertiary)',
+                          border: '1px solid var(--border-color)',
+                          borderRadius: '4px',
+                          color: 'var(--text-primary)',
+                          padding: '6px 10px',
+                          fontSize: '13px',
+                          fontFamily: 'var(--font-mono)',
+                        }}
+                      />
+                    </div>
+                    <div>
+                      <label
+                        style={{ display: 'block', fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}
+                      >
+                        Wake at
+                      </label>
+                      <input
+                        type="time"
+                        value={displaySchedule.wakeTime}
+                        onChange={(e) => setDisplaySchedule({ ...displaySchedule, wakeTime: e.target.value })}
+                        style={{
+                          background: 'var(--bg-tertiary)',
+                          border: '1px solid var(--border-color)',
+                          borderRadius: '4px',
+                          color: 'var(--text-primary)',
+                          padding: '6px 10px',
+                          fontSize: '13px',
+                          fontFamily: 'var(--font-mono)',
+                        }}
+                      />
+                    </div>
+                  </div>
+                )}
+                {displaySchedule.enabled && (
+                  <label
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '10px',
+                      cursor: 'pointer',
+                      fontSize: '13px',
+                      color: 'var(--text-primary)',
+                      marginBottom: '8px',
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={displaySchedule.keepSignalActive !== false}
+                      onChange={(e) => setDisplaySchedule({ ...displaySchedule, keepSignalActive: e.target.checked })}
+                      style={{ accentColor: 'var(--accent-amber)' }}
+                    />
+                    Keep HDMI signal active during sleep (recommended for TVs)
+                  </label>
+                )}
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)' }}>
+                  {displaySchedule.enabled
+                    ? displaySchedule.keepSignalActive !== false
+                      ? `Display will go black at ${displaySchedule.sleepTime} and wake at ${displaySchedule.wakeTime} (local time). The HDMI signal stays alive so TVs don't latch into standby — turn this off only if you want the display to actually power down.`
+                      : `Display will go black at ${displaySchedule.sleepTime} and wake at ${displaySchedule.wakeTime} (local time). The wake lock will be released so your monitor can power off. Note: TVs that go to standby on signal loss will not wake automatically — enable "Keep HDMI signal active" above if this affects you.`
+                    : 'Set a daily schedule to automatically black out the display at night. Ideal for shack TVs and kiosk displays.'}
+                </div>
+              </div>
+
+              <div style={{ marginBottom: '20px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  {t('station.settings.dx.title')}
+                </label>
+                <select
+                  value={dxClusterSource}
+                  onChange={(e) => setDxClusterSource(e.target.value)}
+                  style={{
+                    width: '100%',
+                    padding: '12px',
+                    background: 'var(--bg-tertiary)',
+                    border: '1px solid var(--border-color)',
+                    borderRadius: '6px',
+                    color: 'var(--accent-green)',
+                    fontSize: '14px',
+                    fontFamily: 'var(--font-mono)',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <option value="dxspider-proxy">{t('station.settings.dx.option1')}</option>
+                  <option value="hamqth">{t('station.settings.dx.option2')}</option>
+                  <option value="dxwatch">{t('station.settings.dx.option3')}</option>
+                  <option value="auto">{t('station.settings.dx.option4')}</option>
+                  <option value="custom">{t('station.settings.dx.custom.option')}</option>
+                  {isLocalInstall && (
+                    <option value="udp">
+                      {t('station.settings.dx.udp.option', { defaultValue: 'UDP Spots (Local Network)' })}
+                    </option>
+                  )}
+                </select>
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
+                  {t('station.settings.dx.describe')}
+                </div>
+              </div>
+
+              {dxClusterSource === 'udp' && (
+                <div
+                  style={{
+                    marginBottom: '20px',
+                    padding: '16px',
+                    background: 'var(--bg-tertiary)',
+                    borderRadius: '8px',
+                    border: '1px solid var(--border-color)',
+                  }}
+                >
+                  <label
+                    style={{
+                      display: 'block',
+                      marginBottom: '12px',
+                      color: 'var(--accent-cyan)',
+                      fontSize: '12px',
+                      fontWeight: '600',
+                    }}
+                  >
+                    {t('station.settings.dx.udp.title', { defaultValue: 'UDP Spot Listener' })}
+                  </label>
+
+                  <div style={{ marginBottom: '12px' }}>
+                    <label
+                      style={{ display: 'block', marginBottom: '4px', color: 'var(--text-muted)', fontSize: '11px' }}
+                    >
+                      {t('station.settings.dx.udp.host', { defaultValue: 'UDP IP Address (optional)' })}
+                    </label>
+                    <input
+                      type="text"
+                      value={udpDxCluster.host}
+                      onChange={(e) => setUdpDxCluster({ ...udpDxCluster, host: e.target.value.trim() })}
+                      placeholder={t('station.settings.dx.udp.host.placeholder', {
+                        defaultValue: 'Leave blank unless a specific sender/multicast IP is required',
+                      })}
+                      style={{
+                        width: '100%',
+                        padding: '10px 12px',
+                        background: 'var(--bg-secondary)',
+                        border: '1px solid var(--border-color)',
+                        borderRadius: '6px',
+                        color: 'var(--text-primary)',
+                        fontSize: '14px',
+                        fontFamily: 'var(--font-mono)',
+                      }}
+                    />
+                  </div>
+
+                  <div style={{ marginBottom: '12px' }}>
+                    <label
+                      style={{ display: 'block', marginBottom: '4px', color: 'var(--text-muted)', fontSize: '11px' }}
+                    >
+                      {t('station.settings.dx.udp.port', { defaultValue: 'UDP Port' })}
+                    </label>
+                    <input
+                      type="number"
+                      value={udpDxCluster.port}
+                      onChange={(e) =>
+                        setUdpDxCluster({ ...udpDxCluster, port: parseInt(e.target.value, 10) || 12060 })
+                      }
+                      placeholder={t('station.settings.dx.udp.port.placeholder', { defaultValue: '12060' })}
+                      style={{
+                        width: '100%',
+                        padding: '10px 12px',
+                        background: 'var(--bg-secondary)',
+                        border: '1px solid var(--border-color)',
+                        borderRadius: '6px',
+                        color: 'var(--text-primary)',
+                        fontSize: '14px',
+                        fontFamily: 'var(--font-mono)',
+                      }}
+                    />
+                  </div>
+
+                  <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '8px' }}>
+                    {t('station.settings.dx.udp.help', {
+                      defaultValue:
+                        'OpenHamClock listens for UDP DX spot packets on this port and plots matched spots on the map.',
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {/* Custom DX Cluster Settings */}
+              {dxClusterSource === 'custom' && (
+                <div
+                  style={{
+                    marginBottom: '20px',
+                    padding: '16px',
+                    background: 'var(--bg-tertiary)',
+                    borderRadius: '8px',
+                    border: '1px solid var(--border-color)',
+                  }}
+                >
+                  <label
+                    style={{
+                      display: 'block',
+                      marginBottom: '12px',
+                      color: 'var(--accent-cyan)',
+                      fontSize: '12px',
+                      fontWeight: '600',
+                    }}
+                  >
+                    {t('station.settings.dx.custom.title')}
+                  </label>
+
+                  {/* Host */}
+                  <div style={{ marginBottom: '12px' }}>
+                    <label
+                      style={{ display: 'block', marginBottom: '4px', color: 'var(--text-muted)', fontSize: '11px' }}
+                    >
+                      {t('station.settings.dx.custom.host')}
+                    </label>
+                    <input
+                      type="text"
+                      value={customDxCluster.host}
+                      onChange={(e) => setCustomDxCluster({ ...customDxCluster, host: e.target.value })}
+                      placeholder={t('station.settings.dx.custom.host.placeholder')}
+                      style={{
+                        width: '100%',
+                        padding: '10px 12px',
+                        background: 'var(--bg-secondary)',
+                        border: '1px solid var(--border-color)',
+                        borderRadius: '6px',
+                        color: 'var(--text-primary)',
+                        fontSize: '14px',
+                        fontFamily: 'var(--font-mono)',
+                      }}
+                    />
+                  </div>
+
+                  {/* Port */}
+                  <div style={{ marginBottom: '12px' }}>
+                    <label
+                      style={{ display: 'block', marginBottom: '4px', color: 'var(--text-muted)', fontSize: '11px' }}
+                    >
+                      {t('station.settings.dx.custom.port')}
+                    </label>
+                    <input
+                      type="number"
+                      value={customDxCluster.port}
+                      onChange={(e) =>
+                        setCustomDxCluster({ ...customDxCluster, port: parseInt(e.target.value) || 7300 })
+                      }
+                      placeholder={t('station.settings.dx.custom.port.placeholder')}
+                      style={{
+                        width: '100%',
+                        padding: '10px 12px',
+                        background: 'var(--bg-secondary)',
+                        border: '1px solid var(--border-color)',
+                        borderRadius: '6px',
+                        color: 'var(--text-primary)',
+                        fontSize: '14px',
+                        fontFamily: 'var(--font-mono)',
+                      }}
+                    />
+                  </div>
+
+                  <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '8px' }}>
+                    {t('station.settings.dx.custom.callsign', { callsign: callsign || 'N0CALL' })}{' '}
+                    {t('station.settings.dx.custom.commonPorts')}
+                  </div>
+                  <div style={{ fontSize: '11px', color: 'var(--accent-amber)', marginTop: '8px' }}>
+                    {t('station.settings.dx.custom.warning')}
+                  </div>
+                </div>
+              )}
+
+              {/* Callbook for callsign lookups (#989) */}
+              <div style={{ marginBottom: '20px' }}>
+                <label
+                  htmlFor="callbook-select"
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  {t('station.settings.callbook.title')}
+                </label>
+                <select
+                  id="callbook-select"
+                  value={callbook}
+                  onChange={(e) => {
+                    const next = e.target.value;
+                    setCallbook(next);
+                    try {
+                      localStorage.setItem('ohc_callbook', next);
+                    } catch {}
+                    window.dispatchEvent(new Event('ohc-callbook-changed'));
+                  }}
+                  style={{
+                    width: '100%',
+                    padding: '12px',
+                    background: 'var(--bg-tertiary)',
+                    border: '1px solid var(--border-color)',
+                    borderRadius: '6px',
+                    color: 'var(--accent-green)',
+                    fontSize: '14px',
+                    fontFamily: 'var(--font-mono)',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {CALLBOOKS.map((cb) => (
+                    <option key={cb.id} value={cb.id}>
+                      {cb.label}
+                    </option>
+                  ))}
+                </select>
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
+                  {t('station.settings.callbook.describe')}
+                </div>
+              </div>
+
+              {/* Language */}
+              <div style={{ marginBottom: '20px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  ⊕ {t('station.settings.language')}
+                </label>
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '6px' }}>
+                  {LANGUAGES.map((lang) => (
+                    <button
+                      key={lang.code}
+                      onClick={() => i18n.changeLanguage(lang.code)}
+                      style={{
+                        padding: '8px 6px',
+                        background:
+                          i18n.language === lang.code || (i18n.language && i18n.language.startsWith(lang.code))
+                            ? 'rgba(0, 221, 255, 0.2)'
+                            : 'var(--bg-tertiary)',
+                        border: `1px solid ${
+                          i18n.language === lang.code || (i18n.language && i18n.language.startsWith(lang.code))
+                            ? 'var(--accent-cyan)'
+                            : 'var(--border-color)'
+                        }`,
+                        borderRadius: '6px',
+                        color:
+                          i18n.language === lang.code || (i18n.language && i18n.language.startsWith(lang.code))
+                            ? 'var(--accent-cyan)'
+                            : 'var(--text-secondary)',
+                        fontSize: '12px',
+                        cursor: 'pointer',
+                        fontWeight:
+                          i18n.language === lang.code || (i18n.language && i18n.language.startsWith(lang.code))
+                            ? '600'
+                            : '400',
+                        textAlign: 'center',
+                      }}
+                    >
+                      {(() => {
+                        const iso = emojiToIso2(lang.flag);
+                        return iso ? (
+                          <img
+                            src={`https://flagcdn.com/w20/${iso}.png`}
+                            alt=""
+                            style={{
+                              height: '0.9em',
+                              verticalAlign: 'middle',
+                              borderRadius: '1px',
+                              marginRight: '4px',
+                            }}
+                            crossOrigin="anonymous"
+                          />
+                        ) : (
+                          <span style={{ marginRight: '4px' }}>{lang.flag}</span>
+                        );
+                      })()}
+                      {lang.name}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Integrations Tab */}
+        <div
+          role="tabpanel"
+          id="panel-settings-integrations"
+          aria-labelledby="tab-settings-integrations"
+          hidden={activeTab !== 'integrations'}
+        >
+          {activeTab === 'integrations' && (
+            <div>
+              {/* Status pill */}
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 12,
+                  marginBottom: 16,
+                  padding: '10px 14px',
+                  borderRadius: 10,
+                  border: '1px solid var(--border-color)',
+                  background: 'var(--bg-tertiary)',
+                }}
+              >
+                <div style={{ color: 'var(--text-secondary)', fontSize: 12 }}>
+                  These features require a local OpenHamClock instance.
+                </div>
+                <div
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 11,
+                    padding: '4px 10px',
+                    borderRadius: 999,
+                    border: `1px solid ${isLocalInstall ? 'var(--accent-cyan)' : 'rgba(255,255,255,0.18)'}`,
+                    color: isLocalInstall ? 'var(--accent-cyan)' : 'var(--text-muted)',
+                    background: isLocalInstall ? 'rgba(0,255,255,0.10)' : 'rgba(0,0,0,0.25)',
+                  }}
+                >
+                  {isLocalInstall ? 'Local mode' : 'Hosted mode'}
+                </div>
+              </div>
+
+              {/* Local-only group */}
+              <div
+                style={{
+                  background: 'rgba(0, 255, 255, 0.05)',
+                  border: '1px solid var(--border-color)',
+                  borderRadius: '10px',
+                  padding: '14px 16px',
+                  marginBottom: 16,
+                }}
+              >
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'baseline',
+                    justifyContent: 'space-between',
+                    gap: 12,
+                    marginBottom: 10,
+                  }}
+                >
+                  <div>
+                    <div style={{ color: 'var(--accent-cyan)', fontWeight: 800, letterSpacing: 0.2 }}>Local-only</div>
+                    <div style={{ color: 'var(--text-secondary)', fontSize: 12, lineHeight: 1.45, marginTop: 4 }}>
+                      These integrations are disabled on the hosted site so they can never crash or spam the network.
+                    </div>
+                  </div>
+                </div>
+
+                {/* Rotator */}
+                <div
+                  style={{
+                    borderTop: '1px solid rgba(255,255,255,0.08)',
+                    paddingTop: 12,
+                    marginTop: 8,
+                  }}
+                >
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
+                    <div>
+                      <div style={{ fontWeight: 700, color: 'var(--text-primary)' }}>🧭 Rotator</div>
+                      <div style={{ color: 'var(--text-secondary)', fontSize: 12, lineHeight: 1.45 }}>
+                        Requires a rotator backend (e.g., PstRotatorAz or a simple HTTP bridge) reachable by your local
+                        OpenHamClock Node server.
+                      </div>
+                    </div>
+
+                    <label
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 8,
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 12,
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        disabled={!isLocalInstall}
+                        checked={!!rotatorEnabled && isLocalInstall}
+                        onChange={(e) => {
+                          const next = !!e.target.checked;
+                          setRotatorEnabled(next);
+                          try {
+                            localStorage.setItem('ohc_rotator_enabled', next ? '1' : '0');
+                          } catch {}
+                          // Default overlay OFF when enabling (hosted-safe + predictable)
+                          if (next) {
+                            try {
+                              const raw = localStorage.getItem('openhamclock_mapLayers') || '{}';
+                              const ml = JSON.parse(raw);
+                              ml.showRotatorBearing = false;
+                              localStorage.setItem('openhamclock_mapLayers', JSON.stringify(ml));
+                            } catch {}
+                          }
+                          try {
+                            window.dispatchEvent(new Event('ohc-rotator-config-changed'));
+                          } catch {}
+                        }}
+                      />
+                      Enable
+                    </label>
+                  </div>
+
+                  <details style={{ marginTop: 10 }}>
+                    <summary
+                      style={{
+                        cursor: 'pointer',
+                        color: 'var(--accent-amber)',
+                        fontSize: 12,
+                        userSelect: 'none',
+                      }}
+                    >
+                      Learn how
+                    </summary>
+
+                    <div
+                      style={{
+                        marginTop: 8,
+                        color: 'var(--text-secondary)',
+                        fontSize: 12,
+                        lineHeight: 1.55,
+                      }}
+                    >
+                      <div style={{ marginBottom: 6 }}>
+                        <b>Quick start (Local Only):</b>
+                      </div>
+
+                      <ol style={{ margin: 0, paddingLeft: 18 }}>
+                        <li>
+                          Run OpenHamClock locally:
+                          <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>npm start</div>
+                          Open the local URL shown in your terminal (example: http://127.0.0.1:3001).
+                        </li>
+
+                        <li style={{ marginTop: 6 }}>
+                          Install and configure <b>PstRotatorAz</b> (or another rotator backend) on your LAN.
+                          <div style={{ marginTop: 4 }}>Enable and start its control interface (web/UDP).</div>
+                        </li>
+
+                        <li style={{ marginTop: 6 }}>
+                          In the OpenHamClock folder:
+                          <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>copy .env.example → .env</div>
+                          Then edit:
+                          <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>
+                            VITE_PSTROTATOR_TARGET=http://192.168.1.43:50004
+                          </div>
+                          (Replace with the IP and port of your PstRotatorAz machine.)
+                        </li>
+
+                        <li style={{ marginTop: 6 }}>Ensure Windows Firewall allows the PstRotatorAz port.</li>
+
+                        <li style={{ marginTop: 6 }}>
+                          Enable Rotator here, then add the <b>Rotator</b> panel using the “+” button on any tabset.
+                        </li>
+                      </ol>
+
+                      <div style={{ marginTop: 10, fontSize: 11, color: 'var(--text-muted)' }}>
+                        Tip: Click <b>MAP ON</b> inside the Rotator panel to show the bearing overlay. Hold <b>Shift</b>{' '}
+                        and click the map to rotate your antenna to that heading.
+                      </div>
+
+                      <div style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
+                        Note: This feature cannot work on the hosted site because it requires access to devices on your
+                        local network.
+                      </div>
+                    </div>
+                  </details>
+
+                  {/* DX Weather (Map overlays) */}
+                  <div
+                    style={{
+                      borderTop: '1px solid rgba(255,255,255,0.08)',
+                      paddingTop: 12,
+                      marginTop: 12,
+                    }}
+                  >
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
+                      <div>
+                        <div style={{ fontWeight: 700, color: 'var(--text-primary)' }}>🌦️ DX Weather</div>
+                        <div style={{ color: 'var(--text-secondary)', fontSize: 12, lineHeight: 1.45 }}>
+                          Adds a small weather bubble on hover and weather details inside map popups (DX spots,
+                          POTA/SOTA, and the movable DX marker).
+                        </div>
+
+                        {!isLocalInstall && (
+                          <div style={{ marginTop: 6, color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.45 }}>
+                            Hosted mode disables this feature to protect shared weather-provider rate limits. Available
+                            in Local mode.
+                          </div>
+                        )}
+                      </div>
+
+                      <label
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 8,
+                          fontFamily: 'var(--font-mono)',
+                          fontSize: 12,
+                        }}
+                      >
+                        <input
+                          type="checkbox"
+                          disabled={!isLocalInstall}
+                          checked={!!dxWeatherEnabled}
+                          onChange={(e) => {
+                            const next = !!e.target.checked;
+                            if (!isLocalInstall) return;
+                            setDxWeatherEnabled(next);
+                            try {
+                              localStorage.setItem('ohc_dx_weather_enabled', next ? '1' : '0');
+                            } catch {}
+                            try {
+                              window.dispatchEvent(new Event('ohc-dx-weather-config-changed'));
+                            } catch {}
+                          }}
+                        />
+                        Enable
+                      </label>
+                    </div>
+
+                    <div style={{ marginTop: 10, color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.45 }}>
+                      Tip: A 5–10 minute cache is used automatically and hover fetches are debounced.
+                    </div>
+                  </div>
+
+                  {!isLocalInstall && (
+                    <div
+                      style={{
+                        marginTop: 8,
+                        color: 'var(--text-muted)',
+                        fontSize: 11,
+                      }}
+                    >
+                      Hosted mode detected — Rotator cannot be enabled here.
+                    </div>
+                  )}
+                </div>
+
+                {/* N3FJP */}
+                <div
+                  style={{
+                    borderTop: '1px solid rgba(255,255,255,0.08)',
+                    paddingTop: 12,
+                    marginTop: 14,
+                  }}
+                >
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
+                    <div>
+                      <div style={{ fontWeight: 700, color: 'var(--text-primary)' }}>🗺️ N3FJP Logged QSOs</div>
+                      <div style={{ color: 'var(--text-secondary)', fontSize: 12, lineHeight: 1.45 }}>
+                        Shows recent QSOs posted by your local N3FJP→OHC bridge (layer overlay).
+                      </div>
+                    </div>
+
+                    <label
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 8,
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 12,
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        disabled={!isLocalInstall}
+                        checked={!!n3fjpEnabled && isLocalInstall}
+                        onChange={(e) => {
+                          const next = !!e.target.checked;
+                          setN3fjpEnabled(next);
+                          try {
+                            localStorage.setItem('ohc_n3fjp_enabled', next ? '1' : '0');
+                          } catch {}
+                          try {
+                            window.dispatchEvent(new Event('ohc-n3fjp-config-changed'));
+                          } catch {}
+
+                          // ✅ Also toggle the map layer automatically
+                          try {
+                            // Preferred: uses live WorldMap controls (updates state + localStorage)
+                            if (window.hamclockLayerControls?.toggleLayer) {
+                              window.hamclockLayerControls.toggleLayer('n3fjp_logged_qsos', next);
+                            } else {
+                              // Fallback: write the plugin-layer setting directly
+                              const raw = localStorage.getItem('openhamclock_mapSettings') || '{}';
+                              const settings = JSON.parse(raw);
+                              const layers = settings.layers || {};
+                              layers['n3fjp_logged_qsos'] = { ...(layers['n3fjp_logged_qsos'] || {}), enabled: next };
+                              settings.layers = layers;
+                              localStorage.setItem('openhamclock_mapSettings', JSON.stringify(settings));
+                            }
+                          } catch {}
+                        }}
+                      />
+                      Enable
+                    </label>
+                  </div>
+
+                  {/* Simple config */}
+                  <div style={{ display: 'flex', gap: 10, marginTop: 10, flexWrap: 'wrap' }}>
+                    <div style={{ flex: '1 1 160px' }}>
+                      <label
+                        style={{
+                          display: 'block',
+                          marginBottom: 6,
+                          color: 'var(--text-muted)',
+                          fontSize: 11,
+                          textTransform: 'uppercase',
+                          letterSpacing: 1,
+                        }}
+                      >
+                        Display window
+                      </label>
+                      <select
+                        disabled={!isLocalInstall || !n3fjpEnabled}
+                        value={n3fjpDisplayMinutes}
+                        onChange={(e) => {
+                          const v = parseInt(e.target.value, 10);
+                          const next = Number.isFinite(v) ? v : 15;
+                          setN3fjpDisplayMinutes(next);
+                          try {
+                            localStorage.setItem('n3fjp_display_minutes', String(next));
+                          } catch {}
+                          try {
+                            window.dispatchEvent(new Event('ohc-n3fjp-config-changed'));
+                          } catch {}
+                        }}
+                        style={{
+                          width: '100%',
+                          padding: '10px 12px',
+                          background: 'var(--bg-secondary)',
+                          border: '1px solid var(--border-color)',
+                          borderRadius: '6px',
+                          color: 'var(--text-primary)',
+                          fontSize: '14px',
+                          fontFamily: 'var(--font-mono)',
+                        }}
+                      >
+                        {[15, 30, 60, 120, 240, 720, 1440].map((m) => (
+                          <option key={m} value={m}>
+                            {m === 60 ? '1 hour' : m < 60 ? `${m} min` : `${m / 60} hours`}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div style={{ flex: '0 0 120px' }}>
+                      <label
+                        style={{
+                          display: 'block',
+                          marginBottom: 6,
+                          color: 'var(--text-muted)',
+                          fontSize: 11,
+                          textTransform: 'uppercase',
+                          letterSpacing: 1,
+                        }}
+                      >
+                        Line color
+                      </label>
+                      <input
+                        disabled={!isLocalInstall || !n3fjpEnabled}
+                        type="color"
+                        value={n3fjpLineColor}
+                        onChange={(e) => {
+                          const next = e.target.value || '#3388ff';
+                          setN3fjpLineColor(next);
+                          try {
+                            localStorage.setItem('n3fjp_line_color', next);
+                          } catch {}
+                          try {
+                            window.dispatchEvent(new Event('ohc-n3fjp-config-changed'));
+                          } catch {}
+                        }}
+                        style={{
+                          width: '100%',
+                          height: 40,
+                          padding: 0,
+                          border: '1px solid var(--border-color)',
+                          borderRadius: 6,
+                          background: 'transparent',
+                        }}
+                      />
+                    </div>
+
+                    <div style={{ flex: '0 0 120px' }}>
+                      <label
+                        style={{
+                          display: 'block',
+                          marginBottom: 6,
+                          color: 'var(--text-muted)',
+                          fontSize: 11,
+                          textTransform: 'uppercase',
+                          letterSpacing: 1,
+                        }}
+                      >
+                        Preview color
+                      </label>
+                      <input
+                        disabled={!isLocalInstall || !n3fjpEnabled}
+                        type="color"
+                        value={n3fjpPreviewLineColor}
+                        onChange={(e) => {
+                          const next = e.target.value || '#ffaa00';
+                          setN3fjpPreviewLineColor(next);
+                          try {
+                            localStorage.setItem('n3fjp_preview_line_color', next);
+                          } catch {}
+                          try {
+                            window.dispatchEvent(new Event('ohc-n3fjp-config-changed'));
+                          } catch {}
+                        }}
+                        style={{
+                          width: '100%',
+                          height: 40,
+                          padding: 0,
+                          border: '1px solid var(--border-color)',
+                          borderRadius: 6,
+                          background: 'transparent',
+                        }}
+                      />
+                    </div>
+                  </div>
+
+                  <details style={{ marginTop: 10 }}>
+                    <summary
+                      style={{
+                        cursor: 'pointer',
+                        color: 'var(--accent-amber)',
+                        fontSize: 12,
+                        userSelect: 'none',
+                      }}
+                    >
+                      Learn how
+                    </summary>
+
+                    <div
+                      style={{
+                        marginTop: 8,
+                        color: 'var(--text-secondary)',
+                        fontSize: 12,
+                        lineHeight: 1.55,
+                      }}
+                    >
+                      <div style={{ marginBottom: 6 }}>
+                        <b>Quick start (Local Only):</b>
+                      </div>
+
+                      <ol style={{ margin: 0, paddingLeft: 18 }}>
+                        <li>
+                          Run OpenHamClock locally:
+                          <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>npm start</div>
+                          Open the local URL shown in your terminal (example: http://127.0.0.1:3001).
+                        </li>
+
+                        <li style={{ marginTop: 6 }}>
+                          Install the N3FJP bridge on the same PC (or LAN machine) that can access your N3FJP logger.
+                        </li>
+
+                        <li style={{ marginTop: 6 }}>
+                          Edit the bridge <b>config.json</b> file and set:
+                          <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>
+                            "OHC_BASE_URL": "http://127.0.0.1:3001"
+                          </div>
+                          (Use the exact URL printed by OpenHamClock.)
+                        </li>
+
+                        <li style={{ marginTop: 6 }}>
+                          Ensure:
+                          <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>"ENABLE_OHC_HTTP": true</div>
+                        </li>
+
+                        <li style={{ marginTop: 6 }}>
+                          Start the bridge script (PowerShell or VBS launcher). You should see log messages when QSOs
+                          are entered.
+                        </li>
+
+                        <li style={{ marginTop: 6 }}>
+                          Enable this integration here, then turn on
+                          <b> Logged QSOs (N3FJP)</b> in
+                          <b> Settings → Map Layers</b>.
+                        </li>
+                      </ol>
+
+                      <div style={{ marginTop: 10, fontSize: 11, color: 'var(--text-muted)' }}>
+                        Tip: If you see “connection refused,” verify that OpenHamClock is running locally and that the
+                        port matches your
+                        <b> OHC_BASE_URL</b> setting.
+                      </div>
+
+                      <div style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
+                        Note: This integration cannot work on the hosted site because it requires access to your local
+                        N3FJP logger and LAN services.
+                      </div>
+                    </div>
+                  </details>
+                </div>
+
+                {/* QRZ.com XML API Credentials */}
+                <div
+                  style={{
+                    borderTop: '1px solid rgba(255,255,255,0.08)',
+                    paddingTop: 12,
+                    marginTop: 14,
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: '12px',
+                      fontWeight: '600',
+                      color: 'var(--accent-amber)',
+                      marginBottom: '4px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '8px',
+                    }}
+                  >
+                    <span>📡 QRZ.com Callsign Lookup</span>
+                    {qrzStatus?.configured && (
+                      <span
+                        style={{
+                          fontSize: '10px',
+                          fontWeight: '500',
+                          padding: '1px 6px',
+                          borderRadius: '3px',
+                          background: qrzStatus.hasSession ? 'rgba(46, 204, 113, 0.15)' : 'rgba(241, 196, 15, 0.15)',
+                          color: qrzStatus.hasSession ? '#2ecc71' : '#f1c40f',
+                        }}
+                      >
+                        {qrzStatus.hasSession ? '● Connected' : '○ Configured'}
+                        {qrzStatus.source === 'env' ? ' (env)' : ''}
+                      </span>
+                    )}
+                  </div>
+                  <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '8px', lineHeight: 1.4 }}>
+                    Enables precise station locations from{' '}
+                    <a
+                      href="https://www.qrz.com/i/subscriptions.html"
+                      target="_blank"
+                      rel="noopener"
+                      style={{ color: 'var(--accent-blue)' }}
+                    >
+                      QRZ.com
+                    </a>{' '}
+                    user profiles (user-supplied coordinates, geocoded addresses, grid squares). Without this, locations
+                    fall back to HamQTH (country-level only). Requires a QRZ Logbook Data subscription.
+                    <br />
+                    <strong>Note</strong> this is a server setting and is not related to clicking a callsign to go to
+                    qrz.com. If you are not running a server, you will likely not have the permissions to change this.
+                  </div>
+                  {qrzStatus?.source === 'env' ? (
+                    <div
+                      style={{
+                        fontSize: '11px',
+                        color: 'var(--text-muted)',
+                        padding: '8px',
+                        background: 'var(--bg-primary)',
+                        borderRadius: '4px',
+                      }}
+                    >
+                      ✓ Credentials configured via{' '}
+                      <code style={{ background: 'var(--bg-tertiary)', padding: '1px 4px', borderRadius: '2px' }}>
+                        QRZ_USERNAME
+                      </code>{' '}
+                      /{' '}
+                      <code style={{ background: 'var(--bg-tertiary)', padding: '1px 4px', borderRadius: '2px' }}>
+                        QRZ_PASSWORD
+                      </code>{' '}
+                      in .env file
+                      {qrzStatus.lookupCount > 0 && (
+                        <span style={{ color: 'var(--accent-green)' }}>
+                          {' '}
+                          — {qrzStatus.lookupCount} lookups this session
+                        </span>
+                      )}
+                    </div>
+                  ) : (
+                    <>
+                      <div style={{ display: 'flex', gap: '8px', marginBottom: '8px' }}>
+                        <input
+                          disabled={!isLocalInstall}
+                          type="text"
+                          placeholder="QRZ Username (callsign)"
+                          value={qrzUsername}
+                          onChange={(e) => setQrzUsername(e.target.value)}
+                          style={{
+                            flex: 1,
+                            padding: '8px 12px',
+                            background: 'var(--bg-primary)',
+                            border: '1px solid var(--border-color)',
+                            borderRadius: '4px',
+                            color: 'var(--text-primary)',
+                            fontSize: '12px',
+                            fontFamily: 'var(--font-mono)',
+                            boxSizing: 'border-box',
+                          }}
+                        />
+                        <input
+                          disabled={!isLocalInstall}
+                          type="password"
+                          placeholder="QRZ Password"
+                          value={qrzPassword}
+                          onChange={(e) => setQrzPassword(e.target.value)}
+                          style={{
+                            flex: 1,
+                            padding: '8px 12px',
+                            background: 'var(--bg-primary)',
+                            border: '1px solid var(--border-color)',
+                            borderRadius: '4px',
+                            color: 'var(--text-primary)',
+                            fontSize: '12px',
+                            fontFamily: 'var(--font-mono)',
+                            boxSizing: 'border-box',
+                          }}
+                        />
+                      </div>
+                      <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                        <button
+                          disabled={!isLocalInstall || qrzTesting || !qrzUsername.trim() || !qrzPassword.trim()}
+                          onClick={async () => {
+                            setQrzTesting(true);
+                            setQrzMessage(null);
+                            try {
+                              const res = await fetch('/api/qrz/configure', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ username: qrzUsername.trim(), password: qrzPassword.trim() }),
+                              });
+                              const data = await res.json();
+                              if (data.success) {
+                                setQrzMessage({ type: 'success', text: 'Connected to QRZ.com successfully!' });
+                                setQrzPassword('');
+                                // Refresh status
+                                const st = await fetch('/api/qrz/status').then((r) => r.json());
+                                setQrzStatus(st);
+                              } else {
+                                setQrzMessage({ type: 'error', text: data.error || 'Login failed' });
+                              }
+                            } catch (e) {
+                              setQrzMessage({ type: 'error', text: 'Connection error' });
+                            }
+                            setQrzTesting(false);
+                          }}
+                          style={{
+                            padding: '6px 14px',
+                            fontSize: '11px',
+                            fontWeight: '600',
+                            borderRadius: '4px',
+                            border: 'none',
+                            cursor:
+                              qrzTesting || !qrzUsername.trim() || !qrzPassword.trim() ? 'not-allowed' : 'pointer',
+                            background: 'var(--accent-amber)',
+                            color: '#000',
+                            opacity: qrzTesting || !qrzUsername.trim() || !qrzPassword.trim() ? 0.5 : 1,
+                          }}
+                        >
+                          {qrzTesting ? 'Testing...' : 'Save & Test'}
+                        </button>
+                        {qrzStatus?.configured && qrzStatus.source !== 'env' && (
+                          <button
+                            onClick={async () => {
+                              await fetch('/api/qrz/remove', { method: 'POST' });
+                              setQrzUsername('');
+                              setQrzPassword('');
+                              setQrzMessage(null);
+                              const st = await fetch('/api/qrz/status').then((r) => r.json());
+                              setQrzStatus(st);
+                            }}
+                            style={{
+                              padding: '6px 12px',
+                              fontSize: '11px',
+                              borderRadius: '4px',
+                              border: '1px solid var(--border-color)',
+                              cursor: 'pointer',
+                              background: 'transparent',
+                              color: 'var(--text-muted)',
+                            }}
+                          >
+                            Remove
+                          </button>
+                        )}
+                        {qrzStatus?.configured && qrzStatus.lookupCount > 0 && (
+                          <span style={{ fontSize: '10px', color: 'var(--text-muted)' }}>
+                            {qrzStatus.lookupCount} lookups this session
+                          </span>
+                        )}
+                      </div>
+                      {qrzMessage && (
+                        <div
+                          style={{
+                            marginTop: '6px',
+                            fontSize: '11px',
+                            padding: '6px 10px',
+                            borderRadius: '4px',
+                            background:
+                              qrzMessage.type === 'success' ? 'rgba(46, 204, 113, 0.1)' : 'rgba(231, 76, 60, 0.1)',
+                            color: qrzMessage.type === 'success' ? '#2ecc71' : '#e74c3c',
+                          }}
+                        >
+                          {qrzMessage.type === 'success' ? '✓' : '✗'} {qrzMessage.text}
+                        </div>
+                      )}
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Display Tab */}
+        <div
+          role="tabpanel"
+          id="panel-settings-display"
+          aria-labelledby="tab-settings-display"
+          hidden={activeTab !== 'display'}
+        >
+          {activeTab === 'display' && (
+            <div>
+              {/* Header Sizing */}
+              <div style={{ marginBottom: '24px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  Header Size
+                </label>
+
+                {/* Live preview of header text at current scale */}
+                <div
+                  style={{
+                    background: 'var(--bg-panel)',
+                    border: '1px solid var(--border-color)',
+                    borderRadius: '6px',
+                    padding: '8px 12px',
+                    marginBottom: '10px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '12px',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <span
+                    style={{
+                      fontFamily: 'Orbitron, monospace',
+                      fontWeight: 900,
+                      color: 'var(--accent-amber)',
+                      fontSize: `${22 * headerSize}px`,
+                      lineHeight: 1.2,
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {callsign || 'K0CJH'}
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: 'var(--font-mono)',
+                      fontWeight: 700,
+                      color: 'var(--accent-cyan)',
+                      fontSize: `${24 * headerSize}px`,
+                      lineHeight: 1.2,
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    14:32
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: `${13 * headerSize}px`,
+                      color: 'var(--text-muted)',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    SFI 158
+                  </span>
+                </div>
+
+                {/* Slider */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                  <span style={{ fontSize: '11px', color: 'var(--text-muted)', whiteSpace: 'nowrap' }}>Small</span>
+                  <input
+                    type="range"
+                    min="0.5"
+                    max="4"
+                    step="0.1"
+                    value={headerSize}
+                    onChange={(e) => setheaderSize(parseFloat(e.target.value))}
+                    style={{ flex: 1, accentColor: 'var(--accent-amber)' }}
+                  />
+                  <span style={{ fontSize: '11px', color: 'var(--text-muted)', whiteSpace: 'nowrap' }}>Large</span>
+                </div>
+                <div
+                  style={{
+                    textAlign: 'center',
+                    fontSize: '12px',
+                    color: 'var(--accent-amber)',
+                    fontWeight: 600,
+                    fontFamily: 'var(--font-mono)',
+                    marginTop: '4px',
+                  }}
+                >
+                  {Number(headerSize).toFixed(1)}x
+                </div>
+              </div>
+
+              {/* Clock Order */}
+              <div style={{ marginBottom: '24px' }}>
+                <label
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '10px',
+                    cursor: 'pointer',
+                    fontSize: '13px',
+                    color: 'var(--text-primary)',
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={swapHeaderClocks}
+                    onChange={(e) => setSwapHeaderClocks(e.target.checked)}
+                    style={{ accentColor: 'var(--accent-amber)' }}
+                  />
+                  Show Local Time before UTC in header
+                </label>
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
+                  By default, UTC is shown first. Enable this to display Local Time first.
+                </div>
+              </div>
+
+              {/* Display Whats New on Startup */}
+              <div style={{ marginBottom: '24px' }}>
+                <label
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '10px',
+                    cursor: 'pointer',
+                    fontSize: '13px',
+                    color: 'var(--text-primary)',
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={showWhatsNew}
+                    onChange={(e) => {
+                      config.showWhatsNew = e.target.checked;
+                      setShowWhatsNew(e.target.checked);
+                    }}
+                    style={{ accentColor: 'var(--accent-amber)' }}
+                  />
+                  Show What's New on Startup
+                </label>
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
+                  By default (when checked), What's New is displayed. Unchecking this means it will only be displayed
+                  when the version is clicked.
+                </div>
+              </div>
+
+              {/* Mutual Reception Indicator */}
+              <div style={{ marginBottom: '24px' }}>
+                <label
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '10px',
+                    cursor: 'pointer',
+                    fontSize: '13px',
+                    color: 'var(--text-primary)',
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={showMutualReception}
+                    onChange={(e) => setShowMutualReception(e.target.checked)}
+                    style={{ accentColor: 'var(--accent-amber)' }}
+                  />
+                  Show mutual reception indicator on PSK Reporter spots
+                </label>
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
+                  Marks spots with a gold star (★) when a station hears you AND you hear them on the same band,
+                  indicating a QSO is likely possible.
+                </div>
+              </div>
+
+              {/* Layout */}
+              <div style={{ marginBottom: '24px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  {t('station.settings.layout')}
+                </label>
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '8px' }}>
+                  {['modern', 'classic', 'tablet', 'compact', 'dockable', 'emcomm'].map((l) => (
+                    <button
+                      key={l}
+                      onClick={() => setLayout(l)}
+                      style={{
+                        padding: '10px',
+                        background: layout === l ? 'var(--accent-amber)' : 'var(--bg-tertiary)',
+                        border: `1px solid ${layout === l ? 'var(--accent-amber)' : 'var(--border-color)'}`,
+                        borderRadius: '6px',
+                        color: layout === l ? '#000' : 'var(--text-secondary)',
+                        fontSize: '12px',
+                        cursor: 'pointer',
+                        fontWeight: layout === l ? '600' : '400',
+                      }}
+                    >
+                      {l === 'modern'
+                        ? '🖥️'
+                        : l === 'classic'
+                          ? '📺'
+                          : l === 'tablet'
+                            ? '📱'
+                            : l === 'compact'
+                              ? '📊'
+                              : l === 'emcomm'
+                                ? '📍'
+                                : '⊞'}{' '}
+                      {l === 'dockable' ? t('station.settings.layout.dockable') : t('station.settings.layout.' + l)}
+                    </button>
+                  ))}
+                </div>
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
+                  {layoutDescriptions[layout]}
+                </div>
+                {layout === 'dockable' && onResetLayout && (
+                  <button
+                    onClick={() => {
+                      if (confirm(t('station.settings.layout.reset.confirm'))) {
+                        onResetLayout();
+                      }
+                    }}
+                    style={{
+                      marginTop: '10px',
+                      padding: '8px 12px',
+                      background: 'var(--bg-tertiary)',
+                      border: '1px solid var(--border-color)',
+                      borderRadius: '6px',
+                      color: 'var(--text-secondary)',
+                      fontSize: '12px',
+                      cursor: 'pointer',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '6px',
+                    }}
+                  >
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                      <path d="M3 3v5h5" />
+                    </svg>
+                    {t('station.settings.layout.reset.button')}
+                  </button>
+                )}
+              </div>
+
+              {/* Theme */}
+              <div style={{ marginBottom: '8px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  {t('station.settings.theme')}
+                </label>
+                <ThemeSelector theme={theme} setTheme={setTheme} id="theme-selector-component" />
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
+                  {t('station.settings.theme.' + theme + '.describe')}
+                </div>
+                {theme === 'custom' && customTheme && (
+                  <CustomThemeEditor
+                    customTheme={customTheme}
+                    updateCustomVar={updateCustomVar}
+                    id="custom-theme-editor-component"
+                  />
+                )}
+              </div>
+
+              {/* Monospace font selector (#923 — 0/8 readability) */}
+              <div style={{ marginBottom: '8px' }}>
+                <label
+                  htmlFor="mono-font-select"
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--text-muted)',
+                    fontSize: '11px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                  }}
+                >
+                  {t('station.settings.monoFont')}
+                </label>
+                <select
+                  id="mono-font-select"
+                  value={monoFont}
+                  onChange={(e) => {
+                    const next = e.target.value;
+                    setMonoFont(next);
+                    try {
+                      localStorage.setItem('openhamclock_monoFont', next);
+                    } catch {}
+                    document.documentElement.style.setProperty('--font-mono', next);
+                  }}
+                  style={{
+                    width: '100%',
+                    background: 'var(--bg-tertiary)',
+                    color: 'var(--text-primary)',
+                    border: '1px solid var(--border-color)',
+                    borderRadius: '4px',
+                    padding: '6px 8px',
+                    fontFamily: monoFont,
+                    fontSize: '12px',
+                  }}
+                >
+                  <option value="'JetBrains Mono', monospace">JetBrains Mono — default (dotted 0)</option>
+                  <option value="'Fira Code', monospace">Fira Code — slashed 0</option>
+                  <option value="'IBM Plex Mono', monospace">IBM Plex Mono — slashed 0, wider</option>
+                </select>
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
+                  {t('station.settings.monoFont.describe')}
+                </div>
+                <div
+                  style={{
+                    fontFamily: monoFont,
+                    fontSize: '14px',
+                    marginTop: '8px',
+                    padding: '6px 10px',
+                    background: 'var(--bg-tertiary)',
+                    border: '1px solid var(--border-color)',
+                    borderRadius: '4px',
+                    letterSpacing: '0.05em',
+                  }}
+                >
+                  0 8 O 1 l I — 14.074 MHz — W1AW/0 K8O
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Map Layers Tab */}
+        <div
+          role="tabpanel"
+          id="panel-settings-layers"
+          aria-labelledby="tab-settings-layers"
+          hidden={activeTab !== 'layers'}
+        >
+          {activeTab === 'layers' && (
+            <div>
+              {(() => {
+                const togglePanelVisible = (panelKey) => {
+                  const panels = { ...config.panels };
+                  panels[panelKey] = { ...panels[panelKey], visible: !(panels[panelKey]?.visible !== false) };
+                  onSave({ ...config, panels });
+                };
+
+                const overlayCards = [
+                  {
+                    id: 'de-dx-markers',
+                    checked: mapLayers?.showDeDxMarkers !== false,
+                    onChange: () => onToggleDeDxMarkers?.(),
+                    icon: '📍',
+                    title: 'DE/DX Markers',
+                    description: 'Show or hide your DE and DX position markers on the map',
+                  },
+                  {
+                    id: 'dx-target-panel',
+                    checked: config.panels?.dxLocation?.visible !== false,
+                    onChange: () => togglePanelVisible('dxLocation'),
+                    icon: '🎯',
+                    title: 'DX Target Panel',
+                    description: 'Show or hide the DX target info panel (grid, bearing, sun times)',
+                  },
+                  {
+                    id: 'dx-news-ticker',
+                    checked: mapLayers?.showDXNews !== false,
+                    onChange: () => onToggleDXNews?.(),
+                    icon: '📰',
+                    title: 'DX News Ticker',
+                    description: 'Scrolling DX news headlines on the map',
+                  },
+                ];
+                return (() => {
+                  const categoryOrder = [
+                    { key: 'overlay', label: '🗺️ Map Overlays' },
+                    { key: 'propagation', label: '📡 Propagation' },
+                    { key: 'amateur', label: '📻 Amateur Radio' },
+                    { key: 'weather', label: '🌤️ Weather' },
+                    { key: 'space-weather', label: '☀️ Space Weather' },
+                    { key: 'hazards', label: '⚠️ Natural Hazards' },
+                    { key: 'geology', label: '🌍 Geology' },
+                    { key: 'fun', label: '🎉 Community' },
+                  ];
+
+                  const nonSatLayers = layers.filter((l) => l.category !== 'satellites');
+                  const grouped = {};
+                  nonSatLayers.forEach((l) => {
+                    const cat = l.category || 'overlay';
+                    if (!grouped[cat]) grouped[cat] = [];
+                    grouped[cat].push(l);
+                  });
+                  Object.values(grouped).forEach((arr) =>
+                    arr.sort((a, b) => {
+                      const nameA = (a.name.startsWith('plugins.') ? t(a.name) : a.name).toLowerCase();
+                      const nameB = (b.name.startsWith('plugins.') ? t(b.name) : b.name).toLowerCase();
+                      return nameA.localeCompare(nameB);
+                    }),
+                  );
+
+                  const renderBuiltInOverlayCard = (item) => (
+                    <div
+                      key={item.id}
+                      style={{
+                        background: 'var(--bg-tertiary)',
+                        border: `1px solid ${item.checked ? 'var(--accent-amber)' : 'var(--border-color)'}`,
+                        borderRadius: '8px',
+                        padding: '14px',
+                        marginBottom: '12px',
+                      }}
+                    >
+                      <label style={{ display: 'flex', alignItems: 'center', gap: '10px', cursor: 'pointer' }}>
+                        <input
+                          type="checkbox"
+                          checked={item.checked}
+                          onChange={item.onChange}
+                          style={{ width: '18px', height: '18px', cursor: 'pointer' }}
+                        />
+                        <span style={{ fontSize: '18px' }}>{item.icon}</span>
+                        <div>
+                          <div
+                            style={{
+                              color: item.checked ? 'var(--accent-amber)' : 'var(--text-primary)',
+                              fontSize: '14px',
+                              fontWeight: '600',
+                              fontFamily: 'var(--font-mono)',
+                            }}
+                          >
+                            {item.title}
+                          </div>
+                          <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '2px' }}>
+                            {item.description}
+                          </div>
+                        </div>
+                      </label>
+                    </div>
+                  );
+
+                  const renderLayerCard = (layer) => (
+                    <div
+                      key={layer.id}
+                      style={{
+                        background: 'var(--bg-tertiary)',
+                        border: `1px solid ${layer.enabled ? 'var(--accent-amber)' : 'var(--border-color)'}`,
+                        borderRadius: '8px',
+                        padding: '14px',
+                        marginBottom: '12px',
+                      }}
+                    >
+                      <div
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'space-between',
+                          marginBottom: '8px',
+                        }}
+                      >
+                        <label
+                          style={{ display: 'flex', alignItems: 'center', gap: '10px', cursor: 'pointer', flex: 1 }}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={layer.enabled}
+                            onChange={() => handleToggleLayer(layer.id)}
+                            style={{ width: '18px', height: '18px', cursor: 'pointer' }}
+                          />
+                          <span style={{ fontSize: '18px' }}>{layer.icon}</span>
+                          <div>
+                            <div
+                              style={{
+                                color: layer.enabled ? 'var(--accent-amber)' : 'var(--text-primary)',
+                                fontSize: '14px',
+                                fontWeight: '600',
+                                fontFamily: 'var(--font-mono)',
+                              }}
+                            >
+                              {layer.name.startsWith('plugins.') ? t(layer.name) : layer.name}
+                            </div>
+                            {layer.description && (
+                              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '2px' }}>
+                                {layer.description.startsWith('plugins.') ? t(layer.description) : layer.description}
+                              </div>
+                            )}
+                          </div>
+                        </label>
+                      </div>
+
+                      {layer.enabled && (
+                        <div style={{ paddingLeft: '38px', marginTop: '12px' }}>
+                          <label
+                            style={{
+                              display: 'block',
+                              fontSize: '11px',
+                              color: 'var(--text-muted)',
+                              marginBottom: '6px',
+                              textTransform: 'uppercase',
+                              letterSpacing: '0.5px',
+                            }}
+                          >
+                            {t('station.settings.layers.opacity')}: {Math.round(layer.opacity * 100)}%
+                          </label>
+                          <input
+                            type="range"
+                            min="0"
+                            max="100"
+                            value={layer.opacity * 100}
+                            onChange={(e) => handleOpacityChange(layer.id, parseFloat(e.target.value) / 100)}
+                            style={{ width: '100%', cursor: 'pointer' }}
+                          />
+                          {ctrlPressed &&
+                            ['lightning', 'wspr', 'rbn', 'grayline', 'n3fjp_logged_qsos', 'voacap-heatmap'].includes(
+                              layer.id,
+                            ) && (
+                              <button
+                                onClick={() => resetPopupPositions(layer.id)}
+                                style={{
+                                  marginTop: '12px',
+                                  padding: '8px 12px',
+                                  background: 'var(--accent-red)',
+                                  color: 'white',
+                                  border: 'none',
+                                  borderRadius: '4px',
+                                  cursor: 'pointer',
+                                  fontSize: '11px',
+                                  fontWeight: '600',
+                                  textTransform: 'uppercase',
+                                  width: '100%',
+                                }}
+                              >
+                                🔄 RESET POPUPS
+                              </button>
+                            )}
+                        </div>
+                      )}
+                    </div>
+                  );
+
+                  const result = [];
+                  const rendered = new Set();
+                  categoryOrder.forEach(({ key, label }) => {
+                    const hasBuiltInOverlays = key === 'overlay' && overlayCards.length > 0;
+                    if (!grouped[key] && !hasBuiltInOverlays) return;
+                    if ((!grouped[key] || grouped[key].length === 0) && !hasBuiltInOverlays) return;
+                    result.push(
+                      <div
+                        key={`cat-${key}`}
+                        style={{
+                          fontSize: '11px',
+                          textTransform: 'uppercase',
+                          letterSpacing: '0.5px',
+                          color: 'var(--text-muted)',
+                          marginBottom: '8px',
+                          marginTop: result.length > 0 ? '16px' : '0',
+                          paddingBottom: '4px',
+                          borderBottom: '1px solid var(--border-color)',
+                        }}
+                      >
+                        {label}
+                      </div>,
+                    );
+                    if (key === 'overlay') {
+                      overlayCards.forEach((item) => {
+                        result.push(renderBuiltInOverlayCard(item));
+                      });
+                    }
+                    (grouped[key] || []).forEach((layer) => {
+                      result.push(renderLayerCard(layer));
+                      rendered.add(layer.id);
+                    });
+                  });
+                  // Any uncategorized leftovers
+                  nonSatLayers
+                    .filter((l) => !rendered.has(l.id))
+                    .forEach((layer) => {
+                      result.push(renderLayerCard(layer));
+                    });
+                  if (result.length === 0) {
+                    return (
+                      <div
+                        style={{
+                          textAlign: 'center',
+                          padding: '40px 20px',
+                          color: 'var(--text-muted)',
+                          fontSize: '13px',
+                        }}
+                      >
+                        {t('station.settings.layers.noLayers')}
+                      </div>
+                    );
+                  }
+                  return result;
+                })();
+              })()}
+            </div>
+          )}
+        </div>
+
+        {/* Satellites Tab */}
+        <div
+          role="tabpanel"
+          id="panel-settings-satellites"
+          aria-labelledby="tab-settings-satellites"
+          hidden={activeTab !== 'satellites'}
+        >
+          {activeTab === 'satellites' && (
+            <div>
+              {/* 1. Plugin Layer Toggle Section */}
+              <div style={{ marginBottom: '20px' }}>
+                {layers
+                  .filter((layer) => layer.category === 'satellites')
+                  .map((layer) => (
+                    <div
+                      key={layer.id}
+                      style={{
+                        background: 'var(--bg-tertiary)',
+                        border: `1px solid ${layer.enabled ? 'var(--accent-amber)' : 'var(--border-color)'}`,
+                        borderRadius: '8px',
+                        padding: '14px',
+                        marginBottom: '12px',
+                      }}
+                    >
+                      <label style={{ display: 'flex', alignItems: 'center', gap: '10px', cursor: 'pointer' }}>
+                        <input
+                          type="checkbox"
+                          checked={layer.enabled}
+                          onChange={() => handleToggleLayer(layer.id)}
+                          style={{ width: '18px', height: '18px', cursor: 'pointer' }}
+                        />
+                        <span style={{ fontSize: '18px' }}>🛰️</span>
+                        <div>
+                          <div
+                            style={{
+                              color: layer.enabled ? 'var(--accent-amber)' : 'var(--text-primary)',
+                              fontSize: '14px',
+                              fontWeight: '600',
+                              fontFamily: 'var(--font-mono)',
+                            }}
+                          >
+                            {layer.name}
+                          </div>
+                          <div style={{ fontSize: '11px', color: 'var(--text-muted)' }}>{layer.description}</div>
+                        </div>
+                      </label>
+
+                      {layer.enabled && (
+                        <div
+                          style={{
+                            paddingLeft: '38px',
+                            marginTop: '10px',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: '12px',
+                          }}
+                        >
+                          {/* Sub-Toggles for Tracks and Footprints */}
+                          <div style={{ display: 'flex', gap: '15px' }}>
+                            <label
+                              style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '6px',
+                                fontSize: '11px',
+                                cursor: 'pointer',
+                              }}
+                            >
+                              <input
+                                type="checkbox"
+                                checked={layer.config?.showTracks !== false}
+                                onChange={(e) => handleUpdateLayerConfig(layer.id, { showTracks: e.target.checked })}
+                              />{' '}
+                              Track Lines
+                            </label>
+                            <label
+                              style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '6px',
+                                fontSize: '11px',
+                                cursor: 'pointer',
+                              }}
+                            >
+                              <input
+                                type="checkbox"
+                                checked={layer.config?.showFootprints !== false}
+                                onChange={(e) =>
+                                  handleUpdateLayerConfig(layer.id, { showFootprints: e.target.checked })
+                                }
+                              />{' '}
+                              Footprints
+                            </label>
+                          </div>
+
+                          {/* station altitude and minimum elevation inputs */}
+                          <div
+                            style={{
+                              display: 'grid',
+                              gridTemplateColumns: '1fr 1fr',
+                              gap: '12px',
+                              marginBottom: '12px',
+                            }}
+                          >
+                            <div>
+                              <label
+                                style={{
+                                  display: 'block',
+                                  marginBottom: '6px',
+                                  color: 'var(--text-muted)',
+                                  fontSize: '11px',
+                                  textTransform: 'uppercase',
+                                }}
+                              >
+                                Station Altitude [m]
+                              </label>
+                              <input
+                                type="number"
+                                step="1"
+                                min="-500"
+                                max="9000"
+                                value={isNaN(stationAlt) ? '' : stationAlt}
+                                onChange={(e) =>
+                                  setStationAlt(isNaN(e.target.valueAsNumber) ? 100 : e.target.valueAsNumber)
+                                }
+                                style={{
+                                  width: '100%',
+                                  padding: '10px',
+                                  background: 'var(--bg-tertiary)',
+                                  border: '1px solid var(--border-color)',
+                                  borderRadius: '6px',
+                                  color: 'var(--text-primary)',
+                                  fontSize: '14px',
+                                  fontFamily: 'var(--font-mono)',
+                                  boxSizing: 'border-box',
+                                }}
+                              />
+                            </div>
+                            <div>
+                              <label
+                                style={{
+                                  display: 'block',
+                                  marginBottom: '6px',
+                                  color: 'var(--text-muted)',
+                                  fontSize: '11px',
+                                  textTransform: 'uppercase',
+                                }}
+                              >
+                                Minimum Elevation [°]
+                              </label>
+                              <input
+                                type="number"
+                                step="0.1"
+                                min="-5.0"
+                                max="89.0"
+                                value={isNaN(minElev) ? '' : minElev}
+                                onChange={(e) =>
+                                  setMinElev(isNaN(e.target.valueAsNumber) ? 5.0 : e.target.valueAsNumber)
+                                }
+                                style={{
+                                  width: '100%',
+                                  padding: '10px',
+                                  background: 'var(--bg-tertiary)',
+                                  border: '1px solid var(--border-color)',
+                                  borderRadius: '6px',
+                                  color: 'var(--text-primary)',
+                                  fontSize: '14px',
+                                  fontFamily: 'var(--font-mono)',
+                                  boxSizing: 'border-box',
+                                }}
+                              />
+                            </div>
+                          </div>
+
+                          {/* Lead Time Slider WIP
+						<div style={{ marginTop: '8px' }}>
+						  <label style={{
+							display: 'flex',
+							justifyContent: 'space-between',
+							fontSize: '10px',
+							color: 'var(--text-muted)',
+							textTransform: 'uppercase'
+						  }}>
+							<span>Track Prediction (Lead Time)</span>
+							<span style={{ color: 'var(--accent-amber)' }}>{layer.config?.leadTimeMins || 45} min</span>
+						  </label>
+						  <input
+							type="range"
+							min="15"
+							max="120"
+							step="5"
+							value={layer.config?.leadTimeMins || 45}
+							onChange={(e) => handleUpdateLayerConfig(layer.id, { leadTimeMins: parseInt(e.target.value) })}
+							style={{ width: '100%', cursor: 'pointer' }}
+						  />
+						</div> */}
+
+                          {/* Opacity Slider */}
+                          <div>
+                            <label style={{ fontSize: '10px', color: 'var(--text-muted)', textTransform: 'uppercase' }}>
+                              Opacity: {Math.round(layer.opacity * 100)}%
+                            </label>
+                            <input
+                              type="range"
+                              min="0"
+                              max="100"
+                              value={layer.opacity * 100}
+                              onChange={(e) => handleOpacityChange(layer.id, parseFloat(e.target.value) / 100)}
+                              style={{ width: '100%', cursor: 'pointer' }}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+              </div>
+
+              {/* 2. Existing Satellite Filter Controls */}
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  marginBottom: '16px',
+                  paddingBottom: '12px',
+                  borderBottom: '1px solid var(--border-color)',
+                }}
+              >
+                <button
+                  onClick={() => {
+                    const allSats = (satellites || []).map((s) => s.name);
+                    onSatelliteFiltersChange(allSats);
+                  }}
+                  style={{
+                    background: 'transparent',
+                    border: '1px solid #00ffff',
+                    borderRadius: '4px',
+                    color: '#00ffff',
+                    padding: '6px 12px',
+                    fontSize: '12px',
+                    cursor: 'pointer',
+                    fontFamily: 'var(--font-mono)',
+                  }}
+                >
+                  {t('station.settings.satellites.selectAll')}
+                </button>
+                <button
+                  onClick={() => onSatelliteFiltersChange([])}
+                  style={{
+                    background: 'transparent',
+                    border: '1px solid #ff6666',
+                    borderRadius: '4px',
+                    color: '#ff6666',
+                    padding: '6px 12px',
+                    fontSize: '12px',
+                    cursor: 'pointer',
+                    fontFamily: 'var(--font-mono)',
+                  }}
+                >
+                  {t('station.settings.satellites.clear')}
+                </button>
+              </div>
+
+              <div
+                style={{
+                  fontSize: '11px',
+                  color: 'var(--text-muted)',
+                  marginBottom: '12px',
+                }}
+              >
+                {satelliteFilters.length === 0
+                  ? t('station.settings.satellites.showAll')
+                  : t('station.settings.satellites.selectedCount', { count: satelliteFilters.length })}
+              </div>
+
+              {/* Search Box */}
+              <div style={{ position: 'relative', marginBottom: '12px' }}>
+                <input
+                  type="text"
+                  value={satelliteSearch}
+                  onChange={(e) => setSatelliteSearch(e.target.value)}
+                  placeholder="🔍 Search satellites..."
+                  style={{
+                    width: '100%',
+                    padding: '8px 32px 8px 12px',
+                    background: 'var(--bg-tertiary)',
+                    border: '1px solid var(--border-color)',
+                    borderRadius: '6px',
+                    color: 'var(--text-primary)',
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: '12px',
+                    outline: 'none',
+                  }}
+                />
+                {satelliteSearch && (
+                  <button
+                    onClick={() => setSatelliteSearch('')}
+                    style={{
+                      position: 'absolute',
+                      right: '8px',
+                      top: '50%',
+                      transform: 'translateY(-50%)',
+                      background: 'transparent',
+                      border: 'none',
+                      color: '#ff6666',
+                      cursor: 'pointer',
+                      fontSize: '16px',
+                      padding: '4px 8px',
+                    }}
+                  >
+                    ×
+                  </button>
+                )}
+              </div>
+
+              {/* Satellite Grid */}
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(2, 1fr)',
+                  gap: '8px',
+                  maxHeight: '400px',
+                  overflowY: 'auto',
+                }}
+              >
+                {(satellites || [])
+                  .filter((sat) => !satelliteSearch || sat.name.toLowerCase().includes(satelliteSearch.toLowerCase()))
+                  .sort((a, b) => {
+                    const aSelected = satelliteFilters.includes(a.name);
+                    const bSelected = satelliteFilters.includes(b.name);
+                    if (aSelected && !bSelected) return -1;
+                    if (!aSelected && bSelected) return 1;
+                    return a.name.localeCompare(b.name);
+                  })
+                  .map((sat) => {
+                    const isSelected = satelliteFilters.includes(sat.name);
+                    return (
+                      <button
+                        key={sat.name}
+                        onClick={() => {
+                          if (isSelected) {
+                            onSatelliteFiltersChange(satelliteFilters.filter((n) => n !== sat.name));
+                          } else {
+                            onSatelliteFiltersChange([...satelliteFilters, sat.name]);
+                          }
+                        }}
+                        style={{
+                          background: isSelected ? 'rgba(0, 255, 255, 0.15)' : 'var(--bg-tertiary)',
+                          border: `1px solid ${isSelected ? '#00ffff' : 'var(--border-color)'}`,
+                          borderRadius: '6px',
+                          padding: '10px',
+                          textAlign: 'left',
+                          cursor: 'pointer',
+                          color: 'var(--text-primary)',
+                          fontFamily: 'var(--font-mono)',
+                          fontSize: '12px',
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '8px',
+                        }}
+                      >
+                        <span
+                          style={{
+                            width: '16px',
+                            height: '16px',
+                            borderRadius: '3px',
+                            border: `2px solid ${isSelected ? '#00ffff' : '#666'}`,
+                            background: isSelected ? '#00ffff' : 'transparent',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            fontSize: '10px',
+                            flexShrink: 0,
+                          }}
+                        >
+                          {isSelected && '✓'}
+                        </span>
+                        <div style={{ flex: 1, overflow: 'hidden' }}>
+                          <div
+                            style={{
+                              color: isSelected ? '#00ffff' : 'var(--text-primary)',
+                              fontWeight: '600',
+                              whiteSpace: 'nowrap',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                            }}
+                          >
+                            {sat.name}
+                          </div>
+                        </div>
+                      </button>
+                    );
+                  })}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Profiles Tab */}
+        <div
+          role="tabpanel"
+          id="panel-settings-profiles"
+          aria-labelledby="tab-settings-profiles"
+          hidden={activeTab !== 'profiles'}
+        >
+          {activeTab === 'profiles' && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+              {/* Description */}
+              <div style={{ fontSize: '12px', color: 'var(--text-muted)', lineHeight: '1.5' }}>
+                Save your current layout, theme, map layers, filters, and all preferences as a named profile. Switch
+                between profiles when sharing a HamClock between operators, or to toggle between your own saved views.
+              </div>
+
+              {/* Active profile indicator */}
+              {activeProfileName && (
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                    padding: '8px 12px',
+                    background: 'rgba(0, 255, 136, 0.1)',
+                    border: '1px solid rgba(0, 255, 136, 0.3)',
+                    borderRadius: '6px',
+                    fontSize: '12px',
+                  }}
+                >
+                  <span style={{ color: '#00ff88' }}>●</span>
+                  <span style={{ color: 'var(--text-primary)' }}>
+                    Active: <strong>{activeProfileName}</strong>
+                  </span>
+                </div>
+              )}
+
+              {/* Status message */}
+              {profileMessage && (
+                <div
+                  style={{
+                    padding: '8px 12px',
+                    background: profileMessage.type === 'error' ? 'rgba(255, 68, 102, 0.1)' : 'rgba(0, 255, 136, 0.1)',
+                    border: `1px solid ${profileMessage.type === 'error' ? 'rgba(255, 68, 102, 0.3)' : 'rgba(0, 255, 136, 0.3)'}`,
+                    borderRadius: '6px',
+                    fontSize: '11px',
+                    color: profileMessage.type === 'error' ? '#ff4466' : '#00ff88',
+                  }}
+                >
+                  {profileMessage.text}
+                </div>
+              )}
+
+              {/* Save new profile */}
+              <div
+                style={{
+                  padding: '12px',
+                  background: 'var(--bg-tertiary)',
+                  borderRadius: '8px',
+                  border: '1px solid var(--border-color)',
+                }}
+              >
+                <div style={{ fontSize: '12px', fontWeight: '600', color: 'var(--accent-amber)', marginBottom: '8px' }}>
+                  💾 Save Current State as Profile
+                </div>
+                <div style={{ display: 'flex', gap: '8px' }}>
+                  <input
+                    type="text"
+                    value={newProfileName}
+                    onChange={(e) => setNewProfileName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && newProfileName.trim()) {
+                        const exists = profiles[newProfileName.trim()];
+                        if (exists && !window.confirm(`Profile "${newProfileName.trim()}" already exists. Overwrite?`))
+                          return;
+                        persistCurrentSettings();
+                        saveProfile(newProfileName.trim());
+                        setNewProfileName('');
+                        refreshProfiles();
+                        setProfileMessage({ type: 'success', text: `Profile "${newProfileName.trim()}" saved` });
+                        setTimeout(() => setProfileMessage(null), 3000);
+                      }
+                    }}
+                    placeholder="Profile name (e.g. K0CJH, Contest, Field Day)"
+                    style={{
+                      flex: 1,
+                      padding: '8px 10px',
+                      background: 'var(--bg-primary)',
+                      border: '1px solid var(--border-color)',
+                      borderRadius: '4px',
+                      color: 'var(--text-primary)',
+                      fontSize: '12px',
+                      fontFamily: 'var(--font-mono)',
+                    }}
+                  />
+                  <button
+                    onClick={() => {
+                      if (!newProfileName.trim()) return;
+                      const exists = profiles[newProfileName.trim()];
+                      if (exists && !window.confirm(`Profile "${newProfileName.trim()}" already exists. Overwrite?`))
+                        return;
+                      persistCurrentSettings();
+                      saveProfile(newProfileName.trim());
+                      setNewProfileName('');
+                      refreshProfiles();
+                      setProfileMessage({ type: 'success', text: `Profile "${newProfileName.trim()}" saved` });
+                      setTimeout(() => setProfileMessage(null), 3000);
+                    }}
+                    disabled={!newProfileName.trim()}
+                    style={{
+                      padding: '8px 16px',
+                      background: newProfileName.trim()
+                        ? 'linear-gradient(135deg, #00ff88 0%, #00ddff 100%)'
+                        : 'var(--bg-tertiary)',
+                      border: 'none',
+                      borderRadius: '4px',
+                      color: newProfileName.trim() ? '#000' : 'var(--text-muted)',
+                      fontSize: '12px',
+                      fontWeight: '700',
+                      cursor: newProfileName.trim() ? 'pointer' : 'default',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
+
+              {/* Saved profiles list */}
+              <div>
+                <div style={{ fontSize: '12px', fontWeight: '600', color: 'var(--accent-amber)', marginBottom: '8px' }}>
+                  📋 Saved Profiles ({Object.keys(profiles).length})
+                </div>
+                {Object.keys(profiles).length === 0 ? (
+                  <div
+                    style={{
+                      padding: '20px',
+                      textAlign: 'center',
+                      color: 'var(--text-muted)',
+                      fontSize: '12px',
+                      background: 'var(--bg-tertiary)',
+                      borderRadius: '8px',
+                      border: '1px dashed var(--border-color)',
+                    }}
+                  >
+                    No saved profiles yet. Save your current configuration above.
+                  </div>
+                ) : (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                    {Object.entries(profiles)
+                      .sort((a, b) => (b[1].updatedAt || '').localeCompare(a[1].updatedAt || ''))
+                      .map(([name, profile]) => {
+                        const isActive = name === activeProfileName;
+                        const isRenaming = renamingProfile === name;
+
+                        // Parse callsign from snapshot if available
+                        let snapshotCallsign = '';
+                        try {
+                          const cfg = profile.snapshot?.openhamclock_config;
+                          if (cfg) snapshotCallsign = JSON.parse(cfg).callsign || '';
+                        } catch {}
+
+                        // Parse layout type
+                        let snapshotLayout = '';
+                        try {
+                          const cfg = profile.snapshot?.openhamclock_config;
+                          if (cfg) snapshotLayout = JSON.parse(cfg).layout || '';
+                        } catch {}
+
+                        return (
+                          <div
+                            key={name}
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: '8px',
+                              padding: '10px 12px',
+                              background: isActive ? 'rgba(0, 255, 136, 0.08)' : 'var(--bg-tertiary)',
+                              border: `1px solid ${isActive ? 'rgba(0, 255, 136, 0.3)' : 'var(--border-color)'}`,
+                              borderRadius: '6px',
+                            }}
+                          >
+                            {/* Profile info */}
+                            <div style={{ flex: 1, minWidth: 0 }}>
+                              {isRenaming ? (
+                                <div style={{ display: 'flex', gap: '4px' }}>
+                                  <input
+                                    type="text"
+                                    value={renameValue}
+                                    onChange={(e) => setRenameValue(e.target.value)}
+                                    onKeyDown={(e) => {
+                                      if (e.key === 'Enter') {
+                                        if (renameProfile(name, renameValue)) {
+                                          refreshProfiles();
+                                          setProfileMessage({
+                                            type: 'success',
+                                            text: `Renamed to "${renameValue.trim()}"`,
+                                          });
+                                        } else {
+                                          setProfileMessage({
+                                            type: 'error',
+                                            text: 'Rename failed — name may be taken',
+                                          });
+                                        }
+                                        setRenamingProfile(null);
+                                        setTimeout(() => setProfileMessage(null), 3000);
+                                      }
+                                      if (e.key === 'Escape') setRenamingProfile(null);
+                                    }}
+                                    autoFocus
+                                    style={{
+                                      flex: 1,
+                                      padding: '4px 6px',
+                                      background: 'var(--bg-primary)',
+                                      border: '1px solid var(--accent-amber)',
+                                      borderRadius: '3px',
+                                      color: 'var(--text-primary)',
+                                      fontSize: '12px',
+                                      fontFamily: 'var(--font-mono)',
+                                    }}
+                                  />
+                                  <button
+                                    onClick={() => {
+                                      if (renameProfile(name, renameValue)) {
+                                        refreshProfiles();
+                                        setProfileMessage({
+                                          type: 'success',
+                                          text: `Renamed to "${renameValue.trim()}"`,
+                                        });
+                                      } else {
+                                        setProfileMessage({
+                                          type: 'error',
+                                          text: 'Rename failed — name may already exist',
+                                        });
+                                      }
+                                      setRenamingProfile(null);
+                                      setTimeout(() => setProfileMessage(null), 3000);
+                                    }}
+                                    style={{
+                                      padding: '4px 8px',
+                                      background: 'var(--accent-green)',
+                                      border: 'none',
+                                      borderRadius: '3px',
+                                      color: '#000',
+                                      fontSize: '10px',
+                                      cursor: 'pointer',
+                                      fontWeight: '700',
+                                    }}
+                                  >
+                                    ✓
+                                  </button>
+                                  <button
+                                    onClick={() => setRenamingProfile(null)}
+                                    style={{
+                                      padding: '4px 8px',
+                                      background: 'var(--bg-primary)',
+                                      border: '1px solid var(--border-color)',
+                                      borderRadius: '3px',
+                                      color: 'var(--text-muted)',
+                                      fontSize: '10px',
+                                      cursor: 'pointer',
+                                    }}
+                                  >
+                                    ✕
+                                  </button>
+                                </div>
+                              ) : (
+                                <>
+                                  <div
+                                    style={{
+                                      fontSize: '13px',
+                                      fontWeight: '600',
+                                      color: isActive ? '#00ff88' : 'var(--text-primary)',
+                                      whiteSpace: 'nowrap',
+                                      overflow: 'hidden',
+                                      textOverflow: 'ellipsis',
+                                    }}
+                                  >
+                                    {isActive && <span style={{ marginRight: '4px' }}>●</span>}
+                                    {name}
+                                  </div>
+                                  <div style={{ fontSize: '10px', color: 'var(--text-muted)', marginTop: '2px' }}>
+                                    {snapshotCallsign && <span>{snapshotCallsign}</span>}
+                                    {snapshotLayout && <span> • {snapshotLayout}</span>}
+                                    {profile.updatedAt && (
+                                      <span> • {new Date(profile.updatedAt).toLocaleDateString()}</span>
+                                    )}
+                                  </div>
+                                </>
+                              )}
+                            </div>
+
+                            {/* Action buttons */}
+                            {!isRenaming && (
+                              <div style={{ display: 'flex', gap: '4px', flexShrink: 0 }}>
+                                {/* Load */}
+                                <button
+                                  onClick={() => {
+                                    if (
+                                      window.confirm(
+                                        `Load profile "${name}"? This will replace your current settings and reload.`,
+                                      )
+                                    ) {
+                                      loadProfile(name);
+                                      window.location.reload();
+                                    }
+                                  }}
+                                  title="Load this profile"
+                                  style={{
+                                    padding: '5px 10px',
+                                    background: isActive ? 'rgba(0,255,136,0.15)' : 'var(--bg-primary)',
+                                    border: `1px solid ${isActive ? 'rgba(0,255,136,0.3)' : 'var(--border-color)'}`,
+                                    borderRadius: '4px',
+                                    color: isActive ? '#00ff88' : 'var(--text-secondary)',
+                                    fontSize: '11px',
+                                    cursor: 'pointer',
+                                    fontWeight: '600',
+                                  }}
+                                >
+                                  {isActive ? '✓ Active' : '▶ Load'}
+                                </button>
+                                {/* Update (overwrite with current state) */}
+                                <button
+                                  onClick={() => {
+                                    persistCurrentSettings();
+                                    saveProfile(name);
+                                    refreshProfiles();
+                                    setProfileMessage({
+                                      type: 'success',
+                                      text: `"${name}" updated with current state`,
+                                    });
+                                    setTimeout(() => setProfileMessage(null), 3000);
+                                  }}
+                                  title="Update with current settings"
+                                  aria-label="Update with current settings"
+                                  style={{
+                                    padding: '5px 8px',
+                                    background: 'var(--bg-primary)',
+                                    border: '1px solid var(--border-color)',
+                                    borderRadius: '4px',
+                                    color: 'var(--text-muted)',
+                                    fontSize: '11px',
+                                    cursor: 'pointer',
+                                  }}
+                                >
+                                  ↻
+                                </button>
+                                {/* Rename */}
+                                <button
+                                  onClick={() => {
+                                    setRenamingProfile(name);
+                                    setRenameValue(name);
+                                  }}
+                                  title="Rename"
+                                  aria-label="Rename profile"
+                                  style={{
+                                    padding: '5px 8px',
+                                    background: 'var(--bg-primary)',
+                                    border: '1px solid var(--border-color)',
+                                    borderRadius: '4px',
+                                    color: 'var(--text-muted)',
+                                    fontSize: '11px',
+                                    cursor: 'pointer',
+                                  }}
+                                >
+                                  ✎
+                                </button>
+                                {/* Export */}
+                                <button
+                                  onClick={() => {
+                                    const json = exportProfile(name);
+                                    if (json) {
+                                      const blob = new Blob([json], { type: 'application/json' });
+                                      const url = URL.createObjectURL(blob);
+                                      const a = document.createElement('a');
+                                      a.href = url;
+                                      a.download = (() => {
+                                        const now = new Date();
+                                        const date = now.toISOString().split('T')[0];
+                                        const time = now.toTimeString().slice(0, 8).replace(/:/g, '');
+                                        return `hamclock-profile-${name.replace(/\s+/g, '-').toLowerCase()}-${date}-${time}.json`;
+                                      })();
+                                      a.click();
+                                      URL.revokeObjectURL(url);
+                                      setProfileMessage({ type: 'success', text: `Exported "${name}"` });
+                                      setTimeout(() => setProfileMessage(null), 3000);
+                                    }
+                                  }}
+                                  title="Export to file"
+                                  aria-label="Export profile to file"
+                                  style={{
+                                    padding: '5px 8px',
+                                    background: 'var(--bg-primary)',
+                                    border: '1px solid var(--border-color)',
+                                    borderRadius: '4px',
+                                    color: 'var(--text-muted)',
+                                    fontSize: '11px',
+                                    cursor: 'pointer',
+                                  }}
+                                >
+                                  ⤓
+                                </button>
+                                {/* Delete */}
+                                <button
+                                  onClick={() => {
+                                    if (window.confirm(`Delete profile "${name}"? This cannot be undone.`)) {
+                                      deleteProfile(name);
+                                      refreshProfiles();
+                                      setProfileMessage({ type: 'success', text: `Deleted "${name}"` });
+                                      setTimeout(() => setProfileMessage(null), 3000);
+                                    }
+                                  }}
+                                  title="Delete"
+                                  aria-label="Delete profile"
+                                  style={{
+                                    padding: '5px 8px',
+                                    background: 'var(--bg-primary)',
+                                    border: '1px solid rgba(255,68,102,0.3)',
+                                    borderRadius: '4px',
+                                    color: '#ff4466',
+                                    fontSize: '11px',
+                                    cursor: 'pointer',
+                                  }}
+                                >
+                                  ✕
+                                </button>
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })}
+                  </div>
+                )}
+              </div>
+
+              {/* Open-Meteo API Key (optional) */}
+              <div
+                style={{
+                  padding: '12px',
+                  background: 'var(--bg-tertiary)',
+                  borderRadius: '8px',
+                  border: '1px solid var(--border-color)',
+                  marginBottom: '12px',
+                }}
+              >
+                <div style={{ fontSize: '12px', fontWeight: '600', color: 'var(--accent-amber)', marginBottom: '8px' }}>
+                  🌡️ Open-Meteo API Key{' '}
+                  <span style={{ color: 'var(--text-muted)', fontWeight: '400', fontSize: '11px' }}>(optional)</span>
+                </div>
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '8px', lineHeight: 1.4 }}>
+                  Weather data is provided by Open-Meteo's free API. For higher rate limits or commercial use, enter
+                  your API key from{' '}
+                  <a
+                    href="https://open-meteo.com/en/pricing"
+                    target="_blank"
+                    rel="noopener"
+                    style={{ color: 'var(--accent-blue)' }}
+                  >
+                    open-meteo.com
+                  </a>
+                  . Leave blank for the free tier.
+                </div>
+                <input
+                  type="text"
+                  placeholder="Free tier (no key needed)"
+                  defaultValue={(() => {
+                    try {
+                      return localStorage.getItem('ohc_openmeteo_apikey') || '';
+                    } catch {
+                      return '';
+                    }
+                  })()}
+                  onChange={(e) => {
+                    try {
+                      const val = e.target.value.trim();
+                      if (val) {
+                        localStorage.setItem('ohc_openmeteo_apikey', val);
+                      } else {
+                        localStorage.removeItem('ohc_openmeteo_apikey');
+                      }
+                    } catch {}
+                  }}
+                  style={{
+                    width: '100%',
+                    padding: '8px 12px',
+                    background: 'var(--bg-primary)',
+                    border: '1px solid var(--border-color)',
+                    borderRadius: '4px',
+                    color: 'var(--text-primary)',
+                    fontSize: '12px',
+                    fontFamily: 'var(--font-mono)',
+                    boxSizing: 'border-box',
+                  }}
+                />
+              </div>
+
+              {/* Import / Export section */}
+              <div
+                style={{
+                  padding: '12px',
+                  background: 'var(--bg-tertiary)',
+                  borderRadius: '8px',
+                  border: '1px solid var(--border-color)',
+                }}
+              >
+                <div style={{ fontSize: '12px', fontWeight: '600', color: 'var(--accent-amber)', marginBottom: '8px' }}>
+                  📦 Import / Export
+                </div>
+                <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".json"
+                    style={{ display: 'none' }}
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (!file) return;
+                      const reader = new FileReader();
+                      reader.onload = (ev) => {
+                        const imported = importProfile(ev.target.result);
+                        if (imported) {
+                          refreshProfiles();
+                          setProfileMessage({ type: 'success', text: `Imported profile "${imported}"` });
+                        } else {
+                          setProfileMessage({ type: 'error', text: 'Import failed — invalid profile file' });
+                        }
+                        setTimeout(() => setProfileMessage(null), 3000);
+                      };
+                      reader.readAsText(file);
+                      e.target.value = '';
+                    }}
+                  />
+                  <button
+                    onClick={() => fileInputRef.current?.click()}
+                    style={{
+                      padding: '8px 14px',
+                      background: 'var(--bg-primary)',
+                      border: '1px solid var(--border-color)',
+                      borderRadius: '4px',
+                      color: 'var(--text-secondary)',
+                      fontSize: '11px',
+                      cursor: 'pointer',
+                      fontWeight: '600',
+                    }}
+                  >
+                    ⤒ Import Profile from File
+                  </button>
+                  <button
+                    onClick={() => {
+                      const json = exportCurrentState('Current');
+                      const blob = new Blob([json], { type: 'application/json' });
+                      const url = URL.createObjectURL(blob);
+                      const a = document.createElement('a');
+                      a.href = url;
+                      a.download = (() => {
+                        const now = new Date();
+                        const date = now.toISOString().split('T')[0];
+                        const time = now.toTimeString().slice(0, 8).replace(/:/g, '');
+                        return `hamclock-current-${date}-${time}.json`;
+                      })();
+                      a.click();
+                      URL.revokeObjectURL(url);
+                      setProfileMessage({ type: 'success', text: 'Exported current state' });
+                      setTimeout(() => setProfileMessage(null), 3000);
+                    }}
+                    style={{
+                      padding: '8px 14px',
+                      background: 'var(--bg-primary)',
+                      border: '1px solid var(--border-color)',
+                      borderRadius: '4px',
+                      color: 'var(--text-secondary)',
+                      fontSize: '11px',
+                      cursor: 'pointer',
+                      fontWeight: '600',
+                    }}
+                  >
+                    ⤓ Export Current State
+                  </button>
+                </div>
+                <div style={{ fontSize: '10px', color: 'var(--text-muted)', marginTop: '8px' }}>
+                  Share profile files between devices or operators. Exported files contain all settings, layout
+                  preferences, map layers, and filter configurations.
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Community Tab */}
+        <div
+          role="tabpanel"
+          id="panel-settings-community"
+          aria-labelledby="tab-settings-community"
+          hidden={activeTab !== 'community'}
+        >
+          {activeTab === 'community' && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+              <p style={{ fontSize: '13px', color: 'var(--text-secondary)', marginBottom: '8px' }}>
+                Join the OpenHamClock community — report bugs, request features, and connect with other operators.
+              </p>
+              <a
+                href="https://github.com/accius/openhamclock"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '12px',
+                  padding: '14px 16px',
+                  background: 'var(--bg-tertiary)',
+                  borderRadius: '8px',
+                  textDecoration: 'none',
+                  color: 'var(--text-primary)',
+                  border: '1px solid transparent',
+                  transition: 'border-color 0.2s',
+                }}
+                onMouseOver={(e) => (e.currentTarget.style.borderColor = 'var(--border-color)')}
+                onMouseOut={(e) => (e.currentTarget.style.borderColor = 'transparent')}
+              >
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+                </svg>
+                <div>
+                  <div style={{ fontWeight: 600, fontSize: '14px' }}>GitHub</div>
+                  <div style={{ fontSize: '11px', color: 'var(--text-muted)' }}>Source code, issues & releases</div>
+                </div>
+              </a>
+              <a
+                href="https://www.facebook.com/groups/1217043013897440"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '12px',
+                  padding: '14px 16px',
+                  background: 'var(--bg-tertiary)',
+                  borderRadius: '8px',
+                  textDecoration: 'none',
+                  color: 'var(--text-primary)',
+                  border: '1px solid transparent',
+                  transition: 'border-color 0.2s',
+                }}
+                onMouseOver={(e) => (e.currentTarget.style.borderColor = 'var(--border-color)')}
+                onMouseOut={(e) => (e.currentTarget.style.borderColor = 'transparent')}
+              >
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="#1877F2">
+                  <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
+                </svg>
+                <div>
+                  <div style={{ fontWeight: 600, fontSize: '14px' }}>Facebook Group</div>
+                  <div style={{ fontSize: '11px', color: 'var(--text-muted)' }}>Community discussion & help</div>
+                </div>
+              </a>
+              <a
+                href="https://www.reddit.com/r/OpenHamClock/"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '12px',
+                  padding: '14px 16px',
+                  background: 'var(--bg-tertiary)',
+                  borderRadius: '8px',
+                  textDecoration: 'none',
+                  color: 'var(--text-primary)',
+                  border: '1px solid transparent',
+                  transition: 'border-color 0.2s',
+                }}
+                onMouseOver={(e) => (e.currentTarget.style.borderColor = 'var(--border-color)')}
+                onMouseOut={(e) => (e.currentTarget.style.borderColor = 'transparent')}
+              >
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="#FF4500">
+                  <path d="M12 0A12 12 0 000 12a12 12 0 0012 12 12 12 0 0012-12A12 12 0 0012 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 01-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 01.042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 014.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 01.14-.197.35.35 0 01.238-.042l2.906.617a1.214 1.214 0 011.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 00-.231.094.33.33 0 000 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 000-.463.327.327 0 00-.462 0c-.545.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 00-.205-.094z" />
+                </svg>
+                <div>
+                  <div style={{ fontWeight: 600, fontSize: '14px' }}>Reddit</div>
+                  <div style={{ fontSize: '11px', color: 'var(--text-muted)' }}>r/OpenHamClock</div>
+                </div>
+              </a>
+              <div
+                style={{
+                  marginTop: '16px',
+                  padding: '14px 16px',
+                  background: 'var(--bg-tertiary)',
+                  borderRadius: '8px',
+                  textAlign: 'center',
+                }}
+              >
+                <div style={{ fontSize: '14px', fontWeight: 600, color: 'var(--accent-amber)' }}>
+                  Created by Chris Hetherington — K0CJH
+                </div>
+                <div style={{ fontSize: '12px', color: 'var(--text-secondary)', marginTop: '6px', lineHeight: '1.5' }}>
+                  Built with the help of an amazing community of amateur radio operators contributing features,
+                  reporting bugs, and making OpenHamClock better every day.
+                </div>
+                <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginTop: '6px' }}>
+                  K0CJH / openhamclock.com
+                </div>
+              </div>
+
+              {/* Contributors */}
+              <div
+                style={{
+                  marginTop: '12px',
+                  padding: '14px 16px',
+                  background: 'var(--bg-tertiary)',
+                  borderRadius: '8px',
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: '12px',
+                    color: 'var(--accent-amber)',
+                    fontWeight: 600,
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                    marginBottom: '10px',
+                    textAlign: 'center',
+                  }}
+                >
+                  Contributors
+                </div>
+                <div
+                  style={{ fontSize: '11px', color: 'var(--text-muted)', textAlign: 'center', marginBottom: '10px' }}
+                >
+                  Thank you to everyone who has contributed code, features, bug fixes, and ideas.
+                </div>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', justifyContent: 'center' }}>
+                  {[
+                    'creinemann',
+                    'ceotjoe',
+                    'alanhargreaves',
+                    'dmazan',
+                    'Delerius',
+                    'rfreedman',
+                    'SebFox2011',
+                    'infopcgood',
+                    'thomas-schreck',
+                    'echo-gravitas',
+                    'yuryja',
+                    'Holyszewski',
+                    'trancen',
+                    'ThePangel',
+                    'w8mej',
+                    'JoshuaNewport',
+                    'denete',
+                    'kmanwar89',
+                    'KentenRoth',
+                    's53zo',
+                    'theodeurne76',
+                    'm1dst',
+                    'brianbruff',
+                    'agocs',
+                    'kwirk',
+                    'Oukagen',
+                    'ftl',
+                    'phether',
+                  ].map((name) => (
+                    <a
+                      key={name}
+                      href={`https://github.com/${name}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{
+                        display: 'inline-block',
+                        padding: '4px 10px',
+                        background: 'var(--bg-secondary)',
+                        borderRadius: '12px',
+                        fontSize: '11px',
+                        color: 'var(--text-secondary)',
+                        textDecoration: 'none',
+                        fontFamily: 'var(--font-mono)',
+                        border: '1px solid transparent',
+                        transition: 'all 0.15s',
+                      }}
+                      onMouseOver={(e) => {
+                        e.currentTarget.style.borderColor = 'var(--accent-cyan)';
+                        e.currentTarget.style.color = 'var(--accent-cyan)';
+                      }}
+                      onMouseOut={(e) => {
+                        e.currentTarget.style.borderColor = 'transparent';
+                        e.currentTarget.style.color = 'var(--text-secondary)';
+                      }}
+                    >
+                      {name}
+                    </a>
+                  ))}
+                </div>
+                <div style={{ fontSize: '10px', color: 'var(--text-muted)', textAlign: 'center', marginTop: '10px' }}>
+                  Want to contribute? Check out our GitHub — issues, pull requests, and ideas are all welcome.
+                </div>
+              </div>
+
+              {/* Privacy Notice */}
+              <div
+                style={{
+                  marginTop: '12px',
+                  padding: '14px 16px',
+                  background: 'var(--bg-tertiary)',
+                  borderRadius: '8px',
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: '12px',
+                    color: 'var(--accent-amber)',
+                    fontWeight: 600,
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                    marginBottom: '10px',
+                    textAlign: 'center',
+                  }}
+                >
+                  Privacy
+                </div>
+                <div style={{ fontSize: '12px', color: 'var(--text-secondary)', lineHeight: '1.6' }}>
+                  <p style={{ marginBottom: '10px' }}>
+                    <strong style={{ color: 'var(--text-primary)' }}>No Cookies or Tracking</strong>
+                    <br />
+                    OpenHamClock does not set any HTTP cookies. There are no analytics services, tracking pixels, ad
+                    networks, or telemetry. All vendor libraries (maps, fonts) are self-hosted.
+                  </p>
+                  <p style={{ marginBottom: '10px' }}>
+                    <strong style={{ color: 'var(--text-primary)' }}>Browser Storage</strong>
+                    <br />
+                    Your settings (callsign, theme, filters, layout) are saved to your browser's localStorage. This data
+                    stays on your device and is never shared with third parties. Clearing your browser data removes it.
+                  </p>
+                  <p style={{ marginBottom: '10px' }}>
+                    <strong style={{ color: 'var(--text-primary)' }}>Visitor Statistics</strong>
+                    <br />
+                    The server counts unique visitors using anonymized, one-way hashed identifiers. No IP addresses are
+                    stored to disk or sent to third parties. Only aggregate counts are retained.
+                  </p>
+                  <p style={{ marginBottom: '10px' }}>
+                    <strong style={{ color: 'var(--text-primary)' }}>Active Users Layer</strong>
+                    <br />
+                    If enabled, your callsign and grid square (rounded to ~1km) are shared with other operators on the
+                    map. You can opt out in Station settings without affecting other features. Your presence is
+                    automatically removed when you close the tab or disable the setting.
+                  </p>
+                  <p style={{ marginBottom: '10px' }}>
+                    <strong style={{ color: 'var(--text-primary)' }}>Third-Party APIs</strong>
+                    <br />
+                    Weather data is fetched from Open-Meteo and NOAA directly from your browser. No personal data beyond
+                    your configured coordinates is sent. API keys you provide are stored locally in your browser only.
+                  </p>
+                  <p style={{ margin: 0 }}>
+                    <strong style={{ color: 'var(--text-primary)' }}>Settings Sync</strong>
+                    <br />
+                    If the server operator has enabled settings sync, your preferences may be synced to the server for
+                    cross-device use. This is off by default and does not include profile data.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Audio Alerts Tab */}
+        <div
+          role="tabpanel"
+          id="panel-settings-alerts"
+          aria-labelledby="tab-settings-alerts"
+          hidden={activeTab !== 'alerts'}
+        >
+          {activeTab === 'alerts' && <AudioAlertsTab />}
+        </div>
+
+        {/* Rig Bridge Tab */}
+        <div
+          role="tabpanel"
+          id="panel-settings-rig-bridge"
+          aria-labelledby="tab-settings-rig-bridge"
+          hidden={activeTab !== 'rig-bridge'}
+        >
+          {activeTab === 'rig-bridge' && (
+            <div>
+              {/* README Banner */}
               <div
                 style={{
                   background: 'rgba(255, 193, 7, 0.15)',
@@ -819,453 +5138,20 @@ export const SettingsPanel = ({
                 }}
               >
                 <div style={{ color: 'var(--accent-amber)', fontWeight: '700', marginBottom: '6px' }}>
-                  {t('station.settings.welcome')}
+                  {t('station.settings.rigBridge.readme.heading')}
                 </div>
-                <div style={{ color: 'var(--text-secondary)', lineHeight: 1.5 }}>{t('station.settings.describe')}</div>
-                <div style={{ color: 'var(--text-muted)', fontSize: '11px', marginTop: '8px' }}>
-                  <Trans i18nKey="station.settings.tip.env" components={{ envExample: <Code />, env: <Code /> }} />
+                <div style={{ color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+                  {t('station.settings.rigBridge.readme.body')}{' '}
+                  <a
+                    href="https://github.com/accius/openhamclock/blob/main/rig-bridge/README.md"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ color: 'var(--accent-amber)', textDecoration: 'underline' }}
+                  >
+                    {t('station.settings.rigBridge.readme.link')}
+                  </a>
                 </div>
               </div>
-            )}
-
-            {/* Integrations moved to dedicated tab */}
-            <div
-              style={{
-                background: 'rgba(0, 255, 255, 0.04)',
-                border: '1px solid var(--border-color)',
-                borderRadius: '8px',
-                padding: '10px 14px',
-                marginBottom: '20px',
-                fontSize: 12,
-                color: 'var(--text-secondary)',
-              }}
-            >
-              Looking for Rotator / N3FJP / other add-ons? See{' '}
-              <b>Settings → {t('station.settings.tab.title.integrations')}</b>.
-            </div>
-
-            {/* Callsign */}
-            <div style={{ marginBottom: '20px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  marginBottom: '6px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                {t('station.settings.callsign')}
-              </label>
-              <input
-                type="text"
-                value={callsign}
-                onChange={(e) => setCallsign(e.target.value.toUpperCase())}
-                style={{
-                  width: '100%',
-                  padding: '12px',
-                  background: 'var(--bg-tertiary)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '6px',
-                  color: 'var(--accent-amber)',
-                  fontSize: '18px',
-                  fontFamily: 'var(--font-mono)',
-                  fontWeight: '700',
-                  boxSizing: 'border-box',
-                }}
-              />
-            </div>
-
-            {/* Grid Square */}
-            <div style={{ marginBottom: '20px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  marginBottom: '6px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                {t('station.settings.locator')}
-              </label>
-              <input
-                type="text"
-                value={gridSquare}
-                onChange={(e) => handleGridChange(e.target.value)}
-                onBlur={handleGridBlur}
-                placeholder={t('station.settings.locator.placeholder')}
-                maxLength={6}
-                style={{
-                  width: '100%',
-                  padding: '12px',
-                  background: 'var(--bg-tertiary)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '6px',
-                  color: 'var(--accent-amber)',
-                  fontSize: '18px',
-                  fontFamily: 'var(--font-mono)',
-                  fontWeight: '700',
-                  boxSizing: 'border-box',
-                }}
-              />
-            </div>
-
-            {/* Lat/Lon */}
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px', marginBottom: '12px' }}>
-              <div>
-                <label
-                  style={{
-                    display: 'block',
-                    marginBottom: '6px',
-                    color: 'var(--text-muted)',
-                    fontSize: '11px',
-                    textTransform: 'uppercase',
-                  }}
-                >
-                  {t('station.settings.latitude')}
-                </label>
-                <input
-                  type="number"
-                  step="0.000001"
-                  value={isNaN(lat) ? '' : lat}
-                  onChange={(e) => setLat(parseFloat(e.target.value) || 0)}
-                  style={{
-                    width: '100%',
-                    padding: '10px',
-                    background: 'var(--bg-tertiary)',
-                    border: '1px solid var(--border-color)',
-                    borderRadius: '6px',
-                    color: 'var(--text-primary)',
-                    fontSize: '14px',
-                    fontFamily: 'var(--font-mono)',
-                    boxSizing: 'border-box',
-                  }}
-                />
-              </div>
-              <div>
-                <label
-                  style={{
-                    display: 'block',
-                    marginBottom: '6px',
-                    color: 'var(--text-muted)',
-                    fontSize: '11px',
-                    textTransform: 'uppercase',
-                  }}
-                >
-                  {t('station.settings.longitude')}
-                </label>
-                <input
-                  type="number"
-                  step="0.000001"
-                  value={isNaN(lon) ? '' : lon}
-                  onChange={(e) => setLon(parseFloat(e.target.value) || 0)}
-                  style={{
-                    width: '100%',
-                    padding: '10px',
-                    background: 'var(--bg-tertiary)',
-                    border: '1px solid var(--border-color)',
-                    borderRadius: '6px',
-                    color: 'var(--text-primary)',
-                    fontSize: '14px',
-                    fontFamily: 'var(--font-mono)',
-                    boxSizing: 'border-box',
-                  }}
-                />
-              </div>
-            </div>
-
-            <button
-              onClick={handleUseLocation}
-              style={{
-                width: '100%',
-                padding: '10px',
-                background: 'var(--bg-tertiary)',
-                border: '1px solid var(--border-color)',
-                borderRadius: '6px',
-                color: 'var(--text-secondary)',
-                fontSize: '13px',
-                cursor: 'pointer',
-                marginBottom: '20px',
-              }}
-            >
-              📍 {t('station.settings.useLocation')}
-            </button>
-
-            {/* Mouse wheel zoom factor */}
-            <div style={{ marginBottom: '31px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                {t('station.settings.mouseZoom')}
-                <input
-                  type="range"
-                  min="1"
-                  max="100"
-                  value={mouseZoom}
-                  onChange={(e) => setMouseZoom(e.target.value)}
-                  style={{
-                    width: '100%',
-                    cursor: 'pointer',
-                    marginTop: '3px',
-                  }}
-                />
-              </label>
-              <span style={{ float: 'left', fontSize: '11px', color: 'var(--text-muted)' }}>
-                {t('station.settings.mouseZoom.describeMin')}
-              </span>
-              <span style={{ float: 'right', fontSize: '11px', color: 'var(--text-muted)' }}>
-                {t('station.settings.mouseZoom.describeMax')}
-              </span>
-            </div>
-
-            {/* DX Cluster Source */}
-            <div style={{ marginBottom: '20px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  marginBottom: '8px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                🕐 {t('station.settings.timezone')}
-              </label>
-              <select
-                value={timezone}
-                onChange={(e) => setTimezone(e.target.value)}
-                style={{
-                  width: '100%',
-                  padding: '12px',
-                  background: 'var(--bg-tertiary)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '6px',
-                  color: timezone ? 'var(--accent-green)' : 'var(--text-muted)',
-                  fontSize: '14px',
-                  fontFamily: 'var(--font-mono)',
-                  cursor: 'pointer',
-                }}
-              >
-                <option value="">{t('station.settings.timezone.auto')}</option>
-                <optgroup label={t('station.settings.timezone.group.northAmerica')}>
-                  <option value="America/New_York">Eastern (New York)</option>
-                  <option value="America/Chicago">Central (Chicago)</option>
-                  <option value="America/Denver">Mountain (Denver)</option>
-                  <option value="America/Los_Angeles">Pacific (Los Angeles)</option>
-                  <option value="America/Anchorage">Alaska</option>
-                  <option value="Pacific/Honolulu">Hawaii</option>
-                  <option value="America/Phoenix">Arizona (no DST)</option>
-                  <option value="America/Regina">Saskatchewan (no DST)</option>
-                  <option value="America/Halifax">Atlantic (Halifax)</option>
-                  <option value="America/St_Johns">Newfoundland</option>
-                  <option value="America/Toronto">Ontario (Toronto)</option>
-                  <option value="America/Winnipeg">Manitoba (Winnipeg)</option>
-                  <option value="America/Edmonton">Alberta (Edmonton)</option>
-                  <option value="America/Vancouver">BC (Vancouver)</option>
-                  <option value="America/Mexico_City">Mexico City</option>
-                </optgroup>
-                <optgroup label={t('station.settings.timezone.group.europe')}>
-                  <option value="Europe/London">UK (London)</option>
-                  <option value="Europe/Dublin">Ireland (Dublin)</option>
-                  <option value="Europe/Paris">Central Europe (Paris)</option>
-                  <option value="Europe/Berlin">Germany (Berlin)</option>
-                  <option value="Europe/Rome">Italy (Rome)</option>
-                  <option value="Europe/Madrid">Spain (Madrid)</option>
-                  <option value="Europe/Amsterdam">Netherlands (Amsterdam)</option>
-                  <option value="Europe/Brussels">Belgium (Brussels)</option>
-                  <option value="Europe/Stockholm">Sweden (Stockholm)</option>
-                  <option value="Europe/Helsinki">Finland (Helsinki)</option>
-                  <option value="Europe/Athens">Greece (Athens)</option>
-                  <option value="Europe/Bucharest">Romania (Bucharest)</option>
-                  <option value="Europe/Moscow">Russia (Moscow)</option>
-                  <option value="Europe/Warsaw">Poland (Warsaw)</option>
-                  <option value="Europe/Zurich">Switzerland (Zurich)</option>
-                  <option value="Europe/Lisbon">Portugal (Lisbon)</option>
-                </optgroup>
-                <optgroup label={t('station.settings.timezone.group.asiaPacific')}>
-                  <option value="Asia/Tokyo">Japan (Tokyo)</option>
-                  <option value="Asia/Seoul">Korea (Seoul)</option>
-                  <option value="Asia/Shanghai">China (Shanghai)</option>
-                  <option value="Asia/Hong_Kong">Hong Kong</option>
-                  <option value="Asia/Taipei">Taiwan (Taipei)</option>
-                  <option value="Asia/Singapore">Singapore</option>
-                  <option value="Asia/Kolkata">India (Kolkata)</option>
-                  <option value="Asia/Dubai">UAE (Dubai)</option>
-                  <option value="Asia/Riyadh">Saudi Arabia (Riyadh)</option>
-                  <option value="Asia/Tehran">Iran (Tehran)</option>
-                  <option value="Asia/Bangkok">Thailand (Bangkok)</option>
-                  <option value="Asia/Jakarta">Indonesia (Jakarta)</option>
-                  <option value="Asia/Manila">Philippines (Manila)</option>
-                  <option value="Australia/Brisbane">Australia Eastern (Brisbane)</option>
-                  <option value="Australia/Sydney">Australia Eastern (Sydney, Canberra, Melbourne, Hobart)</option>
-                  <option value="Australia/Adelaide">Australia Central (Adelaide)</option>
-                  <option value="Australia/Perth">Australia Western (Perth)</option>
-                  <option value="Pacific/Auckland">New Zealand (Auckland)</option>
-                  <option value="Pacific/Fiji">Fiji</option>
-                </optgroup>
-                <optgroup label={t('station.settings.timezone.group.southAmerica')}>
-                  <option value="America/Sao_Paulo">Brazil (São Paulo)</option>
-                  <option value="America/Argentina/Buenos_Aires">Argentina (Buenos Aires)</option>
-                  <option value="America/Santiago">Chile (Santiago)</option>
-                  <option value="America/Bogota">Colombia (Bogotá)</option>
-                  <option value="America/Lima">Peru (Lima)</option>
-                  <option value="America/Caracas">Venezuela (Caracas)</option>
-                </optgroup>
-                <optgroup label={t('station.settings.timezone.group.africa')}>
-                  <option value="Africa/Cairo">Egypt (Cairo)</option>
-                  <option value="Africa/Johannesburg">South Africa (Johannesburg)</option>
-                  <option value="Africa/Lagos">Nigeria (Lagos)</option>
-                  <option value="Africa/Nairobi">Kenya (Nairobi)</option>
-                  <option value="Africa/Casablanca">Morocco (Casablanca)</option>
-                </optgroup>
-                <optgroup label={t('station.settings.timezone.group.other')}>
-                  <option value="UTC">UTC</option>
-                  <option value="Atlantic/Reykjavik">Iceland (Reykjavik)</option>
-                  <option value="Atlantic/Azores">Azores</option>
-                  <option value="Indian/Maldives">Maldives</option>
-                  <option value="Indian/Mauritius">Mauritius</option>
-                </optgroup>
-              </select>
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
-                {t('station.settings.timezone.describe')}
-                {timezone ? '' : ' ' + t('station.settings.timezone.currentDefault')}
-              </div>
-            </div>
-
-            {/* Units (Distance, Temperature and Pressure ) */}
-            <div style={{ marginBottom: '20px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  marginBottom: '8px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                📏 {t('station.settings.units.title')}
-              </label>
-              <div style={{ display: 'flex', gap: '8px' }}>
-                <button
-                  onClick={() => toggleDistUnits()}
-                  style={{
-                    flex: 1,
-                    padding: '10px',
-                    background: 'var(--bg-tertiary)',
-                    border: '1px solid var(--border-color)',
-                    borderRadius: '6px',
-                    color: 'var(--accent-green)',
-                    fontSize: '13px',
-                    cursor: 'pointer',
-                    fontWeight: '600',
-                  }}
-                >
-                  {t('station.settings.units.distance')}: {unitString(distUnits)}
-                </button>
-                <button
-                  onClick={() => toggleTempUnits()}
-                  style={{
-                    flex: 1,
-                    padding: '10px',
-                    background: 'var(--bg-tertiary)',
-                    border: '1px solid var(--border-color)',
-                    borderRadius: '6px',
-                    color: 'var(--accent-green)',
-                    fontSize: '13px',
-                    cursor: 'pointer',
-                    fontWeight: '600',
-                  }}
-                >
-                  {t('station.settings.units.temperature')}: {unitString(tempUnits)}
-                </button>
-                <button
-                  onClick={() => togglePressUnits()}
-                  style={{
-                    flex: 1,
-                    padding: '10px',
-                    background: 'var(--bg-tertiary)',
-                    border: '1px solid var(--border-color)',
-                    borderRadius: '6px',
-                    color: 'var(--accent-green)',
-                    fontSize: '13px',
-                    cursor: 'pointer',
-                    fontWeight: '600',
-                  }}
-                >
-                  {t('station.settings.units.pressure')}: {unitString(pressUnits)}
-                </button>
-              </div>
-            </div>
-
-            {/* WSJTX Relay Multicast Options */}
-            <div style={{ marginBottom: '20px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  marginBottom: '8px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                🔁 WSJTX Relay Multicast Options
-              </label>
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '8px', lineHeight: 1.4 }}>
-                <input
-                  type="checkbox"
-                  checked={wsjtxMulticastEnabled}
-                  onChange={(e) => setWsjtxMulticastEnabled(e.target.checked)}
-                  style={{ marginRight: '8px' }}
-                />
-                <span style={{ color: 'var(--text-primary)', fontSize: '14px' }}>Use multicast address &nbsp;</span>
-                <input
-                  type="text"
-                  value={wsjtxMulticastAddress}
-                  onChange={(e) => setWsjtxMulticastAddress(e.target.value.toUpperCase())}
-                  style={{
-                    width: '10%',
-                    marginLeft: '8px',
-                    padding: '8px 12px',
-                    background: 'var(--bg-primary)',
-                    border: '1px solid var(--border-color)',
-                    borderRadius: '4px',
-                    color: wsjtxMulticastEnabled ? 'var(--text-primary)' : 'var(--text-secondary',
-                    fontSize: '12px',
-                    fontFamily: 'var(--font-mono)',
-                    boxSizing: 'border-box',
-                  }}
-                />
-                If you are going to run a wsjt-x relay, define here if you need a multicast listener and what address it
-                should be using.
-              </div>
-            </div>
-
-            {/* Rig Control Settings */}
-            <div style={{ marginBottom: '20px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  marginBottom: '8px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                {t('station.settings.rigControl.title')} (Beta)
-              </label>
 
               <div
                 style={{
@@ -1273,8 +5159,21 @@ export const SettingsPanel = ({
                   padding: '12px',
                   borderRadius: '6px',
                   border: '1px solid var(--border-color)',
+                  marginBottom: '16px',
                 }}
               >
+                <div
+                  style={{
+                    fontSize: '11px',
+                    color: 'var(--text-muted)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                    marginBottom: '10px',
+                  }}
+                >
+                  Connection
+                </div>
+
                 <div style={{ display: 'flex', alignItems: 'center', marginBottom: '12px' }}>
                   <input
                     type="checkbox"
@@ -1282,91 +5181,12 @@ export const SettingsPanel = ({
                     onChange={(e) => setRigEnabled(e.target.checked)}
                     style={{ marginRight: '8px' }}
                   />
-                  <span style={{ color: 'var(--text-primary)', fontSize: '14px' }}>
-                    {t('station.settings.rigControl.enabled')}
-                  </span>
+                  <span style={{ color: 'var(--text-primary)', fontSize: '14px' }}>Enable Rig Bridge</span>
                 </div>
 
                 {rigEnabled && (
                   <>
-                    {/* Download Rig Listener */}
-                    <div
-                      style={{
-                        background: 'rgba(99,102,241,0.08)',
-                        border: '1px solid rgba(99,102,241,0.2)',
-                        borderRadius: '6px',
-                        padding: '10px',
-                        marginBottom: '12px',
-                      }}
-                    >
-                      <div
-                        style={{
-                          fontSize: '11px',
-                          color: 'var(--text-secondary)',
-                          marginBottom: '8px',
-                          lineHeight: 1.4,
-                        }}
-                      >
-                        📻 Download the Rig Listener for your computer. Double-click to run — it connects your radio to
-                        OpenHamClock via USB.
-                      </div>
-                      <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
-                        <a
-                          href="/api/rig/download/windows"
-                          style={{
-                            padding: '5px 12px',
-                            borderRadius: '4px',
-                            fontSize: '11px',
-                            fontWeight: '600',
-                            background: 'rgba(99,102,241,0.15)',
-                            border: '1px solid rgba(99,102,241,0.3)',
-                            color: '#818cf8',
-                            textDecoration: 'none',
-                            cursor: 'pointer',
-                          }}
-                        >
-                          ⊞ Windows
-                        </a>
-                        <a
-                          href="/api/rig/download/mac"
-                          style={{
-                            padding: '5px 12px',
-                            borderRadius: '4px',
-                            fontSize: '11px',
-                            fontWeight: '600',
-                            background: 'rgba(99,102,241,0.15)',
-                            border: '1px solid rgba(99,102,241,0.3)',
-                            color: '#818cf8',
-                            textDecoration: 'none',
-                            cursor: 'pointer',
-                          }}
-                        >
-                          {' '}
-                          Mac
-                        </a>
-                        <a
-                          href="/api/rig/download/linux"
-                          style={{
-                            padding: '5px 12px',
-                            borderRadius: '4px',
-                            fontSize: '11px',
-                            fontWeight: '600',
-                            background: 'rgba(99,102,241,0.15)',
-                            border: '1px solid rgba(99,102,241,0.3)',
-                            color: '#818cf8',
-                            textDecoration: 'none',
-                            cursor: 'pointer',
-                          }}
-                        >
-                          🐧 Linux
-                        </a>
-                      </div>
-                      <div style={{ fontSize: '9px', color: 'var(--text-muted)', marginTop: '6px', opacity: 0.7 }}>
-                        Supports Yaesu, Kenwood, Elecraft, and Icom radios. No extra software needed.
-                      </div>
-                    </div>
-
-                    <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: '10px' }}>
+                    <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: '10px', marginBottom: '10px' }}>
                       <div>
                         <label
                           style={{
@@ -1427,42 +5247,7 @@ export const SettingsPanel = ({
                       </div>
                     </div>
 
-                    <div style={{ marginTop: '10px', display: 'flex', alignItems: 'center' }}>
-                      <input
-                        type="checkbox"
-                        checked={tuneEnabled}
-                        onChange={(e) => setTuneEnabled(e.target.checked)}
-                        style={{ marginRight: '8px' }}
-                      />
-                      <div>
-                        <span style={{ color: 'var(--text-primary)', fontSize: '13px' }}>
-                          {t('station.settings.rigControl.tuneEnabled')}
-                        </span>
-                        <div style={{ fontSize: '10px', color: 'var(--text-muted)' }}>
-                          {t('station.settings.rigControl.tuneEnabled.hint')}
-                        </div>
-                      </div>
-                    </div>
-
-                    <div style={{ marginTop: '10px', display: 'flex', alignItems: 'center' }}>
-                      <input
-                        type="checkbox"
-                        checked={autoMode}
-                        onChange={(e) => setAutoMode(e.target.checked)}
-                        style={{ marginRight: '8px' }}
-                      />
-                      <div>
-                        <span style={{ color: 'var(--text-primary)', fontSize: '13px' }}>
-                          {t('station.settings.rigControl.autoMode')}
-                        </span>
-                        <div style={{ fontSize: '10px', color: 'var(--text-muted)' }}>
-                          {t('station.settings.rigControl.autoMode.hint')}
-                        </div>
-                      </div>
-                    </div>
-
-                    {/* API Token */}
-                    <div style={{ marginTop: '12px' }}>
+                    <div style={{ marginBottom: '10px' }}>
                       <label
                         style={{ display: 'block', fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}
                       >
@@ -1499,7 +5284,7 @@ export const SettingsPanel = ({
                             whiteSpace: 'nowrap',
                           }}
                         >
-                          {showRigToken ? '🙈 Hide' : '👁 Show'}
+                          {showRigToken ? 'Hide' : 'Show'}
                         </button>
                       </div>
                       <div style={{ fontSize: '10px', color: 'var(--text-muted)', marginTop: '4px', lineHeight: 1.4 }}>
@@ -1507,3948 +5292,372 @@ export const SettingsPanel = ({
                       </div>
                     </div>
 
-                    {/* WSJT-X Relay */}
-                    <div
-                      style={{
-                        marginTop: '16px',
-                        paddingTop: '12px',
-                        borderTop: '1px solid var(--border-color)',
-                      }}
-                    >
-                      <div
+                    <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
+                      <label
                         style={{
-                          fontSize: '11px',
-                          color: 'var(--text-muted)',
-                          textTransform: 'uppercase',
-                          letterSpacing: '1px',
-                          marginBottom: '6px',
-                        }}
-                      >
-                        {t('station.settings.rigControl.wsjtxRelay.title')}
-                      </div>
-                      <div
-                        style={{
-                          fontSize: '11px',
-                          color: 'var(--text-secondary)',
-                          marginBottom: '10px',
-                          lineHeight: 1.4,
-                        }}
-                      >
-                        {t('station.settings.rigControl.wsjtxRelay.hint')}
-                      </div>
-
-                      {/* Session ID display */}
-                      {wsjtxSessionId && (
-                        <div style={{ marginBottom: '10px' }}>
-                          <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}>
-                            {t('station.settings.rigControl.wsjtxRelay.sessionId')}
-                          </div>
-                          <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
-                            <input
-                              type="text"
-                              readOnly
-                              value={wsjtxSessionId}
-                              style={{
-                                flex: 1,
-                                padding: '6px 10px',
-                                background: 'var(--bg-primary)',
-                                border: '1px solid var(--border-color)',
-                                borderRadius: '4px',
-                                color: 'var(--text-secondary)',
-                                fontSize: '12px',
-                                fontFamily: 'monospace',
-                              }}
-                            />
-                            <button
-                              type="button"
-                              onClick={() => navigator.clipboard?.writeText(wsjtxSessionId)}
-                              style={{
-                                padding: '6px 10px',
-                                background: 'var(--bg-tertiary)',
-                                border: '1px solid var(--border-color)',
-                                borderRadius: '4px',
-                                color: 'var(--text-secondary)',
-                                fontSize: '11px',
-                                cursor: 'pointer',
-                                whiteSpace: 'nowrap',
-                              }}
-                            >
-                              📋 Copy
-                            </button>
-                          </div>
-                          <div
-                            style={{ fontSize: '10px', color: 'var(--text-muted)', marginTop: '4px', lineHeight: 1.4 }}
-                          >
-                            {t('station.settings.rigControl.wsjtxRelay.sessionId.hint')}
-                          </div>
-                        </div>
-                      )}
-
-                      {/* Configure button */}
-                      <button
-                        type="button"
-                        onClick={handleConfigureWsjtxRelay}
-                        disabled={wsjtxRelayStatus === 'pushing'}
-                        style={{
-                          width: '100%',
-                          padding: '8px',
-                          background: 'rgba(99,102,241,0.15)',
-                          border: '1px solid rgba(99,102,241,0.3)',
-                          borderRadius: '4px',
-                          color: '#818cf8',
-                          fontSize: '12px',
-                          fontWeight: '600',
-                          cursor: wsjtxRelayStatus === 'pushing' ? 'wait' : 'pointer',
-                        }}
-                      >
-                        {wsjtxRelayStatus === 'pushing'
-                          ? t('station.settings.rigControl.wsjtxRelay.status.pushing')
-                          : t('station.settings.rigControl.wsjtxRelay.configure')}
-                      </button>
-
-                      {/* Status feedback */}
-                      {wsjtxRelayStatus && wsjtxRelayStatus !== 'pushing' && (
-                        <div
-                          style={{
-                            marginTop: '6px',
-                            fontSize: '11px',
-                            color:
-                              wsjtxRelayStatus === 'ok' ? 'var(--accent-green, #4ade80)' : 'var(--accent-red, #f87171)',
-                            lineHeight: 1.4,
-                          }}
-                        >
-                          {wsjtxRelayStatus === 'ok' ? '✅ ' : '❌ '}
-                          {wsjtxRelayMsg}
-                        </div>
-                      )}
-                    </div>
-                  </>
-                )}
-              </div>
-            </div>
-
-            {/* Propagation Settings */}
-            <div style={{ marginBottom: '20px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  marginBottom: '8px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                ⌇ {t('station.settings.operatingMode.title')}
-              </label>
-
-              {/* Mode */}
-              <div style={{ marginBottom: '8px' }}>
-                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}>
-                  {t('station.settings.operatingMode')}
-                </div>
-                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '4px' }}>
-                  {[
-                    { id: 'SSB', label: 'SSB', desc: 'Voice' },
-                    { id: 'CW', label: 'CW', desc: 'Morse' },
-                    { id: 'FT8', label: 'FT8', desc: 'Weak sig' },
-                    { id: 'FT4', label: 'FT4', desc: 'Weak sig' },
-                    { id: 'WSPR', label: 'WSPR', desc: 'Beacon' },
-                    { id: 'JS8', label: 'JS8', desc: 'Chat' },
-                    { id: 'RTTY', label: 'RTTY', desc: 'Teletype' },
-                    { id: 'PSK31', label: 'PSK31', desc: 'PSK' },
-                  ].map((m) => (
-                    <button
-                      key={m.id}
-                      onClick={() => setPropMode(m.id)}
-                      aria-pressed={propMode === m.id}
-                      style={{
-                        padding: '6px 4px',
-                        background: propMode === m.id ? 'var(--accent-amber)' : 'var(--bg-tertiary)',
-                        border: `1px solid ${propMode === m.id ? 'var(--accent-amber)' : 'var(--border-color)'}`,
-                        borderRadius: '4px',
-                        color: propMode === m.id ? '#000' : 'var(--text-secondary)',
-                        fontSize: '11px',
-                        cursor: 'pointer',
-                        fontWeight: propMode === m.id ? '700' : '400',
-                        fontFamily: 'var(--font-mono)',
-                        lineHeight: 1.2,
-                        textAlign: 'center',
-                      }}
-                      title={m.desc}
-                    >
-                      {m.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              {/* Power */}
-              <div style={{ marginBottom: '6px' }}>
-                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}>
-                  {t('station.settings.operatingMode.txPower')}
-                </div>
-                <div
-                  style={{
-                    display: 'grid',
-                    gridTemplateColumns: 'repeat(4, 1fr)',
-                    gap: '4px',
-                    alignItems: 'center',
-                  }}
-                >
-                  {[
-                    { w: 5, label: '5W', tip: 'QRP' },
-                    { w: 25, label: '25W', tip: 'Low' },
-                    { w: 100, label: '100W', tip: 'Std' },
-                    { w: 1500, label: '1.5kW', tip: 'Max' },
-                  ].map((p) => (
-                    <button
-                      key={p.w}
-                      onClick={() => setPropPower(p.w)}
-                      aria-pressed={propPower === p.w}
-                      style={{
-                        padding: '6px 4px',
-                        background: propPower === p.w ? 'var(--accent-amber)' : 'var(--bg-tertiary)',
-                        border: `1px solid ${propPower === p.w ? 'var(--accent-amber)' : 'var(--border-color)'}`,
-                        borderRadius: '4px',
-                        color: propPower === p.w ? '#000' : 'var(--text-secondary)',
-                        fontSize: '11px',
-                        cursor: 'pointer',
-                        fontWeight: propPower === p.w ? '700' : '400',
-                        fontFamily: 'var(--font-mono)',
-                      }}
-                      title={p.tip}
-                    >
-                      {p.label}
-                    </button>
-                  ))}
-                </div>
-                {/* Non-preset value (set from Propagation panel's Custom… input) — show, but read-only here */}
-                {![5, 25, 100, 1500].includes(propPower) && (
-                  <div
-                    style={{
-                      marginTop: '4px',
-                      fontSize: '10px',
-                      color: 'var(--text-muted)',
-                      fontFamily: 'var(--font-mono)',
-                    }}
-                  >
-                    Custom: {propPower}W <span style={{ opacity: 0.7 }}>(set from Propagation panel)</span>
-                  </div>
-                )}
-              </div>
-
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
-                {(() => {
-                  const modeAdv = { SSB: 0, CW: 10, RTTY: 8, PSK31: 10, FT8: 34, FT4: 30, WSPR: 41, JS8: 37 };
-                  const adv = modeAdv[propMode] || 0;
-                  const pwrDb = 10 * Math.log10((propPower || 100) / 100);
-                  const margin = adv + pwrDb;
-                  return `Signal margin: ${margin >= 0 ? '+' : ''}${margin.toFixed(1)} dB vs SSB@100W — ${
-                    margin >= 30
-                      ? 'extreme weak-signal advantage'
-                      : margin >= 15
-                        ? 'strong advantage — marginal bands may open'
-                        : margin >= 5
-                          ? 'moderate advantage'
-                          : margin >= -5
-                            ? 'baseline conditions'
-                            : margin >= -15
-                              ? 'reduced margin — some bands may close'
-                              : 'significant disadvantage — only strong openings'
-                  }`;
-                })()}
-              </div>
-            </div>
-
-            {/* Low Memory Mode */}
-            <div style={{ marginBottom: '20px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  marginBottom: '8px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                🧠 Performance Mode
-              </label>
-              <div style={{ display: 'flex', gap: '8px' }}>
-                <button
-                  onClick={() => setLowMemoryMode(false)}
-                  style={{
-                    flex: 1,
-                    padding: '10px',
-                    background: !lowMemoryMode ? 'var(--accent-amber)' : 'var(--bg-tertiary)',
-                    border: `1px solid ${!lowMemoryMode ? 'var(--accent-amber)' : 'var(--border-color)'}`,
-                    borderRadius: '6px',
-                    color: !lowMemoryMode ? '#000' : 'var(--text-secondary)',
-                    fontSize: '13px',
-                    cursor: 'pointer',
-                    fontWeight: !lowMemoryMode ? '600' : '400',
-                  }}
-                >
-                  🚀 Full
-                </button>
-                <button
-                  onClick={() => setLowMemoryMode(true)}
-                  style={{
-                    flex: 1,
-                    padding: '10px',
-                    background: lowMemoryMode ? 'var(--accent-green)' : 'var(--bg-tertiary)',
-                    border: `1px solid ${lowMemoryMode ? 'var(--accent-green)' : 'var(--border-color)'}`,
-                    borderRadius: '6px',
-                    color: lowMemoryMode ? '#000' : 'var(--text-secondary)',
-                    fontSize: '13px',
-                    cursor: 'pointer',
-                    fontWeight: lowMemoryMode ? '600' : '400',
-                  }}
-                >
-                  🪶 Low Memory
-                </button>
-              </div>
-              <div
-                style={{
-                  fontSize: '11px',
-                  color: lowMemoryMode ? 'var(--accent-green)' : 'var(--text-muted)',
-                  marginTop: '6px',
-                }}
-              >
-                {lowMemoryMode
-                  ? '✓ Low Memory Mode: Reduced animations, fewer map markers, smaller spot limits. Recommended for systems with <8GB RAM.'
-                  : 'Full Mode: All features enabled. Requires 8GB+ RAM for best performance.'}
-              </div>
-            </div>
-            <div style={{ marginBottom: '20px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  marginBottom: '8px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                {t('station.settings.preventSleep')}
-              </label>
-              <div style={{ display: 'flex', gap: '10px' }}>
-                <button
-                  onClick={() => setPreventSleep(false)}
-                  style={{
-                    flex: 1,
-                    padding: '10px',
-                    background: !preventSleep ? 'var(--accent-amber)' : 'var(--bg-tertiary)',
-                    border: `1px solid ${!preventSleep ? 'var(--accent-amber)' : 'var(--border-color)'}`,
-                    borderRadius: '6px',
-                    color: !preventSleep ? '#000' : 'var(--text-secondary)',
-                    fontSize: '13px',
-                    cursor: 'pointer',
-                    fontWeight: !preventSleep ? '600' : '400',
-                  }}
-                >
-                  💤 {t('station.settings.preventSleep.off')}
-                </button>
-                <button
-                  onClick={() => setPreventSleep(true)}
-                  style={{
-                    flex: 1,
-                    padding: '10px',
-                    background: preventSleep ? 'var(--accent-green)' : 'var(--bg-tertiary)',
-                    border: `1px solid ${preventSleep ? 'var(--accent-green)' : 'var(--border-color)'}`,
-                    borderRadius: '6px',
-                    color: preventSleep ? '#000' : 'var(--text-secondary)',
-                    fontSize: '13px',
-                    cursor: 'pointer',
-                    fontWeight: preventSleep ? '600' : '400',
-                  }}
-                >
-                  🖥️ {t('station.settings.preventSleep.on')}
-                </button>
-              </div>
-              <div style={{ marginTop: '8px' }}>
-                {preventSleep && wakeLockStatus && (
-                  <div
-                    style={{
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      gap: '5px',
-                      padding: '3px 8px',
-                      borderRadius: '4px',
-                      fontSize: '11px',
-                      fontFamily: 'var(--font-mono)',
-                      fontWeight: '600',
-                      marginBottom: '6px',
-                      background: wakeLockStatus.active ? 'rgba(0,200,100,0.15)' : 'rgba(255,160,0,0.15)',
-                      border: `1px solid ${wakeLockStatus.active ? 'var(--accent-green)' : 'var(--accent-amber)'}`,
-                      color: wakeLockStatus.active ? 'var(--accent-green)' : 'var(--accent-amber)',
-                    }}
-                  >
-                    {wakeLockStatus.active ? '🔒' : '⚠'}
-                    {wakeLockStatus.active
-                      ? t('station.settings.preventSleep.status.active')
-                      : t(`station.settings.preventSleep.status.${wakeLockStatus.reason}`, {
-                          defaultValue: t('station.settings.preventSleep.status.error'),
-                        })}
-                  </div>
-                )}
-                <div
-                  style={{
-                    fontSize: '11px',
-                    color: preventSleep && wakeLockStatus?.active ? 'var(--accent-green)' : 'var(--text-muted)',
-                  }}
-                >
-                  {t(
-                    preventSleep
-                      ? 'station.settings.preventSleep.describe.on'
-                      : 'station.settings.preventSleep.describe.off',
-                  )}
-                </div>
-              </div>
-            </div>
-
-            {/* Active Users Presence */}
-            <div style={{ marginBottom: '20px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  marginBottom: '8px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                {t('station.settings.sharePresence')}
-              </label>
-              <div style={{ display: 'flex', gap: '10px' }}>
-                <button
-                  onClick={() => setSharePresence(false)}
-                  style={{
-                    flex: 1,
-                    padding: '10px',
-                    background: !sharePresence ? 'var(--accent-amber)' : 'var(--bg-tertiary)',
-                    border: `1px solid ${!sharePresence ? 'var(--accent-amber)' : 'var(--border-color)'}`,
-                    borderRadius: '6px',
-                    color: !sharePresence ? '#000' : 'var(--text-secondary)',
-                    fontSize: '13px',
-                    cursor: 'pointer',
-                    fontWeight: !sharePresence ? '600' : '400',
-                  }}
-                >
-                  {t('station.settings.sharePresence.off')}
-                </button>
-                <button
-                  onClick={() => setSharePresence(true)}
-                  style={{
-                    flex: 1,
-                    padding: '10px',
-                    background: sharePresence ? 'var(--accent-green)' : 'var(--bg-tertiary)',
-                    border: `1px solid ${sharePresence ? 'var(--accent-green)' : 'var(--border-color)'}`,
-                    borderRadius: '6px',
-                    color: sharePresence ? '#000' : 'var(--text-secondary)',
-                    fontSize: '13px',
-                    cursor: 'pointer',
-                    fontWeight: sharePresence ? '600' : '400',
-                  }}
-                >
-                  {t('station.settings.sharePresence.on')}
-                </button>
-              </div>
-              <div
-                style={{
-                  fontSize: '11px',
-                  color: 'var(--text-muted)',
-                  marginTop: '8px',
-                }}
-              >
-                {t(
-                  sharePresence
-                    ? 'station.settings.sharePresence.describe.on'
-                    : 'station.settings.sharePresence.describe.off',
-                )}
-              </div>
-            </div>
-
-            {/* Display Schedule */}
-            <div style={{ marginBottom: '20px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  marginBottom: '8px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                Display Schedule
-              </label>
-              <label
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '10px',
-                  cursor: 'pointer',
-                  fontSize: '13px',
-                  color: 'var(--text-primary)',
-                  marginBottom: '10px',
-                }}
-              >
-                <input
-                  type="checkbox"
-                  checked={displaySchedule.enabled}
-                  onChange={(e) => setDisplaySchedule({ ...displaySchedule, enabled: e.target.checked })}
-                  style={{ accentColor: 'var(--accent-amber)' }}
-                />
-                Enable scheduled display sleep
-              </label>
-              {displaySchedule.enabled && (
-                <div style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '8px' }}>
-                  <div>
-                    <label
-                      style={{ display: 'block', fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}
-                    >
-                      Sleep at
-                    </label>
-                    <input
-                      type="time"
-                      value={displaySchedule.sleepTime}
-                      onChange={(e) => setDisplaySchedule({ ...displaySchedule, sleepTime: e.target.value })}
-                      style={{
-                        background: 'var(--bg-tertiary)',
-                        border: '1px solid var(--border-color)',
-                        borderRadius: '4px',
-                        color: 'var(--text-primary)',
-                        padding: '6px 10px',
-                        fontSize: '13px',
-                        fontFamily: 'var(--font-mono)',
-                      }}
-                    />
-                  </div>
-                  <div>
-                    <label
-                      style={{ display: 'block', fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}
-                    >
-                      Wake at
-                    </label>
-                    <input
-                      type="time"
-                      value={displaySchedule.wakeTime}
-                      onChange={(e) => setDisplaySchedule({ ...displaySchedule, wakeTime: e.target.value })}
-                      style={{
-                        background: 'var(--bg-tertiary)',
-                        border: '1px solid var(--border-color)',
-                        borderRadius: '4px',
-                        color: 'var(--text-primary)',
-                        padding: '6px 10px',
-                        fontSize: '13px',
-                        fontFamily: 'var(--font-mono)',
-                      }}
-                    />
-                  </div>
-                </div>
-              )}
-              {displaySchedule.enabled && (
-                <label
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '10px',
-                    cursor: 'pointer',
-                    fontSize: '13px',
-                    color: 'var(--text-primary)',
-                    marginBottom: '8px',
-                  }}
-                >
-                  <input
-                    type="checkbox"
-                    checked={displaySchedule.keepSignalActive !== false}
-                    onChange={(e) => setDisplaySchedule({ ...displaySchedule, keepSignalActive: e.target.checked })}
-                    style={{ accentColor: 'var(--accent-amber)' }}
-                  />
-                  Keep HDMI signal active during sleep (recommended for TVs)
-                </label>
-              )}
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)' }}>
-                {displaySchedule.enabled
-                  ? displaySchedule.keepSignalActive !== false
-                    ? `Display will go black at ${displaySchedule.sleepTime} and wake at ${displaySchedule.wakeTime} (local time). The HDMI signal stays alive so TVs don't latch into standby — turn this off only if you want the display to actually power down.`
-                    : `Display will go black at ${displaySchedule.sleepTime} and wake at ${displaySchedule.wakeTime} (local time). The wake lock will be released so your monitor can power off. Note: TVs that go to standby on signal loss will not wake automatically — enable "Keep HDMI signal active" above if this affects you.`
-                  : 'Set a daily schedule to automatically black out the display at night. Ideal for shack TVs and kiosk displays.'}
-              </div>
-            </div>
-
-            <div style={{ marginBottom: '20px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  marginBottom: '8px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                {t('station.settings.dx.title')}
-              </label>
-              <select
-                value={dxClusterSource}
-                onChange={(e) => setDxClusterSource(e.target.value)}
-                style={{
-                  width: '100%',
-                  padding: '12px',
-                  background: 'var(--bg-tertiary)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '6px',
-                  color: 'var(--accent-green)',
-                  fontSize: '14px',
-                  fontFamily: 'var(--font-mono)',
-                  cursor: 'pointer',
-                }}
-              >
-                <option value="dxspider-proxy">{t('station.settings.dx.option1')}</option>
-                <option value="hamqth">{t('station.settings.dx.option2')}</option>
-                <option value="dxwatch">{t('station.settings.dx.option3')}</option>
-                <option value="auto">{t('station.settings.dx.option4')}</option>
-                <option value="custom">{t('station.settings.dx.custom.option')}</option>
-                {isLocalInstall && (
-                  <option value="udp">
-                    {t('station.settings.dx.udp.option', { defaultValue: 'UDP Spots (Local Network)' })}
-                  </option>
-                )}
-              </select>
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
-                {t('station.settings.dx.describe')}
-              </div>
-            </div>
-
-            {dxClusterSource === 'udp' && (
-              <div
-                style={{
-                  marginBottom: '20px',
-                  padding: '16px',
-                  background: 'var(--bg-tertiary)',
-                  borderRadius: '8px',
-                  border: '1px solid var(--border-color)',
-                }}
-              >
-                <label
-                  style={{
-                    display: 'block',
-                    marginBottom: '12px',
-                    color: 'var(--accent-cyan)',
-                    fontSize: '12px',
-                    fontWeight: '600',
-                  }}
-                >
-                  {t('station.settings.dx.udp.title', { defaultValue: 'UDP Spot Listener' })}
-                </label>
-
-                <div style={{ marginBottom: '12px' }}>
-                  <label
-                    style={{ display: 'block', marginBottom: '4px', color: 'var(--text-muted)', fontSize: '11px' }}
-                  >
-                    {t('station.settings.dx.udp.host', { defaultValue: 'UDP IP Address (optional)' })}
-                  </label>
-                  <input
-                    type="text"
-                    value={udpDxCluster.host}
-                    onChange={(e) => setUdpDxCluster({ ...udpDxCluster, host: e.target.value.trim() })}
-                    placeholder={t('station.settings.dx.udp.host.placeholder', {
-                      defaultValue: 'Leave blank unless a specific sender/multicast IP is required',
-                    })}
-                    style={{
-                      width: '100%',
-                      padding: '10px 12px',
-                      background: 'var(--bg-secondary)',
-                      border: '1px solid var(--border-color)',
-                      borderRadius: '6px',
-                      color: 'var(--text-primary)',
-                      fontSize: '14px',
-                      fontFamily: 'var(--font-mono)',
-                    }}
-                  />
-                </div>
-
-                <div style={{ marginBottom: '12px' }}>
-                  <label
-                    style={{ display: 'block', marginBottom: '4px', color: 'var(--text-muted)', fontSize: '11px' }}
-                  >
-                    {t('station.settings.dx.udp.port', { defaultValue: 'UDP Port' })}
-                  </label>
-                  <input
-                    type="number"
-                    value={udpDxCluster.port}
-                    onChange={(e) => setUdpDxCluster({ ...udpDxCluster, port: parseInt(e.target.value, 10) || 12060 })}
-                    placeholder={t('station.settings.dx.udp.port.placeholder', { defaultValue: '12060' })}
-                    style={{
-                      width: '100%',
-                      padding: '10px 12px',
-                      background: 'var(--bg-secondary)',
-                      border: '1px solid var(--border-color)',
-                      borderRadius: '6px',
-                      color: 'var(--text-primary)',
-                      fontSize: '14px',
-                      fontFamily: 'var(--font-mono)',
-                    }}
-                  />
-                </div>
-
-                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '8px' }}>
-                  {t('station.settings.dx.udp.help', {
-                    defaultValue:
-                      'OpenHamClock listens for UDP DX spot packets on this port and plots matched spots on the map.',
-                  })}
-                </div>
-              </div>
-            )}
-
-            {/* Custom DX Cluster Settings */}
-            {dxClusterSource === 'custom' && (
-              <div
-                style={{
-                  marginBottom: '20px',
-                  padding: '16px',
-                  background: 'var(--bg-tertiary)',
-                  borderRadius: '8px',
-                  border: '1px solid var(--border-color)',
-                }}
-              >
-                <label
-                  style={{
-                    display: 'block',
-                    marginBottom: '12px',
-                    color: 'var(--accent-cyan)',
-                    fontSize: '12px',
-                    fontWeight: '600',
-                  }}
-                >
-                  {t('station.settings.dx.custom.title')}
-                </label>
-
-                {/* Host */}
-                <div style={{ marginBottom: '12px' }}>
-                  <label
-                    style={{ display: 'block', marginBottom: '4px', color: 'var(--text-muted)', fontSize: '11px' }}
-                  >
-                    {t('station.settings.dx.custom.host')}
-                  </label>
-                  <input
-                    type="text"
-                    value={customDxCluster.host}
-                    onChange={(e) => setCustomDxCluster({ ...customDxCluster, host: e.target.value })}
-                    placeholder={t('station.settings.dx.custom.host.placeholder')}
-                    style={{
-                      width: '100%',
-                      padding: '10px 12px',
-                      background: 'var(--bg-secondary)',
-                      border: '1px solid var(--border-color)',
-                      borderRadius: '6px',
-                      color: 'var(--text-primary)',
-                      fontSize: '14px',
-                      fontFamily: 'var(--font-mono)',
-                    }}
-                  />
-                </div>
-
-                {/* Port */}
-                <div style={{ marginBottom: '12px' }}>
-                  <label
-                    style={{ display: 'block', marginBottom: '4px', color: 'var(--text-muted)', fontSize: '11px' }}
-                  >
-                    {t('station.settings.dx.custom.port')}
-                  </label>
-                  <input
-                    type="number"
-                    value={customDxCluster.port}
-                    onChange={(e) => setCustomDxCluster({ ...customDxCluster, port: parseInt(e.target.value) || 7300 })}
-                    placeholder={t('station.settings.dx.custom.port.placeholder')}
-                    style={{
-                      width: '100%',
-                      padding: '10px 12px',
-                      background: 'var(--bg-secondary)',
-                      border: '1px solid var(--border-color)',
-                      borderRadius: '6px',
-                      color: 'var(--text-primary)',
-                      fontSize: '14px',
-                      fontFamily: 'var(--font-mono)',
-                    }}
-                  />
-                </div>
-
-                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '8px' }}>
-                  {t('station.settings.dx.custom.callsign', { callsign: callsign || 'N0CALL' })}{' '}
-                  {t('station.settings.dx.custom.commonPorts')}
-                </div>
-                <div style={{ fontSize: '11px', color: 'var(--accent-amber)', marginTop: '8px' }}>
-                  {t('station.settings.dx.custom.warning')}
-                </div>
-              </div>
-            )}
-
-            {/* Callbook for callsign lookups (#989) */}
-            <div style={{ marginBottom: '20px' }}>
-              <label
-                htmlFor="callbook-select"
-                style={{
-                  display: 'block',
-                  marginBottom: '8px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                {t('station.settings.callbook.title')}
-              </label>
-              <select
-                id="callbook-select"
-                value={callbook}
-                onChange={(e) => {
-                  const next = e.target.value;
-                  setCallbook(next);
-                  try {
-                    localStorage.setItem('ohc_callbook', next);
-                  } catch {}
-                  window.dispatchEvent(new Event('ohc-callbook-changed'));
-                }}
-                style={{
-                  width: '100%',
-                  padding: '12px',
-                  background: 'var(--bg-tertiary)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '6px',
-                  color: 'var(--accent-green)',
-                  fontSize: '14px',
-                  fontFamily: 'var(--font-mono)',
-                  cursor: 'pointer',
-                }}
-              >
-                {CALLBOOKS.map((cb) => (
-                  <option key={cb.id} value={cb.id}>
-                    {cb.label}
-                  </option>
-                ))}
-              </select>
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
-                {t('station.settings.callbook.describe')}
-              </div>
-            </div>
-
-            {/* Language */}
-            <div style={{ marginBottom: '20px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  marginBottom: '8px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                ⊕ {t('station.settings.language')}
-              </label>
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '6px' }}>
-                {LANGUAGES.map((lang) => (
-                  <button
-                    key={lang.code}
-                    onClick={() => i18n.changeLanguage(lang.code)}
-                    style={{
-                      padding: '8px 6px',
-                      background:
-                        i18n.language === lang.code || (i18n.language && i18n.language.startsWith(lang.code))
-                          ? 'rgba(0, 221, 255, 0.2)'
-                          : 'var(--bg-tertiary)',
-                      border: `1px solid ${
-                        i18n.language === lang.code || (i18n.language && i18n.language.startsWith(lang.code))
-                          ? 'var(--accent-cyan)'
-                          : 'var(--border-color)'
-                      }`,
-                      borderRadius: '6px',
-                      color:
-                        i18n.language === lang.code || (i18n.language && i18n.language.startsWith(lang.code))
-                          ? 'var(--accent-cyan)'
-                          : 'var(--text-secondary)',
-                      fontSize: '12px',
-                      cursor: 'pointer',
-                      fontWeight:
-                        i18n.language === lang.code || (i18n.language && i18n.language.startsWith(lang.code))
-                          ? '600'
-                          : '400',
-                      textAlign: 'center',
-                    }}
-                  >
-                    {(() => {
-                      const iso = emojiToIso2(lang.flag);
-                      return iso ? (
-                        <img
-                          src={`https://flagcdn.com/w20/${iso}.png`}
-                          alt=""
-                          style={{ height: '0.9em', verticalAlign: 'middle', borderRadius: '1px', marginRight: '4px' }}
-                          crossOrigin="anonymous"
-                        />
-                      ) : (
-                        <span style={{ marginRight: '4px' }}>{lang.flag}</span>
-                      );
-                    })()}
-                    {lang.name}
-                  </button>
-                ))}
-              </div>
-            </div>
-          </>
-        )}
-
-        {/* Integrations Tab */}
-        {activeTab === 'integrations' && (
-          <div>
-            {/* Status pill */}
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                gap: 12,
-                marginBottom: 16,
-                padding: '10px 14px',
-                borderRadius: 10,
-                border: '1px solid var(--border-color)',
-                background: 'var(--bg-tertiary)',
-              }}
-            >
-              <div style={{ color: 'var(--text-secondary)', fontSize: 12 }}>
-                These features require a local OpenHamClock instance.
-              </div>
-              <div
-                style={{
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 11,
-                  padding: '4px 10px',
-                  borderRadius: 999,
-                  border: `1px solid ${isLocalInstall ? 'var(--accent-cyan)' : 'rgba(255,255,255,0.18)'}`,
-                  color: isLocalInstall ? 'var(--accent-cyan)' : 'var(--text-muted)',
-                  background: isLocalInstall ? 'rgba(0,255,255,0.10)' : 'rgba(0,0,0,0.25)',
-                }}
-              >
-                {isLocalInstall ? 'Local mode' : 'Hosted mode'}
-              </div>
-            </div>
-
-            {/* Local-only group */}
-            <div
-              style={{
-                background: 'rgba(0, 255, 255, 0.05)',
-                border: '1px solid var(--border-color)',
-                borderRadius: '10px',
-                padding: '14px 16px',
-                marginBottom: 16,
-              }}
-            >
-              <div
-                style={{
-                  display: 'flex',
-                  alignItems: 'baseline',
-                  justifyContent: 'space-between',
-                  gap: 12,
-                  marginBottom: 10,
-                }}
-              >
-                <div>
-                  <div style={{ color: 'var(--accent-cyan)', fontWeight: 800, letterSpacing: 0.2 }}>Local-only</div>
-                  <div style={{ color: 'var(--text-secondary)', fontSize: 12, lineHeight: 1.45, marginTop: 4 }}>
-                    These integrations are disabled on the hosted site so they can never crash or spam the network.
-                  </div>
-                </div>
-              </div>
-
-              {/* Rotator */}
-              <div
-                style={{
-                  borderTop: '1px solid rgba(255,255,255,0.08)',
-                  paddingTop: 12,
-                  marginTop: 8,
-                }}
-              >
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
-                  <div>
-                    <div style={{ fontWeight: 700, color: 'var(--text-primary)' }}>🧭 Rotator</div>
-                    <div style={{ color: 'var(--text-secondary)', fontSize: 12, lineHeight: 1.45 }}>
-                      Requires a rotator backend (e.g., PstRotatorAz or a simple HTTP bridge) reachable by your local
-                      OpenHamClock Node server.
-                    </div>
-                  </div>
-
-                  <label
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 8,
-                      fontFamily: 'var(--font-mono)',
-                      fontSize: 12,
-                    }}
-                  >
-                    <input
-                      type="checkbox"
-                      disabled={!isLocalInstall}
-                      checked={!!rotatorEnabled && isLocalInstall}
-                      onChange={(e) => {
-                        const next = !!e.target.checked;
-                        setRotatorEnabled(next);
-                        try {
-                          localStorage.setItem('ohc_rotator_enabled', next ? '1' : '0');
-                        } catch {}
-                        // Default overlay OFF when enabling (hosted-safe + predictable)
-                        if (next) {
-                          try {
-                            const raw = localStorage.getItem('openhamclock_mapLayers') || '{}';
-                            const ml = JSON.parse(raw);
-                            ml.showRotatorBearing = false;
-                            localStorage.setItem('openhamclock_mapLayers', JSON.stringify(ml));
-                          } catch {}
-                        }
-                        try {
-                          window.dispatchEvent(new Event('ohc-rotator-config-changed'));
-                        } catch {}
-                      }}
-                    />
-                    Enable
-                  </label>
-                </div>
-
-                <details style={{ marginTop: 10 }}>
-                  <summary
-                    style={{
-                      cursor: 'pointer',
-                      color: 'var(--accent-amber)',
-                      fontSize: 12,
-                      userSelect: 'none',
-                    }}
-                  >
-                    Learn how
-                  </summary>
-
-                  <div
-                    style={{
-                      marginTop: 8,
-                      color: 'var(--text-secondary)',
-                      fontSize: 12,
-                      lineHeight: 1.55,
-                    }}
-                  >
-                    <div style={{ marginBottom: 6 }}>
-                      <b>Quick start (Local Only):</b>
-                    </div>
-
-                    <ol style={{ margin: 0, paddingLeft: 18 }}>
-                      <li>
-                        Run OpenHamClock locally:
-                        <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>npm start</div>
-                        Open the local URL shown in your terminal (example: http://127.0.0.1:3001).
-                      </li>
-
-                      <li style={{ marginTop: 6 }}>
-                        Install and configure <b>PstRotatorAz</b> (or another rotator backend) on your LAN.
-                        <div style={{ marginTop: 4 }}>Enable and start its control interface (web/UDP).</div>
-                      </li>
-
-                      <li style={{ marginTop: 6 }}>
-                        In the OpenHamClock folder:
-                        <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>copy .env.example → .env</div>
-                        Then edit:
-                        <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>
-                          VITE_PSTROTATOR_TARGET=http://192.168.1.43:50004
-                        </div>
-                        (Replace with the IP and port of your PstRotatorAz machine.)
-                      </li>
-
-                      <li style={{ marginTop: 6 }}>Ensure Windows Firewall allows the PstRotatorAz port.</li>
-
-                      <li style={{ marginTop: 6 }}>
-                        Enable Rotator here, then add the <b>Rotator</b> panel using the “+” button on any tabset.
-                      </li>
-                    </ol>
-
-                    <div style={{ marginTop: 10, fontSize: 11, color: 'var(--text-muted)' }}>
-                      Tip: Click <b>MAP ON</b> inside the Rotator panel to show the bearing overlay. Hold <b>Shift</b>{' '}
-                      and click the map to rotate your antenna to that heading.
-                    </div>
-
-                    <div style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
-                      Note: This feature cannot work on the hosted site because it requires access to devices on your
-                      local network.
-                    </div>
-                  </div>
-                </details>
-
-                {/* DX Weather (Map overlays) */}
-                <div
-                  style={{
-                    borderTop: '1px solid rgba(255,255,255,0.08)',
-                    paddingTop: 12,
-                    marginTop: 12,
-                  }}
-                >
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
-                    <div>
-                      <div style={{ fontWeight: 700, color: 'var(--text-primary)' }}>🌦️ DX Weather</div>
-                      <div style={{ color: 'var(--text-secondary)', fontSize: 12, lineHeight: 1.45 }}>
-                        Adds a small weather bubble on hover and weather details inside map popups (DX spots, POTA/SOTA,
-                        and the movable DX marker).
-                      </div>
-
-                      {!isLocalInstall && (
-                        <div style={{ marginTop: 6, color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.45 }}>
-                          Hosted mode disables this feature to protect shared weather-provider rate limits. Available in
-                          Local mode.
-                        </div>
-                      )}
-                    </div>
-
-                    <label
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 8,
-                        fontFamily: 'var(--font-mono)',
-                        fontSize: 12,
-                      }}
-                    >
-                      <input
-                        type="checkbox"
-                        disabled={!isLocalInstall}
-                        checked={!!dxWeatherEnabled}
-                        onChange={(e) => {
-                          const next = !!e.target.checked;
-                          if (!isLocalInstall) return;
-                          setDxWeatherEnabled(next);
-                          try {
-                            localStorage.setItem('ohc_dx_weather_enabled', next ? '1' : '0');
-                          } catch {}
-                          try {
-                            window.dispatchEvent(new Event('ohc-dx-weather-config-changed'));
-                          } catch {}
-                        }}
-                      />
-                      Enable
-                    </label>
-                  </div>
-
-                  <div style={{ marginTop: 10, color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.45 }}>
-                    Tip: A 5–10 minute cache is used automatically and hover fetches are debounced.
-                  </div>
-                </div>
-
-                {!isLocalInstall && (
-                  <div
-                    style={{
-                      marginTop: 8,
-                      color: 'var(--text-muted)',
-                      fontSize: 11,
-                    }}
-                  >
-                    Hosted mode detected — Rotator cannot be enabled here.
-                  </div>
-                )}
-              </div>
-
-              {/* N3FJP */}
-              <div
-                style={{
-                  borderTop: '1px solid rgba(255,255,255,0.08)',
-                  paddingTop: 12,
-                  marginTop: 14,
-                }}
-              >
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
-                  <div>
-                    <div style={{ fontWeight: 700, color: 'var(--text-primary)' }}>🗺️ N3FJP Logged QSOs</div>
-                    <div style={{ color: 'var(--text-secondary)', fontSize: 12, lineHeight: 1.45 }}>
-                      Shows recent QSOs posted by your local N3FJP→OHC bridge (layer overlay).
-                    </div>
-                  </div>
-
-                  <label
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 8,
-                      fontFamily: 'var(--font-mono)',
-                      fontSize: 12,
-                    }}
-                  >
-                    <input
-                      type="checkbox"
-                      disabled={!isLocalInstall}
-                      checked={!!n3fjpEnabled && isLocalInstall}
-                      onChange={(e) => {
-                        const next = !!e.target.checked;
-                        setN3fjpEnabled(next);
-                        try {
-                          localStorage.setItem('ohc_n3fjp_enabled', next ? '1' : '0');
-                        } catch {}
-                        try {
-                          window.dispatchEvent(new Event('ohc-n3fjp-config-changed'));
-                        } catch {}
-
-                        // ✅ Also toggle the map layer automatically
-                        try {
-                          // Preferred: uses live WorldMap controls (updates state + localStorage)
-                          if (window.hamclockLayerControls?.toggleLayer) {
-                            window.hamclockLayerControls.toggleLayer('n3fjp_logged_qsos', next);
-                          } else {
-                            // Fallback: write the plugin-layer setting directly
-                            const raw = localStorage.getItem('openhamclock_mapSettings') || '{}';
-                            const settings = JSON.parse(raw);
-                            const layers = settings.layers || {};
-                            layers['n3fjp_logged_qsos'] = { ...(layers['n3fjp_logged_qsos'] || {}), enabled: next };
-                            settings.layers = layers;
-                            localStorage.setItem('openhamclock_mapSettings', JSON.stringify(settings));
-                          }
-                        } catch {}
-                      }}
-                    />
-                    Enable
-                  </label>
-                </div>
-
-                {/* Simple config */}
-                <div style={{ display: 'flex', gap: 10, marginTop: 10, flexWrap: 'wrap' }}>
-                  <div style={{ flex: '1 1 160px' }}>
-                    <label
-                      style={{
-                        display: 'block',
-                        marginBottom: 6,
-                        color: 'var(--text-muted)',
-                        fontSize: 11,
-                        textTransform: 'uppercase',
-                        letterSpacing: 1,
-                      }}
-                    >
-                      Display window
-                    </label>
-                    <select
-                      disabled={!isLocalInstall || !n3fjpEnabled}
-                      value={n3fjpDisplayMinutes}
-                      onChange={(e) => {
-                        const v = parseInt(e.target.value, 10);
-                        const next = Number.isFinite(v) ? v : 15;
-                        setN3fjpDisplayMinutes(next);
-                        try {
-                          localStorage.setItem('n3fjp_display_minutes', String(next));
-                        } catch {}
-                        try {
-                          window.dispatchEvent(new Event('ohc-n3fjp-config-changed'));
-                        } catch {}
-                      }}
-                      style={{
-                        width: '100%',
-                        padding: '10px 12px',
-                        background: 'var(--bg-secondary)',
-                        border: '1px solid var(--border-color)',
-                        borderRadius: '6px',
-                        color: 'var(--text-primary)',
-                        fontSize: '14px',
-                        fontFamily: 'var(--font-mono)',
-                      }}
-                    >
-                      {[15, 30, 60, 120, 240, 720, 1440].map((m) => (
-                        <option key={m} value={m}>
-                          {m === 60 ? '1 hour' : m < 60 ? `${m} min` : `${m / 60} hours`}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-
-                  <div style={{ flex: '0 0 120px' }}>
-                    <label
-                      style={{
-                        display: 'block',
-                        marginBottom: 6,
-                        color: 'var(--text-muted)',
-                        fontSize: 11,
-                        textTransform: 'uppercase',
-                        letterSpacing: 1,
-                      }}
-                    >
-                      Line color
-                    </label>
-                    <input
-                      disabled={!isLocalInstall || !n3fjpEnabled}
-                      type="color"
-                      value={n3fjpLineColor}
-                      onChange={(e) => {
-                        const next = e.target.value || '#3388ff';
-                        setN3fjpLineColor(next);
-                        try {
-                          localStorage.setItem('n3fjp_line_color', next);
-                        } catch {}
-                        try {
-                          window.dispatchEvent(new Event('ohc-n3fjp-config-changed'));
-                        } catch {}
-                      }}
-                      style={{
-                        width: '100%',
-                        height: 40,
-                        padding: 0,
-                        border: '1px solid var(--border-color)',
-                        borderRadius: 6,
-                        background: 'transparent',
-                      }}
-                    />
-                  </div>
-
-                  <div style={{ flex: '0 0 120px' }}>
-                    <label
-                      style={{
-                        display: 'block',
-                        marginBottom: 6,
-                        color: 'var(--text-muted)',
-                        fontSize: 11,
-                        textTransform: 'uppercase',
-                        letterSpacing: 1,
-                      }}
-                    >
-                      Preview color
-                    </label>
-                    <input
-                      disabled={!isLocalInstall || !n3fjpEnabled}
-                      type="color"
-                      value={n3fjpPreviewLineColor}
-                      onChange={(e) => {
-                        const next = e.target.value || '#ffaa00';
-                        setN3fjpPreviewLineColor(next);
-                        try {
-                          localStorage.setItem('n3fjp_preview_line_color', next);
-                        } catch {}
-                        try {
-                          window.dispatchEvent(new Event('ohc-n3fjp-config-changed'));
-                        } catch {}
-                      }}
-                      style={{
-                        width: '100%',
-                        height: 40,
-                        padding: 0,
-                        border: '1px solid var(--border-color)',
-                        borderRadius: 6,
-                        background: 'transparent',
-                      }}
-                    />
-                  </div>
-                </div>
-
-                <details style={{ marginTop: 10 }}>
-                  <summary
-                    style={{
-                      cursor: 'pointer',
-                      color: 'var(--accent-amber)',
-                      fontSize: 12,
-                      userSelect: 'none',
-                    }}
-                  >
-                    Learn how
-                  </summary>
-
-                  <div
-                    style={{
-                      marginTop: 8,
-                      color: 'var(--text-secondary)',
-                      fontSize: 12,
-                      lineHeight: 1.55,
-                    }}
-                  >
-                    <div style={{ marginBottom: 6 }}>
-                      <b>Quick start (Local Only):</b>
-                    </div>
-
-                    <ol style={{ margin: 0, paddingLeft: 18 }}>
-                      <li>
-                        Run OpenHamClock locally:
-                        <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>npm start</div>
-                        Open the local URL shown in your terminal (example: http://127.0.0.1:3001).
-                      </li>
-
-                      <li style={{ marginTop: 6 }}>
-                        Install the N3FJP bridge on the same PC (or LAN machine) that can access your N3FJP logger.
-                      </li>
-
-                      <li style={{ marginTop: 6 }}>
-                        Edit the bridge <b>config.json</b> file and set:
-                        <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>
-                          "OHC_BASE_URL": "http://127.0.0.1:3001"
-                        </div>
-                        (Use the exact URL printed by OpenHamClock.)
-                      </li>
-
-                      <li style={{ marginTop: 6 }}>
-                        Ensure:
-                        <div style={{ fontFamily: 'var(--font-mono)', marginTop: 4 }}>"ENABLE_OHC_HTTP": true</div>
-                      </li>
-
-                      <li style={{ marginTop: 6 }}>
-                        Start the bridge script (PowerShell or VBS launcher). You should see log messages when QSOs are
-                        entered.
-                      </li>
-
-                      <li style={{ marginTop: 6 }}>
-                        Enable this integration here, then turn on
-                        <b> Logged QSOs (N3FJP)</b> in
-                        <b> Settings → Map Layers</b>.
-                      </li>
-                    </ol>
-
-                    <div style={{ marginTop: 10, fontSize: 11, color: 'var(--text-muted)' }}>
-                      Tip: If you see “connection refused,” verify that OpenHamClock is running locally and that the
-                      port matches your
-                      <b> OHC_BASE_URL</b> setting.
-                    </div>
-
-                    <div style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
-                      Note: This integration cannot work on the hosted site because it requires access to your local
-                      N3FJP logger and LAN services.
-                    </div>
-                  </div>
-                </details>
-              </div>
-
-              {/* QRZ.com XML API Credentials */}
-              <div
-                style={{
-                  borderTop: '1px solid rgba(255,255,255,0.08)',
-                  paddingTop: 12,
-                  marginTop: 14,
-                }}
-              >
-                <div
-                  style={{
-                    fontSize: '12px',
-                    fontWeight: '600',
-                    color: 'var(--accent-amber)',
-                    marginBottom: '4px',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '8px',
-                  }}
-                >
-                  <span>📡 QRZ.com Callsign Lookup</span>
-                  {qrzStatus?.configured && (
-                    <span
-                      style={{
-                        fontSize: '10px',
-                        fontWeight: '500',
-                        padding: '1px 6px',
-                        borderRadius: '3px',
-                        background: qrzStatus.hasSession ? 'rgba(46, 204, 113, 0.15)' : 'rgba(241, 196, 15, 0.15)',
-                        color: qrzStatus.hasSession ? '#2ecc71' : '#f1c40f',
-                      }}
-                    >
-                      {qrzStatus.hasSession ? '● Connected' : '○ Configured'}
-                      {qrzStatus.source === 'env' ? ' (env)' : ''}
-                    </span>
-                  )}
-                </div>
-                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '8px', lineHeight: 1.4 }}>
-                  Enables precise station locations from{' '}
-                  <a
-                    href="https://www.qrz.com/i/subscriptions.html"
-                    target="_blank"
-                    rel="noopener"
-                    style={{ color: 'var(--accent-blue)' }}
-                  >
-                    QRZ.com
-                  </a>{' '}
-                  user profiles (user-supplied coordinates, geocoded addresses, grid squares). Without this, locations
-                  fall back to HamQTH (country-level only). Requires a QRZ Logbook Data subscription.
-                  <br />
-                  <strong>Note</strong> this is a server setting and is not related to clicking a callsign to go to
-                  qrz.com. If you are not running a server, you will likely not have the permissions to change this.
-                </div>
-                {qrzStatus?.source === 'env' ? (
-                  <div
-                    style={{
-                      fontSize: '11px',
-                      color: 'var(--text-muted)',
-                      padding: '8px',
-                      background: 'var(--bg-primary)',
-                      borderRadius: '4px',
-                    }}
-                  >
-                    ✓ Credentials configured via{' '}
-                    <code style={{ background: 'var(--bg-tertiary)', padding: '1px 4px', borderRadius: '2px' }}>
-                      QRZ_USERNAME
-                    </code>{' '}
-                    /{' '}
-                    <code style={{ background: 'var(--bg-tertiary)', padding: '1px 4px', borderRadius: '2px' }}>
-                      QRZ_PASSWORD
-                    </code>{' '}
-                    in .env file
-                    {qrzStatus.lookupCount > 0 && (
-                      <span style={{ color: 'var(--accent-green)' }}>
-                        {' '}
-                        — {qrzStatus.lookupCount} lookups this session
-                      </span>
-                    )}
-                  </div>
-                ) : (
-                  <>
-                    <div style={{ display: 'flex', gap: '8px', marginBottom: '8px' }}>
-                      <input
-                        disabled={!isLocalInstall}
-                        type="text"
-                        placeholder="QRZ Username (callsign)"
-                        value={qrzUsername}
-                        onChange={(e) => setQrzUsername(e.target.value)}
-                        style={{
-                          flex: 1,
-                          padding: '8px 12px',
-                          background: 'var(--bg-primary)',
-                          border: '1px solid var(--border-color)',
-                          borderRadius: '4px',
-                          color: 'var(--text-primary)',
-                          fontSize: '12px',
-                          fontFamily: 'var(--font-mono)',
-                          boxSizing: 'border-box',
-                        }}
-                      />
-                      <input
-                        disabled={!isLocalInstall}
-                        type="password"
-                        placeholder="QRZ Password"
-                        value={qrzPassword}
-                        onChange={(e) => setQrzPassword(e.target.value)}
-                        style={{
-                          flex: 1,
-                          padding: '8px 12px',
-                          background: 'var(--bg-primary)',
-                          border: '1px solid var(--border-color)',
-                          borderRadius: '4px',
-                          color: 'var(--text-primary)',
-                          fontSize: '12px',
-                          fontFamily: 'var(--font-mono)',
-                          boxSizing: 'border-box',
-                        }}
-                      />
-                    </div>
-                    <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-                      <button
-                        disabled={!isLocalInstall || qrzTesting || !qrzUsername.trim() || !qrzPassword.trim()}
-                        onClick={async () => {
-                          setQrzTesting(true);
-                          setQrzMessage(null);
-                          try {
-                            const res = await fetch('/api/qrz/configure', {
-                              method: 'POST',
-                              headers: { 'Content-Type': 'application/json' },
-                              body: JSON.stringify({ username: qrzUsername.trim(), password: qrzPassword.trim() }),
-                            });
-                            const data = await res.json();
-                            if (data.success) {
-                              setQrzMessage({ type: 'success', text: 'Connected to QRZ.com successfully!' });
-                              setQrzPassword('');
-                              // Refresh status
-                              const st = await fetch('/api/qrz/status').then((r) => r.json());
-                              setQrzStatus(st);
-                            } else {
-                              setQrzMessage({ type: 'error', text: data.error || 'Login failed' });
-                            }
-                          } catch (e) {
-                            setQrzMessage({ type: 'error', text: 'Connection error' });
-                          }
-                          setQrzTesting(false);
-                        }}
-                        style={{
-                          padding: '6px 14px',
-                          fontSize: '11px',
-                          fontWeight: '600',
-                          borderRadius: '4px',
-                          border: 'none',
-                          cursor: qrzTesting || !qrzUsername.trim() || !qrzPassword.trim() ? 'not-allowed' : 'pointer',
-                          background: 'var(--accent-amber)',
-                          color: '#000',
-                          opacity: qrzTesting || !qrzUsername.trim() || !qrzPassword.trim() ? 0.5 : 1,
-                        }}
-                      >
-                        {qrzTesting ? 'Testing...' : 'Save & Test'}
-                      </button>
-                      {qrzStatus?.configured && qrzStatus.source !== 'env' && (
-                        <button
-                          onClick={async () => {
-                            await fetch('/api/qrz/remove', { method: 'POST' });
-                            setQrzUsername('');
-                            setQrzPassword('');
-                            setQrzMessage(null);
-                            const st = await fetch('/api/qrz/status').then((r) => r.json());
-                            setQrzStatus(st);
-                          }}
-                          style={{
-                            padding: '6px 12px',
-                            fontSize: '11px',
-                            borderRadius: '4px',
-                            border: '1px solid var(--border-color)',
-                            cursor: 'pointer',
-                            background: 'transparent',
-                            color: 'var(--text-muted)',
-                          }}
-                        >
-                          Remove
-                        </button>
-                      )}
-                      {qrzStatus?.configured && qrzStatus.lookupCount > 0 && (
-                        <span style={{ fontSize: '10px', color: 'var(--text-muted)' }}>
-                          {qrzStatus.lookupCount} lookups this session
-                        </span>
-                      )}
-                    </div>
-                    {qrzMessage && (
-                      <div
-                        style={{
-                          marginTop: '6px',
-                          fontSize: '11px',
-                          padding: '6px 10px',
-                          borderRadius: '4px',
-                          background:
-                            qrzMessage.type === 'success' ? 'rgba(46, 204, 113, 0.1)' : 'rgba(231, 76, 60, 0.1)',
-                          color: qrzMessage.type === 'success' ? '#2ecc71' : '#e74c3c',
-                        }}
-                      >
-                        {qrzMessage.type === 'success' ? '✓' : '✗'} {qrzMessage.text}
-                      </div>
-                    )}
-                  </>
-                )}
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Display Tab */}
-        {activeTab === 'display' && (
-          <div>
-            {/* Header Sizing */}
-            <div style={{ marginBottom: '24px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  marginBottom: '8px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                Header Size
-              </label>
-
-              {/* Live preview of header text at current scale */}
-              <div
-                style={{
-                  background: 'var(--bg-panel)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '6px',
-                  padding: '8px 12px',
-                  marginBottom: '10px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '12px',
-                  overflow: 'hidden',
-                }}
-              >
-                <span
-                  style={{
-                    fontFamily: 'Orbitron, monospace',
-                    fontWeight: 900,
-                    color: 'var(--accent-amber)',
-                    fontSize: `${22 * headerSize}px`,
-                    lineHeight: 1.2,
-                    whiteSpace: 'nowrap',
-                  }}
-                >
-                  {callsign || 'K0CJH'}
-                </span>
-                <span
-                  style={{
-                    fontFamily: 'var(--font-mono)',
-                    fontWeight: 700,
-                    color: 'var(--accent-cyan)',
-                    fontSize: `${24 * headerSize}px`,
-                    lineHeight: 1.2,
-                    whiteSpace: 'nowrap',
-                  }}
-                >
-                  14:32
-                </span>
-                <span
-                  style={{
-                    fontFamily: 'var(--font-mono)',
-                    fontSize: `${13 * headerSize}px`,
-                    color: 'var(--text-muted)',
-                    whiteSpace: 'nowrap',
-                  }}
-                >
-                  SFI 158
-                </span>
-              </div>
-
-              {/* Slider */}
-              <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                <span style={{ fontSize: '11px', color: 'var(--text-muted)', whiteSpace: 'nowrap' }}>Small</span>
-                <input
-                  type="range"
-                  min="0.5"
-                  max="4"
-                  step="0.1"
-                  value={headerSize}
-                  onChange={(e) => setheaderSize(parseFloat(e.target.value))}
-                  style={{ flex: 1, accentColor: 'var(--accent-amber)' }}
-                />
-                <span style={{ fontSize: '11px', color: 'var(--text-muted)', whiteSpace: 'nowrap' }}>Large</span>
-              </div>
-              <div
-                style={{
-                  textAlign: 'center',
-                  fontSize: '12px',
-                  color: 'var(--accent-amber)',
-                  fontWeight: 600,
-                  fontFamily: 'var(--font-mono)',
-                  marginTop: '4px',
-                }}
-              >
-                {Number(headerSize).toFixed(1)}x
-              </div>
-            </div>
-
-            {/* Clock Order */}
-            <div style={{ marginBottom: '24px' }}>
-              <label
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '10px',
-                  cursor: 'pointer',
-                  fontSize: '13px',
-                  color: 'var(--text-primary)',
-                }}
-              >
-                <input
-                  type="checkbox"
-                  checked={swapHeaderClocks}
-                  onChange={(e) => setSwapHeaderClocks(e.target.checked)}
-                  style={{ accentColor: 'var(--accent-amber)' }}
-                />
-                Show Local Time before UTC in header
-              </label>
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
-                By default, UTC is shown first. Enable this to display Local Time first.
-              </div>
-            </div>
-
-            {/* Display Whats New on Startup */}
-            <div style={{ marginBottom: '24px' }}>
-              <label
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '10px',
-                  cursor: 'pointer',
-                  fontSize: '13px',
-                  color: 'var(--text-primary)',
-                }}
-              >
-                <input
-                  type="checkbox"
-                  checked={showWhatsNew}
-                  onChange={(e) => {
-                    config.showWhatsNew = e.target.checked;
-                    setShowWhatsNew(e.target.checked);
-                  }}
-                  style={{ accentColor: 'var(--accent-amber)' }}
-                />
-                Show What's New on Startup
-              </label>
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
-                By default (when checked), What's New is displayed. Unchecking this means it will only be displayed when
-                the version is clicked.
-              </div>
-            </div>
-
-            {/* Mutual Reception Indicator */}
-            <div style={{ marginBottom: '24px' }}>
-              <label
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '10px',
-                  cursor: 'pointer',
-                  fontSize: '13px',
-                  color: 'var(--text-primary)',
-                }}
-              >
-                <input
-                  type="checkbox"
-                  checked={showMutualReception}
-                  onChange={(e) => setShowMutualReception(e.target.checked)}
-                  style={{ accentColor: 'var(--accent-amber)' }}
-                />
-                Show mutual reception indicator on PSK Reporter spots
-              </label>
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
-                Marks spots with a gold star (★) when a station hears you AND you hear them on the same band, indicating
-                a QSO is likely possible.
-              </div>
-            </div>
-
-            {/* Layout */}
-            <div style={{ marginBottom: '24px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  marginBottom: '8px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                {t('station.settings.layout')}
-              </label>
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '8px' }}>
-                {['modern', 'classic', 'tablet', 'compact', 'dockable', 'emcomm'].map((l) => (
-                  <button
-                    key={l}
-                    onClick={() => setLayout(l)}
-                    style={{
-                      padding: '10px',
-                      background: layout === l ? 'var(--accent-amber)' : 'var(--bg-tertiary)',
-                      border: `1px solid ${layout === l ? 'var(--accent-amber)' : 'var(--border-color)'}`,
-                      borderRadius: '6px',
-                      color: layout === l ? '#000' : 'var(--text-secondary)',
-                      fontSize: '12px',
-                      cursor: 'pointer',
-                      fontWeight: layout === l ? '600' : '400',
-                    }}
-                  >
-                    {l === 'modern'
-                      ? '🖥️'
-                      : l === 'classic'
-                        ? '📺'
-                        : l === 'tablet'
-                          ? '📱'
-                          : l === 'compact'
-                            ? '📊'
-                            : l === 'emcomm'
-                              ? '📍'
-                              : '⊞'}{' '}
-                    {l === 'dockable' ? t('station.settings.layout.dockable') : t('station.settings.layout.' + l)}
-                  </button>
-                ))}
-              </div>
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
-                {layoutDescriptions[layout]}
-              </div>
-              {layout === 'dockable' && onResetLayout && (
-                <button
-                  onClick={() => {
-                    if (confirm(t('station.settings.layout.reset.confirm'))) {
-                      onResetLayout();
-                    }
-                  }}
-                  style={{
-                    marginTop: '10px',
-                    padding: '8px 12px',
-                    background: 'var(--bg-tertiary)',
-                    border: '1px solid var(--border-color)',
-                    borderRadius: '6px',
-                    color: 'var(--text-secondary)',
-                    fontSize: '12px',
-                    cursor: 'pointer',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '6px',
-                  }}
-                >
-                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
-                    <path d="M3 3v5h5" />
-                  </svg>
-                  {t('station.settings.layout.reset.button')}
-                </button>
-              )}
-            </div>
-
-            {/* Theme */}
-            <div style={{ marginBottom: '8px' }}>
-              <label
-                style={{
-                  display: 'block',
-                  marginBottom: '8px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                {t('station.settings.theme')}
-              </label>
-              <ThemeSelector theme={theme} setTheme={setTheme} id="theme-selector-component" />
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
-                {t('station.settings.theme.' + theme + '.describe')}
-              </div>
-              {theme === 'custom' && customTheme && (
-                <CustomThemeEditor
-                  customTheme={customTheme}
-                  updateCustomVar={updateCustomVar}
-                  id="custom-theme-editor-component"
-                />
-              )}
-            </div>
-
-            {/* Monospace font selector (#923 — 0/8 readability) */}
-            <div style={{ marginBottom: '8px' }}>
-              <label
-                htmlFor="mono-font-select"
-                style={{
-                  display: 'block',
-                  marginBottom: '8px',
-                  color: 'var(--text-muted)',
-                  fontSize: '11px',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                }}
-              >
-                {t('station.settings.monoFont')}
-              </label>
-              <select
-                id="mono-font-select"
-                value={monoFont}
-                onChange={(e) => {
-                  const next = e.target.value;
-                  setMonoFont(next);
-                  try {
-                    localStorage.setItem('openhamclock_monoFont', next);
-                  } catch {}
-                  document.documentElement.style.setProperty('--font-mono', next);
-                }}
-                style={{
-                  width: '100%',
-                  background: 'var(--bg-tertiary)',
-                  color: 'var(--text-primary)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '4px',
-                  padding: '6px 8px',
-                  fontFamily: monoFont,
-                  fontSize: '12px',
-                }}
-              >
-                <option value="'JetBrains Mono', monospace">JetBrains Mono — default (dotted 0)</option>
-                <option value="'Fira Code', monospace">Fira Code — slashed 0</option>
-                <option value="'IBM Plex Mono', monospace">IBM Plex Mono — slashed 0, wider</option>
-              </select>
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '6px' }}>
-                {t('station.settings.monoFont.describe')}
-              </div>
-              <div
-                style={{
-                  fontFamily: monoFont,
-                  fontSize: '14px',
-                  marginTop: '8px',
-                  padding: '6px 10px',
-                  background: 'var(--bg-tertiary)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '4px',
-                  letterSpacing: '0.05em',
-                }}
-              >
-                0 8 O 1 l I — 14.074 MHz — W1AW/0 K8O
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Map Layers Tab */}
-        {activeTab === 'layers' && (
-          <div>
-            {(() => {
-              const togglePanelVisible = (panelKey) => {
-                const panels = { ...config.panels };
-                panels[panelKey] = { ...panels[panelKey], visible: !(panels[panelKey]?.visible !== false) };
-                onSave({ ...config, panels });
-              };
-
-              const overlayCards = [
-                {
-                  id: 'de-dx-markers',
-                  checked: mapLayers?.showDeDxMarkers !== false,
-                  onChange: () => onToggleDeDxMarkers?.(),
-                  icon: '📍',
-                  title: 'DE/DX Markers',
-                  description: 'Show or hide your DE and DX position markers on the map',
-                },
-                {
-                  id: 'dx-target-panel',
-                  checked: config.panels?.dxLocation?.visible !== false,
-                  onChange: () => togglePanelVisible('dxLocation'),
-                  icon: '🎯',
-                  title: 'DX Target Panel',
-                  description: 'Show or hide the DX target info panel (grid, bearing, sun times)',
-                },
-                {
-                  id: 'dx-news-ticker',
-                  checked: mapLayers?.showDXNews !== false,
-                  onChange: () => onToggleDXNews?.(),
-                  icon: '📰',
-                  title: 'DX News Ticker',
-                  description: 'Scrolling DX news headlines on the map',
-                },
-              ];
-              return (() => {
-                const categoryOrder = [
-                  { key: 'overlay', label: '🗺️ Map Overlays' },
-                  { key: 'propagation', label: '📡 Propagation' },
-                  { key: 'amateur', label: '📻 Amateur Radio' },
-                  { key: 'weather', label: '🌤️ Weather' },
-                  { key: 'space-weather', label: '☀️ Space Weather' },
-                  { key: 'hazards', label: '⚠️ Natural Hazards' },
-                  { key: 'geology', label: '🌍 Geology' },
-                  { key: 'fun', label: '🎉 Community' },
-                ];
-
-                const nonSatLayers = layers.filter((l) => l.category !== 'satellites');
-                const grouped = {};
-                nonSatLayers.forEach((l) => {
-                  const cat = l.category || 'overlay';
-                  if (!grouped[cat]) grouped[cat] = [];
-                  grouped[cat].push(l);
-                });
-                Object.values(grouped).forEach((arr) =>
-                  arr.sort((a, b) => {
-                    const nameA = (a.name.startsWith('plugins.') ? t(a.name) : a.name).toLowerCase();
-                    const nameB = (b.name.startsWith('plugins.') ? t(b.name) : b.name).toLowerCase();
-                    return nameA.localeCompare(nameB);
-                  }),
-                );
-
-                const renderBuiltInOverlayCard = (item) => (
-                  <div
-                    key={item.id}
-                    style={{
-                      background: 'var(--bg-tertiary)',
-                      border: `1px solid ${item.checked ? 'var(--accent-amber)' : 'var(--border-color)'}`,
-                      borderRadius: '8px',
-                      padding: '14px',
-                      marginBottom: '12px',
-                    }}
-                  >
-                    <label style={{ display: 'flex', alignItems: 'center', gap: '10px', cursor: 'pointer' }}>
-                      <input
-                        type="checkbox"
-                        checked={item.checked}
-                        onChange={item.onChange}
-                        style={{ width: '18px', height: '18px', cursor: 'pointer' }}
-                      />
-                      <span style={{ fontSize: '18px' }}>{item.icon}</span>
-                      <div>
-                        <div
-                          style={{
-                            color: item.checked ? 'var(--accent-amber)' : 'var(--text-primary)',
-                            fontSize: '14px',
-                            fontWeight: '600',
-                            fontFamily: 'var(--font-mono)',
-                          }}
-                        >
-                          {item.title}
-                        </div>
-                        <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '2px' }}>
-                          {item.description}
-                        </div>
-                      </div>
-                    </label>
-                  </div>
-                );
-
-                const renderLayerCard = (layer) => (
-                  <div
-                    key={layer.id}
-                    style={{
-                      background: 'var(--bg-tertiary)',
-                      border: `1px solid ${layer.enabled ? 'var(--accent-amber)' : 'var(--border-color)'}`,
-                      borderRadius: '8px',
-                      padding: '14px',
-                      marginBottom: '12px',
-                    }}
-                  >
-                    <div
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'space-between',
-                        marginBottom: '8px',
-                      }}
-                    >
-                      <label style={{ display: 'flex', alignItems: 'center', gap: '10px', cursor: 'pointer', flex: 1 }}>
-                        <input
-                          type="checkbox"
-                          checked={layer.enabled}
-                          onChange={() => handleToggleLayer(layer.id)}
-                          style={{ width: '18px', height: '18px', cursor: 'pointer' }}
-                        />
-                        <span style={{ fontSize: '18px' }}>{layer.icon}</span>
-                        <div>
-                          <div
-                            style={{
-                              color: layer.enabled ? 'var(--accent-amber)' : 'var(--text-primary)',
-                              fontSize: '14px',
-                              fontWeight: '600',
-                              fontFamily: 'var(--font-mono)',
-                            }}
-                          >
-                            {layer.name.startsWith('plugins.') ? t(layer.name) : layer.name}
-                          </div>
-                          {layer.description && (
-                            <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '2px' }}>
-                              {layer.description.startsWith('plugins.') ? t(layer.description) : layer.description}
-                            </div>
-                          )}
-                        </div>
-                      </label>
-                    </div>
-
-                    {layer.enabled && (
-                      <div style={{ paddingLeft: '38px', marginTop: '12px' }}>
-                        <label
-                          style={{
-                            display: 'block',
-                            fontSize: '11px',
-                            color: 'var(--text-muted)',
-                            marginBottom: '6px',
-                            textTransform: 'uppercase',
-                            letterSpacing: '0.5px',
-                          }}
-                        >
-                          {t('station.settings.layers.opacity')}: {Math.round(layer.opacity * 100)}%
-                        </label>
-                        <input
-                          type="range"
-                          min="0"
-                          max="100"
-                          value={layer.opacity * 100}
-                          onChange={(e) => handleOpacityChange(layer.id, parseFloat(e.target.value) / 100)}
-                          style={{ width: '100%', cursor: 'pointer' }}
-                        />
-                        {ctrlPressed &&
-                          ['lightning', 'wspr', 'rbn', 'grayline', 'n3fjp_logged_qsos', 'voacap-heatmap'].includes(
-                            layer.id,
-                          ) && (
-                            <button
-                              onClick={() => resetPopupPositions(layer.id)}
-                              style={{
-                                marginTop: '12px',
-                                padding: '8px 12px',
-                                background: 'var(--accent-red)',
-                                color: 'white',
-                                border: 'none',
-                                borderRadius: '4px',
-                                cursor: 'pointer',
-                                fontSize: '11px',
-                                fontWeight: '600',
-                                textTransform: 'uppercase',
-                                width: '100%',
-                              }}
-                            >
-                              🔄 RESET POPUPS
-                            </button>
-                          )}
-                      </div>
-                    )}
-                  </div>
-                );
-
-                const result = [];
-                const rendered = new Set();
-                categoryOrder.forEach(({ key, label }) => {
-                  const hasBuiltInOverlays = key === 'overlay' && overlayCards.length > 0;
-                  if (!grouped[key] && !hasBuiltInOverlays) return;
-                  if ((!grouped[key] || grouped[key].length === 0) && !hasBuiltInOverlays) return;
-                  result.push(
-                    <div
-                      key={`cat-${key}`}
-                      style={{
-                        fontSize: '11px',
-                        textTransform: 'uppercase',
-                        letterSpacing: '0.5px',
-                        color: 'var(--text-muted)',
-                        marginBottom: '8px',
-                        marginTop: result.length > 0 ? '16px' : '0',
-                        paddingBottom: '4px',
-                        borderBottom: '1px solid var(--border-color)',
-                      }}
-                    >
-                      {label}
-                    </div>,
-                  );
-                  if (key === 'overlay') {
-                    overlayCards.forEach((item) => {
-                      result.push(renderBuiltInOverlayCard(item));
-                    });
-                  }
-                  (grouped[key] || []).forEach((layer) => {
-                    result.push(renderLayerCard(layer));
-                    rendered.add(layer.id);
-                  });
-                });
-                // Any uncategorized leftovers
-                nonSatLayers
-                  .filter((l) => !rendered.has(l.id))
-                  .forEach((layer) => {
-                    result.push(renderLayerCard(layer));
-                  });
-                if (result.length === 0) {
-                  return (
-                    <div
-                      style={{
-                        textAlign: 'center',
-                        padding: '40px 20px',
-                        color: 'var(--text-muted)',
-                        fontSize: '13px',
-                      }}
-                    >
-                      {t('station.settings.layers.noLayers')}
-                    </div>
-                  );
-                }
-                return result;
-              })();
-            })()}
-          </div>
-        )}
-
-        {/* Satellites Tab */}
-        {activeTab === 'satellites' && (
-          <div>
-            {/* 1. Plugin Layer Toggle Section */}
-            <div style={{ marginBottom: '20px' }}>
-              {layers
-                .filter((layer) => layer.category === 'satellites')
-                .map((layer) => (
-                  <div
-                    key={layer.id}
-                    style={{
-                      background: 'var(--bg-tertiary)',
-                      border: `1px solid ${layer.enabled ? 'var(--accent-amber)' : 'var(--border-color)'}`,
-                      borderRadius: '8px',
-                      padding: '14px',
-                      marginBottom: '12px',
-                    }}
-                  >
-                    <label style={{ display: 'flex', alignItems: 'center', gap: '10px', cursor: 'pointer' }}>
-                      <input
-                        type="checkbox"
-                        checked={layer.enabled}
-                        onChange={() => handleToggleLayer(layer.id)}
-                        style={{ width: '18px', height: '18px', cursor: 'pointer' }}
-                      />
-                      <span style={{ fontSize: '18px' }}>🛰️</span>
-                      <div>
-                        <div
-                          style={{
-                            color: layer.enabled ? 'var(--accent-amber)' : 'var(--text-primary)',
-                            fontSize: '14px',
-                            fontWeight: '600',
-                            fontFamily: 'var(--font-mono)',
-                          }}
-                        >
-                          {layer.name}
-                        </div>
-                        <div style={{ fontSize: '11px', color: 'var(--text-muted)' }}>{layer.description}</div>
-                      </div>
-                    </label>
-
-                    {layer.enabled && (
-                      <div
-                        style={{
-                          paddingLeft: '38px',
-                          marginTop: '10px',
-                          display: 'flex',
-                          flexDirection: 'column',
-                          gap: '12px',
-                        }}
-                      >
-                        {/* Sub-Toggles for Tracks and Footprints */}
-                        <div style={{ display: 'flex', gap: '15px' }}>
-                          <label
-                            style={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: '6px',
-                              fontSize: '11px',
-                              cursor: 'pointer',
-                            }}
-                          >
-                            <input
-                              type="checkbox"
-                              checked={layer.config?.showTracks !== false}
-                              onChange={(e) => handleUpdateLayerConfig(layer.id, { showTracks: e.target.checked })}
-                            />{' '}
-                            Track Lines
-                          </label>
-                          <label
-                            style={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: '6px',
-                              fontSize: '11px',
-                              cursor: 'pointer',
-                            }}
-                          >
-                            <input
-                              type="checkbox"
-                              checked={layer.config?.showFootprints !== false}
-                              onChange={(e) => handleUpdateLayerConfig(layer.id, { showFootprints: e.target.checked })}
-                            />{' '}
-                            Footprints
-                          </label>
-                        </div>
-
-                        {/* station altitude and minimum elevation inputs */}
-                        <div
-                          style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px', marginBottom: '12px' }}
-                        >
-                          <div>
-                            <label
-                              style={{
-                                display: 'block',
-                                marginBottom: '6px',
-                                color: 'var(--text-muted)',
-                                fontSize: '11px',
-                                textTransform: 'uppercase',
-                              }}
-                            >
-                              Station Altitude [m]
-                            </label>
-                            <input
-                              type="number"
-                              step="1"
-                              min="-500"
-                              max="9000"
-                              value={isNaN(stationAlt) ? '' : stationAlt}
-                              onChange={(e) =>
-                                setStationAlt(isNaN(e.target.valueAsNumber) ? 100 : e.target.valueAsNumber)
-                              }
-                              style={{
-                                width: '100%',
-                                padding: '10px',
-                                background: 'var(--bg-tertiary)',
-                                border: '1px solid var(--border-color)',
-                                borderRadius: '6px',
-                                color: 'var(--text-primary)',
-                                fontSize: '14px',
-                                fontFamily: 'var(--font-mono)',
-                                boxSizing: 'border-box',
-                              }}
-                            />
-                          </div>
-                          <div>
-                            <label
-                              style={{
-                                display: 'block',
-                                marginBottom: '6px',
-                                color: 'var(--text-muted)',
-                                fontSize: '11px',
-                                textTransform: 'uppercase',
-                              }}
-                            >
-                              Minimum Elevation [°]
-                            </label>
-                            <input
-                              type="number"
-                              step="0.1"
-                              min="-5.0"
-                              max="89.0"
-                              value={isNaN(minElev) ? '' : minElev}
-                              onChange={(e) => setMinElev(isNaN(e.target.valueAsNumber) ? 5.0 : e.target.valueAsNumber)}
-                              style={{
-                                width: '100%',
-                                padding: '10px',
-                                background: 'var(--bg-tertiary)',
-                                border: '1px solid var(--border-color)',
-                                borderRadius: '6px',
-                                color: 'var(--text-primary)',
-                                fontSize: '14px',
-                                fontFamily: 'var(--font-mono)',
-                                boxSizing: 'border-box',
-                              }}
-                            />
-                          </div>
-                        </div>
-
-                        {/* Lead Time Slider WIP
-						<div style={{ marginTop: '8px' }}>
-						  <label style={{
-							display: 'flex',
-							justifyContent: 'space-between',
-							fontSize: '10px',
-							color: 'var(--text-muted)',
-							textTransform: 'uppercase'
-						  }}>
-							<span>Track Prediction (Lead Time)</span>
-							<span style={{ color: 'var(--accent-amber)' }}>{layer.config?.leadTimeMins || 45} min</span>
-						  </label>
-						  <input
-							type="range"
-							min="15"
-							max="120"
-							step="5"
-							value={layer.config?.leadTimeMins || 45}
-							onChange={(e) => handleUpdateLayerConfig(layer.id, { leadTimeMins: parseInt(e.target.value) })}
-							style={{ width: '100%', cursor: 'pointer' }}
-						  />
-						</div> */}
-
-                        {/* Opacity Slider */}
-                        <div>
-                          <label style={{ fontSize: '10px', color: 'var(--text-muted)', textTransform: 'uppercase' }}>
-                            Opacity: {Math.round(layer.opacity * 100)}%
-                          </label>
-                          <input
-                            type="range"
-                            min="0"
-                            max="100"
-                            value={layer.opacity * 100}
-                            onChange={(e) => handleOpacityChange(layer.id, parseFloat(e.target.value) / 100)}
-                            style={{ width: '100%', cursor: 'pointer' }}
-                          />
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                ))}
-            </div>
-
-            {/* 2. Existing Satellite Filter Controls */}
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                marginBottom: '16px',
-                paddingBottom: '12px',
-                borderBottom: '1px solid var(--border-color)',
-              }}
-            >
-              <button
-                onClick={() => {
-                  const allSats = (satellites || []).map((s) => s.name);
-                  onSatelliteFiltersChange(allSats);
-                }}
-                style={{
-                  background: 'transparent',
-                  border: '1px solid #00ffff',
-                  borderRadius: '4px',
-                  color: '#00ffff',
-                  padding: '6px 12px',
-                  fontSize: '12px',
-                  cursor: 'pointer',
-                  fontFamily: 'var(--font-mono)',
-                }}
-              >
-                {t('station.settings.satellites.selectAll')}
-              </button>
-              <button
-                onClick={() => onSatelliteFiltersChange([])}
-                style={{
-                  background: 'transparent',
-                  border: '1px solid #ff6666',
-                  borderRadius: '4px',
-                  color: '#ff6666',
-                  padding: '6px 12px',
-                  fontSize: '12px',
-                  cursor: 'pointer',
-                  fontFamily: 'var(--font-mono)',
-                }}
-              >
-                {t('station.settings.satellites.clear')}
-              </button>
-            </div>
-
-            <div
-              style={{
-                fontSize: '11px',
-                color: 'var(--text-muted)',
-                marginBottom: '12px',
-              }}
-            >
-              {satelliteFilters.length === 0
-                ? t('station.settings.satellites.showAll')
-                : t('station.settings.satellites.selectedCount', { count: satelliteFilters.length })}
-            </div>
-
-            {/* Search Box */}
-            <div style={{ position: 'relative', marginBottom: '12px' }}>
-              <input
-                type="text"
-                value={satelliteSearch}
-                onChange={(e) => setSatelliteSearch(e.target.value)}
-                placeholder="🔍 Search satellites..."
-                style={{
-                  width: '100%',
-                  padding: '8px 32px 8px 12px',
-                  background: 'var(--bg-tertiary)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '6px',
-                  color: 'var(--text-primary)',
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: '12px',
-                  outline: 'none',
-                }}
-              />
-              {satelliteSearch && (
-                <button
-                  onClick={() => setSatelliteSearch('')}
-                  style={{
-                    position: 'absolute',
-                    right: '8px',
-                    top: '50%',
-                    transform: 'translateY(-50%)',
-                    background: 'transparent',
-                    border: 'none',
-                    color: '#ff6666',
-                    cursor: 'pointer',
-                    fontSize: '16px',
-                    padding: '4px 8px',
-                  }}
-                >
-                  ×
-                </button>
-              )}
-            </div>
-
-            {/* Satellite Grid */}
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: 'repeat(2, 1fr)',
-                gap: '8px',
-                maxHeight: '400px',
-                overflowY: 'auto',
-              }}
-            >
-              {(satellites || [])
-                .filter((sat) => !satelliteSearch || sat.name.toLowerCase().includes(satelliteSearch.toLowerCase()))
-                .sort((a, b) => {
-                  const aSelected = satelliteFilters.includes(a.name);
-                  const bSelected = satelliteFilters.includes(b.name);
-                  if (aSelected && !bSelected) return -1;
-                  if (!aSelected && bSelected) return 1;
-                  return a.name.localeCompare(b.name);
-                })
-                .map((sat) => {
-                  const isSelected = satelliteFilters.includes(sat.name);
-                  return (
-                    <button
-                      key={sat.name}
-                      onClick={() => {
-                        if (isSelected) {
-                          onSatelliteFiltersChange(satelliteFilters.filter((n) => n !== sat.name));
-                        } else {
-                          onSatelliteFiltersChange([...satelliteFilters, sat.name]);
-                        }
-                      }}
-                      style={{
-                        background: isSelected ? 'rgba(0, 255, 255, 0.15)' : 'var(--bg-tertiary)',
-                        border: `1px solid ${isSelected ? '#00ffff' : 'var(--border-color)'}`,
-                        borderRadius: '6px',
-                        padding: '10px',
-                        textAlign: 'left',
-                        cursor: 'pointer',
-                        color: 'var(--text-primary)',
-                        fontFamily: 'var(--font-mono)',
-                        fontSize: '12px',
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '8px',
-                      }}
-                    >
-                      <span
-                        style={{
-                          width: '16px',
-                          height: '16px',
-                          borderRadius: '3px',
-                          border: `2px solid ${isSelected ? '#00ffff' : '#666'}`,
-                          background: isSelected ? '#00ffff' : 'transparent',
                           display: 'flex',
                           alignItems: 'center',
-                          justifyContent: 'center',
-                          fontSize: '10px',
-                          flexShrink: 0,
+                          gap: '6px',
+                          color: 'var(--text-primary)',
+                          fontSize: '13px',
                         }}
                       >
-                        {isSelected && '✓'}
-                      </span>
-                      <div style={{ flex: 1, overflow: 'hidden' }}>
-                        <div
-                          style={{
-                            color: isSelected ? '#00ffff' : 'var(--text-primary)',
-                            fontWeight: '600',
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                          }}
-                        >
-                          {sat.name}
-                        </div>
-                      </div>
-                    </button>
-                  );
-                })}
-            </div>
-          </div>
-        )}
-
-        {/* Profiles Tab */}
-        {activeTab === 'profiles' && (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-            {/* Description */}
-            <div style={{ fontSize: '12px', color: 'var(--text-muted)', lineHeight: '1.5' }}>
-              Save your current layout, theme, map layers, filters, and all preferences as a named profile. Switch
-              between profiles when sharing a HamClock between operators, or to toggle between your own saved views.
-            </div>
-
-            {/* Active profile indicator */}
-            {activeProfileName && (
-              <div
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '8px',
-                  padding: '8px 12px',
-                  background: 'rgba(0, 255, 136, 0.1)',
-                  border: '1px solid rgba(0, 255, 136, 0.3)',
-                  borderRadius: '6px',
-                  fontSize: '12px',
-                }}
-              >
-                <span style={{ color: '#00ff88' }}>●</span>
-                <span style={{ color: 'var(--text-primary)' }}>
-                  Active: <strong>{activeProfileName}</strong>
-                </span>
-              </div>
-            )}
-
-            {/* Status message */}
-            {profileMessage && (
-              <div
-                style={{
-                  padding: '8px 12px',
-                  background: profileMessage.type === 'error' ? 'rgba(255, 68, 102, 0.1)' : 'rgba(0, 255, 136, 0.1)',
-                  border: `1px solid ${profileMessage.type === 'error' ? 'rgba(255, 68, 102, 0.3)' : 'rgba(0, 255, 136, 0.3)'}`,
-                  borderRadius: '6px',
-                  fontSize: '11px',
-                  color: profileMessage.type === 'error' ? '#ff4466' : '#00ff88',
-                }}
-              >
-                {profileMessage.text}
-              </div>
-            )}
-
-            {/* Save new profile */}
-            <div
-              style={{
-                padding: '12px',
-                background: 'var(--bg-tertiary)',
-                borderRadius: '8px',
-                border: '1px solid var(--border-color)',
-              }}
-            >
-              <div style={{ fontSize: '12px', fontWeight: '600', color: 'var(--accent-amber)', marginBottom: '8px' }}>
-                💾 Save Current State as Profile
-              </div>
-              <div style={{ display: 'flex', gap: '8px' }}>
-                <input
-                  type="text"
-                  value={newProfileName}
-                  onChange={(e) => setNewProfileName(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && newProfileName.trim()) {
-                      const exists = profiles[newProfileName.trim()];
-                      if (exists && !window.confirm(`Profile "${newProfileName.trim()}" already exists. Overwrite?`))
-                        return;
-                      persistCurrentSettings();
-                      saveProfile(newProfileName.trim());
-                      setNewProfileName('');
-                      refreshProfiles();
-                      setProfileMessage({ type: 'success', text: `Profile "${newProfileName.trim()}" saved` });
-                      setTimeout(() => setProfileMessage(null), 3000);
-                    }
-                  }}
-                  placeholder="Profile name (e.g. K0CJH, Contest, Field Day)"
-                  style={{
-                    flex: 1,
-                    padding: '8px 10px',
-                    background: 'var(--bg-primary)',
-                    border: '1px solid var(--border-color)',
-                    borderRadius: '4px',
-                    color: 'var(--text-primary)',
-                    fontSize: '12px',
-                    fontFamily: 'var(--font-mono)',
-                  }}
-                />
-                <button
-                  onClick={() => {
-                    if (!newProfileName.trim()) return;
-                    const exists = profiles[newProfileName.trim()];
-                    if (exists && !window.confirm(`Profile "${newProfileName.trim()}" already exists. Overwrite?`))
-                      return;
-                    persistCurrentSettings();
-                    saveProfile(newProfileName.trim());
-                    setNewProfileName('');
-                    refreshProfiles();
-                    setProfileMessage({ type: 'success', text: `Profile "${newProfileName.trim()}" saved` });
-                    setTimeout(() => setProfileMessage(null), 3000);
-                  }}
-                  disabled={!newProfileName.trim()}
-                  style={{
-                    padding: '8px 16px',
-                    background: newProfileName.trim()
-                      ? 'linear-gradient(135deg, #00ff88 0%, #00ddff 100%)'
-                      : 'var(--bg-tertiary)',
-                    border: 'none',
-                    borderRadius: '4px',
-                    color: newProfileName.trim() ? '#000' : 'var(--text-muted)',
-                    fontSize: '12px',
-                    fontWeight: '700',
-                    cursor: newProfileName.trim() ? 'pointer' : 'default',
-                    whiteSpace: 'nowrap',
-                  }}
-                >
-                  Save
-                </button>
-              </div>
-            </div>
-
-            {/* Saved profiles list */}
-            <div>
-              <div style={{ fontSize: '12px', fontWeight: '600', color: 'var(--accent-amber)', marginBottom: '8px' }}>
-                📋 Saved Profiles ({Object.keys(profiles).length})
-              </div>
-              {Object.keys(profiles).length === 0 ? (
-                <div
-                  style={{
-                    padding: '20px',
-                    textAlign: 'center',
-                    color: 'var(--text-muted)',
-                    fontSize: '12px',
-                    background: 'var(--bg-tertiary)',
-                    borderRadius: '8px',
-                    border: '1px dashed var(--border-color)',
-                  }}
-                >
-                  No saved profiles yet. Save your current configuration above.
-                </div>
-              ) : (
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-                  {Object.entries(profiles)
-                    .sort((a, b) => (b[1].updatedAt || '').localeCompare(a[1].updatedAt || ''))
-                    .map(([name, profile]) => {
-                      const isActive = name === activeProfileName;
-                      const isRenaming = renamingProfile === name;
-
-                      // Parse callsign from snapshot if available
-                      let snapshotCallsign = '';
-                      try {
-                        const cfg = profile.snapshot?.openhamclock_config;
-                        if (cfg) snapshotCallsign = JSON.parse(cfg).callsign || '';
-                      } catch {}
-
-                      // Parse layout type
-                      let snapshotLayout = '';
-                      try {
-                        const cfg = profile.snapshot?.openhamclock_config;
-                        if (cfg) snapshotLayout = JSON.parse(cfg).layout || '';
-                      } catch {}
-
-                      return (
-                        <div
-                          key={name}
-                          style={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: '8px',
-                            padding: '10px 12px',
-                            background: isActive ? 'rgba(0, 255, 136, 0.08)' : 'var(--bg-tertiary)',
-                            border: `1px solid ${isActive ? 'rgba(0, 255, 136, 0.3)' : 'var(--border-color)'}`,
-                            borderRadius: '6px',
-                          }}
-                        >
-                          {/* Profile info */}
-                          <div style={{ flex: 1, minWidth: 0 }}>
-                            {isRenaming ? (
-                              <div style={{ display: 'flex', gap: '4px' }}>
-                                <input
-                                  type="text"
-                                  value={renameValue}
-                                  onChange={(e) => setRenameValue(e.target.value)}
-                                  onKeyDown={(e) => {
-                                    if (e.key === 'Enter') {
-                                      if (renameProfile(name, renameValue)) {
-                                        refreshProfiles();
-                                        setProfileMessage({
-                                          type: 'success',
-                                          text: `Renamed to "${renameValue.trim()}"`,
-                                        });
-                                      } else {
-                                        setProfileMessage({ type: 'error', text: 'Rename failed — name may be taken' });
-                                      }
-                                      setRenamingProfile(null);
-                                      setTimeout(() => setProfileMessage(null), 3000);
-                                    }
-                                    if (e.key === 'Escape') setRenamingProfile(null);
-                                  }}
-                                  autoFocus
-                                  style={{
-                                    flex: 1,
-                                    padding: '4px 6px',
-                                    background: 'var(--bg-primary)',
-                                    border: '1px solid var(--accent-amber)',
-                                    borderRadius: '3px',
-                                    color: 'var(--text-primary)',
-                                    fontSize: '12px',
-                                    fontFamily: 'var(--font-mono)',
-                                  }}
-                                />
-                                <button
-                                  onClick={() => {
-                                    if (renameProfile(name, renameValue)) {
-                                      refreshProfiles();
-                                      setProfileMessage({
-                                        type: 'success',
-                                        text: `Renamed to "${renameValue.trim()}"`,
-                                      });
-                                    } else {
-                                      setProfileMessage({
-                                        type: 'error',
-                                        text: 'Rename failed — name may already exist',
-                                      });
-                                    }
-                                    setRenamingProfile(null);
-                                    setTimeout(() => setProfileMessage(null), 3000);
-                                  }}
-                                  style={{
-                                    padding: '4px 8px',
-                                    background: 'var(--accent-green)',
-                                    border: 'none',
-                                    borderRadius: '3px',
-                                    color: '#000',
-                                    fontSize: '10px',
-                                    cursor: 'pointer',
-                                    fontWeight: '700',
-                                  }}
-                                >
-                                  ✓
-                                </button>
-                                <button
-                                  onClick={() => setRenamingProfile(null)}
-                                  style={{
-                                    padding: '4px 8px',
-                                    background: 'var(--bg-primary)',
-                                    border: '1px solid var(--border-color)',
-                                    borderRadius: '3px',
-                                    color: 'var(--text-muted)',
-                                    fontSize: '10px',
-                                    cursor: 'pointer',
-                                  }}
-                                >
-                                  ✕
-                                </button>
-                              </div>
-                            ) : (
-                              <>
-                                <div
-                                  style={{
-                                    fontSize: '13px',
-                                    fontWeight: '600',
-                                    color: isActive ? '#00ff88' : 'var(--text-primary)',
-                                    whiteSpace: 'nowrap',
-                                    overflow: 'hidden',
-                                    textOverflow: 'ellipsis',
-                                  }}
-                                >
-                                  {isActive && <span style={{ marginRight: '4px' }}>●</span>}
-                                  {name}
-                                </div>
-                                <div style={{ fontSize: '10px', color: 'var(--text-muted)', marginTop: '2px' }}>
-                                  {snapshotCallsign && <span>{snapshotCallsign}</span>}
-                                  {snapshotLayout && <span> • {snapshotLayout}</span>}
-                                  {profile.updatedAt && (
-                                    <span> • {new Date(profile.updatedAt).toLocaleDateString()}</span>
-                                  )}
-                                </div>
-                              </>
-                            )}
-                          </div>
-
-                          {/* Action buttons */}
-                          {!isRenaming && (
-                            <div style={{ display: 'flex', gap: '4px', flexShrink: 0 }}>
-                              {/* Load */}
-                              <button
-                                onClick={() => {
-                                  if (
-                                    window.confirm(
-                                      `Load profile "${name}"? This will replace your current settings and reload.`,
-                                    )
-                                  ) {
-                                    loadProfile(name);
-                                    window.location.reload();
-                                  }
-                                }}
-                                title="Load this profile"
-                                style={{
-                                  padding: '5px 10px',
-                                  background: isActive ? 'rgba(0,255,136,0.15)' : 'var(--bg-primary)',
-                                  border: `1px solid ${isActive ? 'rgba(0,255,136,0.3)' : 'var(--border-color)'}`,
-                                  borderRadius: '4px',
-                                  color: isActive ? '#00ff88' : 'var(--text-secondary)',
-                                  fontSize: '11px',
-                                  cursor: 'pointer',
-                                  fontWeight: '600',
-                                }}
-                              >
-                                {isActive ? '✓ Active' : '▶ Load'}
-                              </button>
-                              {/* Update (overwrite with current state) */}
-                              <button
-                                onClick={() => {
-                                  persistCurrentSettings();
-                                  saveProfile(name);
-                                  refreshProfiles();
-                                  setProfileMessage({ type: 'success', text: `"${name}" updated with current state` });
-                                  setTimeout(() => setProfileMessage(null), 3000);
-                                }}
-                                title="Update with current settings"
-                                aria-label="Update with current settings"
-                                style={{
-                                  padding: '5px 8px',
-                                  background: 'var(--bg-primary)',
-                                  border: '1px solid var(--border-color)',
-                                  borderRadius: '4px',
-                                  color: 'var(--text-muted)',
-                                  fontSize: '11px',
-                                  cursor: 'pointer',
-                                }}
-                              >
-                                ↻
-                              </button>
-                              {/* Rename */}
-                              <button
-                                onClick={() => {
-                                  setRenamingProfile(name);
-                                  setRenameValue(name);
-                                }}
-                                title="Rename"
-                                aria-label="Rename profile"
-                                style={{
-                                  padding: '5px 8px',
-                                  background: 'var(--bg-primary)',
-                                  border: '1px solid var(--border-color)',
-                                  borderRadius: '4px',
-                                  color: 'var(--text-muted)',
-                                  fontSize: '11px',
-                                  cursor: 'pointer',
-                                }}
-                              >
-                                ✎
-                              </button>
-                              {/* Export */}
-                              <button
-                                onClick={() => {
-                                  const json = exportProfile(name);
-                                  if (json) {
-                                    const blob = new Blob([json], { type: 'application/json' });
-                                    const url = URL.createObjectURL(blob);
-                                    const a = document.createElement('a');
-                                    a.href = url;
-                                    a.download = (() => {
-                                      const now = new Date();
-                                      const date = now.toISOString().split('T')[0];
-                                      const time = now.toTimeString().slice(0, 8).replace(/:/g, '');
-                                      return `hamclock-profile-${name.replace(/\s+/g, '-').toLowerCase()}-${date}-${time}.json`;
-                                    })();
-                                    a.click();
-                                    URL.revokeObjectURL(url);
-                                    setProfileMessage({ type: 'success', text: `Exported "${name}"` });
-                                    setTimeout(() => setProfileMessage(null), 3000);
-                                  }
-                                }}
-                                title="Export to file"
-                                aria-label="Export profile to file"
-                                style={{
-                                  padding: '5px 8px',
-                                  background: 'var(--bg-primary)',
-                                  border: '1px solid var(--border-color)',
-                                  borderRadius: '4px',
-                                  color: 'var(--text-muted)',
-                                  fontSize: '11px',
-                                  cursor: 'pointer',
-                                }}
-                              >
-                                ⤓
-                              </button>
-                              {/* Delete */}
-                              <button
-                                onClick={() => {
-                                  if (window.confirm(`Delete profile "${name}"? This cannot be undone.`)) {
-                                    deleteProfile(name);
-                                    refreshProfiles();
-                                    setProfileMessage({ type: 'success', text: `Deleted "${name}"` });
-                                    setTimeout(() => setProfileMessage(null), 3000);
-                                  }
-                                }}
-                                title="Delete"
-                                aria-label="Delete profile"
-                                style={{
-                                  padding: '5px 8px',
-                                  background: 'var(--bg-primary)',
-                                  border: '1px solid rgba(255,68,102,0.3)',
-                                  borderRadius: '4px',
-                                  color: '#ff4466',
-                                  fontSize: '11px',
-                                  cursor: 'pointer',
-                                }}
-                              >
-                                ✕
-                              </button>
-                            </div>
-                          )}
-                        </div>
-                      );
-                    })}
-                </div>
-              )}
-            </div>
-
-            {/* Open-Meteo API Key (optional) */}
-            <div
-              style={{
-                padding: '12px',
-                background: 'var(--bg-tertiary)',
-                borderRadius: '8px',
-                border: '1px solid var(--border-color)',
-                marginBottom: '12px',
-              }}
-            >
-              <div style={{ fontSize: '12px', fontWeight: '600', color: 'var(--accent-amber)', marginBottom: '8px' }}>
-                🌡️ Open-Meteo API Key{' '}
-                <span style={{ color: 'var(--text-muted)', fontWeight: '400', fontSize: '11px' }}>(optional)</span>
-              </div>
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '8px', lineHeight: 1.4 }}>
-                Weather data is provided by Open-Meteo's free API. For higher rate limits or commercial use, enter your
-                API key from{' '}
-                <a
-                  href="https://open-meteo.com/en/pricing"
-                  target="_blank"
-                  rel="noopener"
-                  style={{ color: 'var(--accent-blue)' }}
-                >
-                  open-meteo.com
-                </a>
-                . Leave blank for the free tier.
-              </div>
-              <input
-                type="text"
-                placeholder="Free tier (no key needed)"
-                defaultValue={(() => {
-                  try {
-                    return localStorage.getItem('ohc_openmeteo_apikey') || '';
-                  } catch {
-                    return '';
-                  }
-                })()}
-                onChange={(e) => {
-                  try {
-                    const val = e.target.value.trim();
-                    if (val) {
-                      localStorage.setItem('ohc_openmeteo_apikey', val);
-                    } else {
-                      localStorage.removeItem('ohc_openmeteo_apikey');
-                    }
-                  } catch {}
-                }}
-                style={{
-                  width: '100%',
-                  padding: '8px 12px',
-                  background: 'var(--bg-primary)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '4px',
-                  color: 'var(--text-primary)',
-                  fontSize: '12px',
-                  fontFamily: 'var(--font-mono)',
-                  boxSizing: 'border-box',
-                }}
-              />
-            </div>
-
-            {/* Import / Export section */}
-            <div
-              style={{
-                padding: '12px',
-                background: 'var(--bg-tertiary)',
-                borderRadius: '8px',
-                border: '1px solid var(--border-color)',
-              }}
-            >
-              <div style={{ fontSize: '12px', fontWeight: '600', color: 'var(--accent-amber)', marginBottom: '8px' }}>
-                📦 Import / Export
-              </div>
-              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept=".json"
-                  style={{ display: 'none' }}
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (!file) return;
-                    const reader = new FileReader();
-                    reader.onload = (ev) => {
-                      const imported = importProfile(ev.target.result);
-                      if (imported) {
-                        refreshProfiles();
-                        setProfileMessage({ type: 'success', text: `Imported profile "${imported}"` });
-                      } else {
-                        setProfileMessage({ type: 'error', text: 'Import failed — invalid profile file' });
-                      }
-                      setTimeout(() => setProfileMessage(null), 3000);
-                    };
-                    reader.readAsText(file);
-                    e.target.value = '';
-                  }}
-                />
-                <button
-                  onClick={() => fileInputRef.current?.click()}
-                  style={{
-                    padding: '8px 14px',
-                    background: 'var(--bg-primary)',
-                    border: '1px solid var(--border-color)',
-                    borderRadius: '4px',
-                    color: 'var(--text-secondary)',
-                    fontSize: '11px',
-                    cursor: 'pointer',
-                    fontWeight: '600',
-                  }}
-                >
-                  ⤒ Import Profile from File
-                </button>
-                <button
-                  onClick={() => {
-                    const json = exportCurrentState('Current');
-                    const blob = new Blob([json], { type: 'application/json' });
-                    const url = URL.createObjectURL(blob);
-                    const a = document.createElement('a');
-                    a.href = url;
-                    a.download = (() => {
-                      const now = new Date();
-                      const date = now.toISOString().split('T')[0];
-                      const time = now.toTimeString().slice(0, 8).replace(/:/g, '');
-                      return `hamclock-current-${date}-${time}.json`;
-                    })();
-                    a.click();
-                    URL.revokeObjectURL(url);
-                    setProfileMessage({ type: 'success', text: 'Exported current state' });
-                    setTimeout(() => setProfileMessage(null), 3000);
-                  }}
-                  style={{
-                    padding: '8px 14px',
-                    background: 'var(--bg-primary)',
-                    border: '1px solid var(--border-color)',
-                    borderRadius: '4px',
-                    color: 'var(--text-secondary)',
-                    fontSize: '11px',
-                    cursor: 'pointer',
-                    fontWeight: '600',
-                  }}
-                >
-                  ⤓ Export Current State
-                </button>
-              </div>
-              <div style={{ fontSize: '10px', color: 'var(--text-muted)', marginTop: '8px' }}>
-                Share profile files between devices or operators. Exported files contain all settings, layout
-                preferences, map layers, and filter configurations.
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Community Tab */}
-        {activeTab === 'community' && (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
-            <p style={{ fontSize: '13px', color: 'var(--text-secondary)', marginBottom: '8px' }}>
-              Join the OpenHamClock community — report bugs, request features, and connect with other operators.
-            </p>
-            <a
-              href="https://github.com/accius/openhamclock"
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '12px',
-                padding: '14px 16px',
-                background: 'var(--bg-tertiary)',
-                borderRadius: '8px',
-                textDecoration: 'none',
-                color: 'var(--text-primary)',
-                border: '1px solid transparent',
-                transition: 'border-color 0.2s',
-              }}
-              onMouseOver={(e) => (e.currentTarget.style.borderColor = 'var(--border-color)')}
-              onMouseOut={(e) => (e.currentTarget.style.borderColor = 'transparent')}
-            >
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
-              </svg>
-              <div>
-                <div style={{ fontWeight: 600, fontSize: '14px' }}>GitHub</div>
-                <div style={{ fontSize: '11px', color: 'var(--text-muted)' }}>Source code, issues & releases</div>
-              </div>
-            </a>
-            <a
-              href="https://www.facebook.com/groups/1217043013897440"
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '12px',
-                padding: '14px 16px',
-                background: 'var(--bg-tertiary)',
-                borderRadius: '8px',
-                textDecoration: 'none',
-                color: 'var(--text-primary)',
-                border: '1px solid transparent',
-                transition: 'border-color 0.2s',
-              }}
-              onMouseOver={(e) => (e.currentTarget.style.borderColor = 'var(--border-color)')}
-              onMouseOut={(e) => (e.currentTarget.style.borderColor = 'transparent')}
-            >
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="#1877F2">
-                <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
-              </svg>
-              <div>
-                <div style={{ fontWeight: 600, fontSize: '14px' }}>Facebook Group</div>
-                <div style={{ fontSize: '11px', color: 'var(--text-muted)' }}>Community discussion & help</div>
-              </div>
-            </a>
-            <a
-              href="https://www.reddit.com/r/OpenHamClock/"
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '12px',
-                padding: '14px 16px',
-                background: 'var(--bg-tertiary)',
-                borderRadius: '8px',
-                textDecoration: 'none',
-                color: 'var(--text-primary)',
-                border: '1px solid transparent',
-                transition: 'border-color 0.2s',
-              }}
-              onMouseOver={(e) => (e.currentTarget.style.borderColor = 'var(--border-color)')}
-              onMouseOut={(e) => (e.currentTarget.style.borderColor = 'transparent')}
-            >
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="#FF4500">
-                <path d="M12 0A12 12 0 000 12a12 12 0 0012 12 12 12 0 0012-12A12 12 0 0012 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 01-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 01.042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 014.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 01.14-.197.35.35 0 01.238-.042l2.906.617a1.214 1.214 0 011.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 00-.231.094.33.33 0 000 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 000-.463.327.327 0 00-.462 0c-.545.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 00-.205-.094z" />
-              </svg>
-              <div>
-                <div style={{ fontWeight: 600, fontSize: '14px' }}>Reddit</div>
-                <div style={{ fontSize: '11px', color: 'var(--text-muted)' }}>r/OpenHamClock</div>
-              </div>
-            </a>
-            <div
-              style={{
-                marginTop: '16px',
-                padding: '14px 16px',
-                background: 'var(--bg-tertiary)',
-                borderRadius: '8px',
-                textAlign: 'center',
-              }}
-            >
-              <div style={{ fontSize: '14px', fontWeight: 600, color: 'var(--accent-amber)' }}>
-                Created by Chris Hetherington — K0CJH
-              </div>
-              <div style={{ fontSize: '12px', color: 'var(--text-secondary)', marginTop: '6px', lineHeight: '1.5' }}>
-                Built with the help of an amazing community of amateur radio operators contributing features, reporting
-                bugs, and making OpenHamClock better every day.
-              </div>
-              <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginTop: '6px' }}>
-                K0CJH / openhamclock.com
-              </div>
-            </div>
-
-            {/* Contributors */}
-            <div
-              style={{ marginTop: '12px', padding: '14px 16px', background: 'var(--bg-tertiary)', borderRadius: '8px' }}
-            >
-              <div
-                style={{
-                  fontSize: '12px',
-                  color: 'var(--accent-amber)',
-                  fontWeight: 600,
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                  marginBottom: '10px',
-                  textAlign: 'center',
-                }}
-              >
-                Contributors
-              </div>
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', textAlign: 'center', marginBottom: '10px' }}>
-                Thank you to everyone who has contributed code, features, bug fixes, and ideas.
-              </div>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', justifyContent: 'center' }}>
-                {[
-                  'creinemann',
-                  'ceotjoe',
-                  'alanhargreaves',
-                  'dmazan',
-                  'Delerius',
-                  'rfreedman',
-                  'SebFox2011',
-                  'infopcgood',
-                  'thomas-schreck',
-                  'echo-gravitas',
-                  'yuryja',
-                  'Holyszewski',
-                  'trancen',
-                  'ThePangel',
-                  'w8mej',
-                  'JoshuaNewport',
-                  'denete',
-                  'kmanwar89',
-                  'KentenRoth',
-                  's53zo',
-                  'theodeurne76',
-                  'm1dst',
-                  'brianbruff',
-                  'agocs',
-                  'kwirk',
-                  'Oukagen',
-                  'ftl',
-                  'phether',
-                ].map((name) => (
-                  <a
-                    key={name}
-                    href={`https://github.com/${name}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={{
-                      display: 'inline-block',
-                      padding: '4px 10px',
-                      background: 'var(--bg-secondary)',
-                      borderRadius: '12px',
-                      fontSize: '11px',
-                      color: 'var(--text-secondary)',
-                      textDecoration: 'none',
-                      fontFamily: 'var(--font-mono)',
-                      border: '1px solid transparent',
-                      transition: 'all 0.15s',
-                    }}
-                    onMouseOver={(e) => {
-                      e.currentTarget.style.borderColor = 'var(--accent-cyan)';
-                      e.currentTarget.style.color = 'var(--accent-cyan)';
-                    }}
-                    onMouseOut={(e) => {
-                      e.currentTarget.style.borderColor = 'transparent';
-                      e.currentTarget.style.color = 'var(--text-secondary)';
-                    }}
-                  >
-                    {name}
-                  </a>
-                ))}
-              </div>
-              <div style={{ fontSize: '10px', color: 'var(--text-muted)', textAlign: 'center', marginTop: '10px' }}>
-                Want to contribute? Check out our GitHub — issues, pull requests, and ideas are all welcome.
-              </div>
-            </div>
-
-            {/* Privacy Notice */}
-            <div
-              style={{ marginTop: '12px', padding: '14px 16px', background: 'var(--bg-tertiary)', borderRadius: '8px' }}
-            >
-              <div
-                style={{
-                  fontSize: '12px',
-                  color: 'var(--accent-amber)',
-                  fontWeight: 600,
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                  marginBottom: '10px',
-                  textAlign: 'center',
-                }}
-              >
-                Privacy
-              </div>
-              <div style={{ fontSize: '12px', color: 'var(--text-secondary)', lineHeight: '1.6' }}>
-                <p style={{ marginBottom: '10px' }}>
-                  <strong style={{ color: 'var(--text-primary)' }}>No Cookies or Tracking</strong>
-                  <br />
-                  OpenHamClock does not set any HTTP cookies. There are no analytics services, tracking pixels, ad
-                  networks, or telemetry. All vendor libraries (maps, fonts) are self-hosted.
-                </p>
-                <p style={{ marginBottom: '10px' }}>
-                  <strong style={{ color: 'var(--text-primary)' }}>Browser Storage</strong>
-                  <br />
-                  Your settings (callsign, theme, filters, layout) are saved to your browser's localStorage. This data
-                  stays on your device and is never shared with third parties. Clearing your browser data removes it.
-                </p>
-                <p style={{ marginBottom: '10px' }}>
-                  <strong style={{ color: 'var(--text-primary)' }}>Visitor Statistics</strong>
-                  <br />
-                  The server counts unique visitors using anonymized, one-way hashed identifiers. No IP addresses are
-                  stored to disk or sent to third parties. Only aggregate counts are retained.
-                </p>
-                <p style={{ marginBottom: '10px' }}>
-                  <strong style={{ color: 'var(--text-primary)' }}>Active Users Layer</strong>
-                  <br />
-                  If enabled, your callsign and grid square (rounded to ~1km) are shared with other operators on the
-                  map. You can opt out in Station settings without affecting other features. Your presence is
-                  automatically removed when you close the tab or disable the setting.
-                </p>
-                <p style={{ marginBottom: '10px' }}>
-                  <strong style={{ color: 'var(--text-primary)' }}>Third-Party APIs</strong>
-                  <br />
-                  Weather data is fetched from Open-Meteo and NOAA directly from your browser. No personal data beyond
-                  your configured coordinates is sent. API keys you provide are stored locally in your browser only.
-                </p>
-                <p style={{ margin: 0 }}>
-                  <strong style={{ color: 'var(--text-primary)' }}>Settings Sync</strong>
-                  <br />
-                  If the server operator has enabled settings sync, your preferences may be synced to the server for
-                  cross-device use. This is off by default and does not include profile data.
-                </p>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Audio Alerts Tab */}
-        {activeTab === 'alerts' && <AudioAlertsTab />}
-
-        {/* Rig Bridge Tab */}
-        {activeTab === 'rig-bridge' && (
-          <div>
-            {/* README Banner */}
-            <div
-              style={{
-                background: 'rgba(255, 193, 7, 0.15)',
-                border: '1px solid var(--accent-amber)',
-                borderRadius: '8px',
-                padding: '12px 16px',
-                marginBottom: '20px',
-                fontSize: '13px',
-              }}
-            >
-              <div style={{ color: 'var(--accent-amber)', fontWeight: '700', marginBottom: '6px' }}>
-                {t('station.settings.rigBridge.readme.heading')}
-              </div>
-              <div style={{ color: 'var(--text-secondary)', lineHeight: 1.5 }}>
-                {t('station.settings.rigBridge.readme.body')}{' '}
-                <a
-                  href="https://github.com/accius/openhamclock/blob/main/rig-bridge/README.md"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{ color: 'var(--accent-amber)', textDecoration: 'underline' }}
-                >
-                  {t('station.settings.rigBridge.readme.link')}
-                </a>
-              </div>
-            </div>
-
-            <div
-              style={{
-                background: 'var(--bg-tertiary)',
-                padding: '12px',
-                borderRadius: '6px',
-                border: '1px solid var(--border-color)',
-                marginBottom: '16px',
-              }}
-            >
-              <div
-                style={{
-                  fontSize: '11px',
-                  color: 'var(--text-muted)',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                  marginBottom: '10px',
-                }}
-              >
-                Connection
-              </div>
-
-              <div style={{ display: 'flex', alignItems: 'center', marginBottom: '12px' }}>
-                <input
-                  type="checkbox"
-                  checked={rigEnabled}
-                  onChange={(e) => setRigEnabled(e.target.checked)}
-                  style={{ marginRight: '8px' }}
-                />
-                <span style={{ color: 'var(--text-primary)', fontSize: '14px' }}>Enable Rig Bridge</span>
+                        <input
+                          type="checkbox"
+                          checked={tuneEnabled}
+                          onChange={(e) => setTuneEnabled(e.target.checked)}
+                        />
+                        Click-to-tune
+                      </label>
+                      <label
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '6px',
+                          color: 'var(--text-primary)',
+                          fontSize: '13px',
+                        }}
+                      >
+                        <input type="checkbox" checked={autoMode} onChange={(e) => setAutoMode(e.target.checked)} />
+                        Auto-mode from band plan
+                      </label>
+                    </div>
+                  </>
+                )}
               </div>
 
               {rigEnabled && (
                 <>
-                  <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: '10px', marginBottom: '10px' }}>
-                    <div>
-                      <label
-                        style={{ display: 'block', marginBottom: '4px', color: 'var(--text-muted)', fontSize: '10px' }}
-                      >
-                        {t('station.settings.rigControl.host')}
-                      </label>
-                      <input
-                        type="text"
-                        value={rigHost}
-                        onChange={(e) => setRigHost(e.target.value)}
-                        placeholder="http://localhost"
-                        style={{
-                          width: '100%',
-                          padding: '8px',
-                          background: 'var(--bg-primary)',
-                          border: '1px solid var(--border-color)',
-                          borderRadius: '4px',
-                          color: 'var(--accent-cyan)',
-                          fontSize: '13px',
-                          fontFamily: 'var(--font-mono)',
-                          boxSizing: 'border-box',
-                        }}
-                      />
-                    </div>
-                    <div>
-                      <label
-                        style={{ display: 'block', marginBottom: '4px', color: 'var(--text-muted)', fontSize: '10px' }}
-                      >
-                        {t('station.settings.rigControl.port')}
-                      </label>
-                      <input
-                        type="number"
-                        value={rigPort}
-                        onChange={(e) => setRigPort(e.target.value)}
-                        placeholder="5555"
-                        style={{
-                          width: '100%',
-                          padding: '8px',
-                          background: 'var(--bg-primary)',
-                          border: '1px solid var(--border-color)',
-                          borderRadius: '4px',
-                          color: 'var(--accent-cyan)',
-                          fontSize: '13px',
-                          fontFamily: 'var(--font-mono)',
-                          boxSizing: 'border-box',
-                        }}
-                      />
-                    </div>
-                  </div>
-
-                  <div style={{ marginBottom: '10px' }}>
-                    <label
-                      style={{ display: 'block', fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}
+                  {/* Setup UI Link */}
+                  <div
+                    style={{
+                      background: 'rgba(99,102,241,0.08)',
+                      border: '1px solid rgba(99,102,241,0.2)',
+                      borderRadius: '6px',
+                      padding: '12px',
+                      marginBottom: '16px',
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontSize: '12px',
+                        color: 'var(--text-secondary)',
+                        marginBottom: '10px',
+                        lineHeight: 1.4,
+                      }}
                     >
-                      {t('station.settings.rigControl.apiToken')}
-                    </label>
-                    <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
-                      <input
-                        type={showRigToken ? 'text' : 'password'}
-                        value={rigApiToken}
-                        onChange={(e) => setRigApiToken(e.target.value)}
-                        placeholder={t('station.settings.rigControl.apiToken.placeholder')}
+                      Download and run Rig Bridge on your local computer. Configure your radio, digital modes, APRS TNC,
+                      rotator, and cloud relay in its setup UI.
+                    </div>
+                    <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap', marginBottom: '8px' }}>
+                      <a
+                        href="/api/rig-bridge/download/windows"
                         style={{
-                          flex: 1,
-                          padding: '6px 10px',
-                          background: 'var(--bg-primary)',
-                          border: '1px solid var(--border-color)',
+                          padding: '6px 14px',
                           borderRadius: '4px',
-                          color: 'var(--text-primary)',
-                          fontSize: '12px',
-                          fontFamily: 'monospace',
-                        }}
-                      />
-                      <button
-                        type="button"
-                        onClick={() => setShowRigToken((v) => !v)}
-                        style={{
-                          padding: '6px 10px',
-                          background: 'var(--bg-tertiary)',
-                          border: '1px solid var(--border-color)',
-                          borderRadius: '4px',
-                          color: 'var(--text-secondary)',
                           fontSize: '11px',
+                          fontWeight: '600',
+                          background: 'rgba(99,102,241,0.15)',
+                          border: '1px solid rgba(99,102,241,0.3)',
+                          color: '#818cf8',
+                          textDecoration: 'none',
                           cursor: 'pointer',
-                          whiteSpace: 'nowrap',
                         }}
                       >
-                        {showRigToken ? 'Hide' : 'Show'}
-                      </button>
+                        Windows
+                      </a>
+                      <a
+                        href="/api/rig-bridge/download/mac"
+                        style={{
+                          padding: '6px 14px',
+                          borderRadius: '4px',
+                          fontSize: '11px',
+                          fontWeight: '600',
+                          background: 'rgba(99,102,241,0.15)',
+                          border: '1px solid rgba(99,102,241,0.3)',
+                          color: '#818cf8',
+                          textDecoration: 'none',
+                          cursor: 'pointer',
+                        }}
+                      >
+                        Mac
+                      </a>
+                      <a
+                        href="/api/rig-bridge/download/linux"
+                        style={{
+                          padding: '6px 14px',
+                          borderRadius: '4px',
+                          fontSize: '11px',
+                          fontWeight: '600',
+                          background: 'rgba(99,102,241,0.15)',
+                          border: '1px solid rgba(99,102,241,0.3)',
+                          color: '#818cf8',
+                          textDecoration: 'none',
+                          cursor: 'pointer',
+                        }}
+                      >
+                        Linux
+                      </a>
+                      <a
+                        href={
+                          /^https?:\/\//i.test(rigHost)
+                            ? `${rigHost.replace(/\/$/, '')}:${rigPort}`
+                            : `http://localhost:${rigPort}`
+                        }
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{
+                          padding: '6px 14px',
+                          borderRadius: '4px',
+                          fontSize: '11px',
+                          fontWeight: '600',
+                          background: 'rgba(99,102,241,0.15)',
+                          border: '1px solid rgba(99,102,241,0.3)',
+                          color: '#818cf8',
+                          textDecoration: 'none',
+                          cursor: 'pointer',
+                        }}
+                      >
+                        Open Setup UI
+                      </a>
                     </div>
-                    <div style={{ fontSize: '10px', color: 'var(--text-muted)', marginTop: '4px', lineHeight: 1.4 }}>
-                      {t('station.settings.rigControl.apiToken.hint')}
+                    <div style={{ fontSize: '9px', color: 'var(--text-muted)', opacity: 0.7 }}>
+                      Requires Node.js and git. The installer downloads rig-bridge and starts it automatically.
                     </div>
                   </div>
 
-                  <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
-                    <label
+                  {/* Plugin Status */}
+                  <div
+                    style={{
+                      background: 'var(--bg-tertiary)',
+                      padding: '12px',
+                      borderRadius: '6px',
+                      border: '1px solid var(--border-color)',
+                      marginBottom: '16px',
+                    }}
+                  >
+                    <div
                       style={{
+                        fontSize: '11px',
+                        color: 'var(--text-muted)',
+                        textTransform: 'uppercase',
+                        letterSpacing: '1px',
+                        marginBottom: '8px',
+                      }}
+                    >
+                      Available Plugins
+                    </div>
+                    <div style={{ fontSize: '11px', color: 'var(--text-secondary)', lineHeight: 1.8 }}>
+                      <div>
+                        <strong>Radio:</strong> Yaesu, Kenwood, Icom (USB) | rigctld, flrig, TCI, SmartSDR, RTL-TCP
+                      </div>
+                      <div>
+                        <strong>Digital:</strong> WSJT-X, MSHV, JTDX, JS8Call (bidirectional)
+                      </div>
+                      <div>
+                        <strong>Packet:</strong> APRS TNC (KISS/Direwolf), Winlink (Pat client)
+                      </div>
+                      <div>
+                        <strong>Hardware:</strong> Rotator (rotctld)
+                      </div>
+                      <div>
+                        <strong>Cloud:</strong> Cloud Relay (proxy rig features to cloud-hosted OHC)
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Cloud Relay Setup */}
+                  <div
+                    style={{
+                      background: cloudRelaySession ? 'rgba(34, 197, 94, 0.12)' : 'rgba(34, 197, 94, 0.08)',
+                      border: cloudRelaySession
+                        ? '1px solid rgba(34, 197, 94, 0.4)'
+                        : '1px solid rgba(34, 197, 94, 0.2)',
+                      borderRadius: '6px',
+                      padding: '12px',
+                      marginBottom: '16px',
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontSize: '11px',
+                        color: 'var(--text-muted)',
+                        textTransform: 'uppercase',
+                        letterSpacing: '1px',
+                        marginBottom: '8px',
                         display: 'flex',
                         alignItems: 'center',
                         gap: '6px',
-                        color: 'var(--text-primary)',
-                        fontSize: '13px',
                       }}
                     >
-                      <input type="checkbox" checked={tuneEnabled} onChange={(e) => setTuneEnabled(e.target.checked)} />
-                      Click-to-tune
-                    </label>
-                    <label
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '6px',
-                        color: 'var(--text-primary)',
-                        fontSize: '13px',
-                      }}
-                    >
-                      <input type="checkbox" checked={autoMode} onChange={(e) => setAutoMode(e.target.checked)} />
-                      Auto-mode from band plan
-                    </label>
+                      {t('station.settings.rigBridge.cloudRelay.title')}
+                      <span
+                        style={{
+                          fontSize: '9px',
+                          fontWeight: '700',
+                          letterSpacing: '0.5px',
+                          textTransform: 'uppercase',
+                          color: 'var(--accent-amber)',
+                          border: '1px solid var(--accent-amber)',
+                          borderRadius: '3px',
+                          padding: '1px 4px',
+                          lineHeight: 1.4,
+                          opacity: 0.85,
+                        }}
+                      >
+                        {t('station.settings.rigBridge.alpha')}
+                      </span>
+                    </div>
+                    {cloudRelaySession ? (
+                      <>
+                        <div
+                          style={{
+                            fontSize: '11px',
+                            color: '#22c55e',
+                            marginBottom: '10px',
+                            lineHeight: 1.4,
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '6px',
+                          }}
+                        >
+                          <span style={{ fontSize: '10px' }}>&#9679;</span>
+                          Active &mdash; session{' '}
+                          <span style={{ fontFamily: 'monospace', opacity: 0.8 }}>
+                            {cloudRelaySession.slice(0, 8)}&hellip;
+                          </span>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            const rigPortValue = String(rigPort ?? '').trim();
+                            let nextRigPort = 5555;
+                            if (rigPortValue === '0') {
+                              nextRigPort = 0;
+                            } else {
+                              const p = parseInt(rigPortValue, 10);
+                              if (Number.isFinite(p) && p > 0) nextRigPort = p;
+                            }
+                            setCloudRelaySession('');
+                            // Clear session and configured flag from localStorage
+                            clearRelaySession();
+                            onSave({
+                              ...config,
+                              rigControl: {
+                                ...config.rigControl,
+                                enabled: rigEnabled,
+                                host: rigHost,
+                                port: nextRigPort,
+                                tuneEnabled,
+                                autoMode,
+                                apiToken: rigApiToken.trim(),
+                              },
+                            });
+                          }}
+                          style={{
+                            padding: '8px 16px',
+                            borderRadius: '4px',
+                            fontSize: '12px',
+                            fontWeight: '600',
+                            background: 'rgba(239, 68, 68, 0.15)',
+                            border: '1px solid rgba(239, 68, 68, 0.3)',
+                            color: '#ef4444',
+                            cursor: 'pointer',
+                          }}
+                        >
+                          Disconnect Cloud Relay
+                        </button>
+                        <div style={{ fontSize: '9px', color: 'var(--text-muted)', marginTop: '6px', opacity: 0.7 }}>
+                          Switches to direct connection. Disable the Cloud Relay plugin in rig-bridge too.
+                        </div>
+                      </>
+                    ) : (
+                      <>
+                        <div
+                          style={{
+                            fontSize: '11px',
+                            color: 'var(--text-secondary)',
+                            marginBottom: '10px',
+                            lineHeight: 1.4,
+                          }}
+                        >
+                          Running OpenHamClock in the cloud? The Cloud Relay connects your local rig-bridge to this
+                          server, enabling click-to-tune, PTT, WSJT-X decodes, and APRS from anywhere.
+                        </div>
+                        <button
+                          type="button"
+                          onClick={async () => {
+                            try {
+                              const credRes = await fetch('/api/rig-bridge/relay/configure', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({}),
+                              });
+                              const credData = await credRes.json();
+                              if (!credRes.ok) {
+                                alert(`Error: ${credData.error}`);
+                                return;
+                              }
+
+                              setCloudRelaySession(credData.session);
+                              // Persist in localStorage so all relay-consuming hooks
+                              // (WSJTX, MeshCom, APRS) immediately poll with this ID
+                              // instead of whatever random ID they generated earlier.
+                              setRelaySessionId(credData.session);
+                              // Mark cloud relay as explicitly configured so RigContext
+                              // enters cloud relay mode on next re-render (save triggers it).
+                              setRelayConfigured(true);
+
+                              // Copy config to clipboard for easy paste into rig-bridge
+                              const configText = JSON.stringify(credData.configPayload, null, 2);
+                              try {
+                                await navigator.clipboard.writeText(configText);
+                              } catch (e) {}
+
+                              alert(
+                                `Cloud Relay credentials generated!\n\n` +
+                                  `Session: ${credData.session}\n` +
+                                  `Server: ${credData.serverUrl}\n\n` +
+                                  `Next steps:\n` +
+                                  `1. Open Rig Bridge setup UI at http://localhost:5555\n` +
+                                  `2. Go to the Plugins tab\n` +
+                                  `3. Enable "Cloud Relay"\n` +
+                                  `4. Paste these settings:\n` +
+                                  `   Server URL: ${credData.serverUrl}\n` +
+                                  `   API Key: ${credData.relayKey}\n` +
+                                  `   Session: ${credData.session}\n` +
+                                  `5. Restart rig-bridge\n` +
+                                  `6. Click Save below in OHC settings\n\n` +
+                                  `(Config copied to clipboard)`,
+                              );
+                            } catch (e) {
+                              alert(`Failed to get relay credentials: ${e.message}`);
+                            }
+                          }}
+                          style={{
+                            padding: '8px 16px',
+                            borderRadius: '4px',
+                            fontSize: '12px',
+                            fontWeight: '600',
+                            background: 'rgba(34, 197, 94, 0.15)',
+                            border: '1px solid rgba(34, 197, 94, 0.3)',
+                            color: '#22c55e',
+                            cursor: 'pointer',
+                          }}
+                        >
+                          Connect Cloud Relay
+                        </button>
+                        <div style={{ fontSize: '9px', color: 'var(--text-muted)', marginTop: '6px', opacity: 0.7 }}>
+                          Requires rig-bridge running locally and RIG_BRIDGE_RELAY_KEY set on this server.
+                        </div>
+                      </>
+                    )}
                   </div>
                 </>
               )}
             </div>
-
-            {rigEnabled && (
-              <>
-                {/* Setup UI Link */}
-                <div
-                  style={{
-                    background: 'rgba(99,102,241,0.08)',
-                    border: '1px solid rgba(99,102,241,0.2)',
-                    borderRadius: '6px',
-                    padding: '12px',
-                    marginBottom: '16px',
-                  }}
-                >
-                  <div
-                    style={{ fontSize: '12px', color: 'var(--text-secondary)', marginBottom: '10px', lineHeight: 1.4 }}
-                  >
-                    Download and run Rig Bridge on your local computer. Configure your radio, digital modes, APRS TNC,
-                    rotator, and cloud relay in its setup UI.
-                  </div>
-                  <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap', marginBottom: '8px' }}>
-                    <a
-                      href="/api/rig-bridge/download/windows"
-                      style={{
-                        padding: '6px 14px',
-                        borderRadius: '4px',
-                        fontSize: '11px',
-                        fontWeight: '600',
-                        background: 'rgba(99,102,241,0.15)',
-                        border: '1px solid rgba(99,102,241,0.3)',
-                        color: '#818cf8',
-                        textDecoration: 'none',
-                        cursor: 'pointer',
-                      }}
-                    >
-                      Windows
-                    </a>
-                    <a
-                      href="/api/rig-bridge/download/mac"
-                      style={{
-                        padding: '6px 14px',
-                        borderRadius: '4px',
-                        fontSize: '11px',
-                        fontWeight: '600',
-                        background: 'rgba(99,102,241,0.15)',
-                        border: '1px solid rgba(99,102,241,0.3)',
-                        color: '#818cf8',
-                        textDecoration: 'none',
-                        cursor: 'pointer',
-                      }}
-                    >
-                      Mac
-                    </a>
-                    <a
-                      href="/api/rig-bridge/download/linux"
-                      style={{
-                        padding: '6px 14px',
-                        borderRadius: '4px',
-                        fontSize: '11px',
-                        fontWeight: '600',
-                        background: 'rgba(99,102,241,0.15)',
-                        border: '1px solid rgba(99,102,241,0.3)',
-                        color: '#818cf8',
-                        textDecoration: 'none',
-                        cursor: 'pointer',
-                      }}
-                    >
-                      Linux
-                    </a>
-                    <a
-                      href={
-                        /^https?:\/\//i.test(rigHost)
-                          ? `${rigHost.replace(/\/$/, '')}:${rigPort}`
-                          : `http://localhost:${rigPort}`
-                      }
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      style={{
-                        padding: '6px 14px',
-                        borderRadius: '4px',
-                        fontSize: '11px',
-                        fontWeight: '600',
-                        background: 'rgba(99,102,241,0.15)',
-                        border: '1px solid rgba(99,102,241,0.3)',
-                        color: '#818cf8',
-                        textDecoration: 'none',
-                        cursor: 'pointer',
-                      }}
-                    >
-                      Open Setup UI
-                    </a>
-                  </div>
-                  <div style={{ fontSize: '9px', color: 'var(--text-muted)', opacity: 0.7 }}>
-                    Requires Node.js and git. The installer downloads rig-bridge and starts it automatically.
-                  </div>
-                </div>
-
-                {/* Plugin Status */}
-                <div
-                  style={{
-                    background: 'var(--bg-tertiary)',
-                    padding: '12px',
-                    borderRadius: '6px',
-                    border: '1px solid var(--border-color)',
-                    marginBottom: '16px',
-                  }}
-                >
-                  <div
-                    style={{
-                      fontSize: '11px',
-                      color: 'var(--text-muted)',
-                      textTransform: 'uppercase',
-                      letterSpacing: '1px',
-                      marginBottom: '8px',
-                    }}
-                  >
-                    Available Plugins
-                  </div>
-                  <div style={{ fontSize: '11px', color: 'var(--text-secondary)', lineHeight: 1.8 }}>
-                    <div>
-                      <strong>Radio:</strong> Yaesu, Kenwood, Icom (USB) | rigctld, flrig, TCI, SmartSDR, RTL-TCP
-                    </div>
-                    <div>
-                      <strong>Digital:</strong> WSJT-X, MSHV, JTDX, JS8Call (bidirectional)
-                    </div>
-                    <div>
-                      <strong>Packet:</strong> APRS TNC (KISS/Direwolf), Winlink (Pat client)
-                    </div>
-                    <div>
-                      <strong>Hardware:</strong> Rotator (rotctld)
-                    </div>
-                    <div>
-                      <strong>Cloud:</strong> Cloud Relay (proxy rig features to cloud-hosted OHC)
-                    </div>
-                  </div>
-                </div>
-
-                {/* Cloud Relay Setup */}
-                <div
-                  style={{
-                    background: cloudRelaySession ? 'rgba(34, 197, 94, 0.12)' : 'rgba(34, 197, 94, 0.08)',
-                    border: cloudRelaySession ? '1px solid rgba(34, 197, 94, 0.4)' : '1px solid rgba(34, 197, 94, 0.2)',
-                    borderRadius: '6px',
-                    padding: '12px',
-                    marginBottom: '16px',
-                  }}
-                >
-                  <div
-                    style={{
-                      fontSize: '11px',
-                      color: 'var(--text-muted)',
-                      textTransform: 'uppercase',
-                      letterSpacing: '1px',
-                      marginBottom: '8px',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '6px',
-                    }}
-                  >
-                    {t('station.settings.rigBridge.cloudRelay.title')}
-                    <span
-                      style={{
-                        fontSize: '9px',
-                        fontWeight: '700',
-                        letterSpacing: '0.5px',
-                        textTransform: 'uppercase',
-                        color: 'var(--accent-amber)',
-                        border: '1px solid var(--accent-amber)',
-                        borderRadius: '3px',
-                        padding: '1px 4px',
-                        lineHeight: 1.4,
-                        opacity: 0.85,
-                      }}
-                    >
-                      {t('station.settings.rigBridge.alpha')}
-                    </span>
-                  </div>
-                  {cloudRelaySession ? (
-                    <>
-                      <div
-                        style={{
-                          fontSize: '11px',
-                          color: '#22c55e',
-                          marginBottom: '10px',
-                          lineHeight: 1.4,
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: '6px',
-                        }}
-                      >
-                        <span style={{ fontSize: '10px' }}>&#9679;</span>
-                        Active &mdash; session{' '}
-                        <span style={{ fontFamily: 'monospace', opacity: 0.8 }}>
-                          {cloudRelaySession.slice(0, 8)}&hellip;
-                        </span>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          const rigPortValue = String(rigPort ?? '').trim();
-                          let nextRigPort = 5555;
-                          if (rigPortValue === '0') {
-                            nextRigPort = 0;
-                          } else {
-                            const p = parseInt(rigPortValue, 10);
-                            if (Number.isFinite(p) && p > 0) nextRigPort = p;
-                          }
-                          setCloudRelaySession('');
-                          // Clear session and configured flag from localStorage
-                          clearRelaySession();
-                          onSave({
-                            ...config,
-                            rigControl: {
-                              ...config.rigControl,
-                              enabled: rigEnabled,
-                              host: rigHost,
-                              port: nextRigPort,
-                              tuneEnabled,
-                              autoMode,
-                              apiToken: rigApiToken.trim(),
-                            },
-                          });
-                        }}
-                        style={{
-                          padding: '8px 16px',
-                          borderRadius: '4px',
-                          fontSize: '12px',
-                          fontWeight: '600',
-                          background: 'rgba(239, 68, 68, 0.15)',
-                          border: '1px solid rgba(239, 68, 68, 0.3)',
-                          color: '#ef4444',
-                          cursor: 'pointer',
-                        }}
-                      >
-                        Disconnect Cloud Relay
-                      </button>
-                      <div style={{ fontSize: '9px', color: 'var(--text-muted)', marginTop: '6px', opacity: 0.7 }}>
-                        Switches to direct connection. Disable the Cloud Relay plugin in rig-bridge too.
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <div
-                        style={{
-                          fontSize: '11px',
-                          color: 'var(--text-secondary)',
-                          marginBottom: '10px',
-                          lineHeight: 1.4,
-                        }}
-                      >
-                        Running OpenHamClock in the cloud? The Cloud Relay connects your local rig-bridge to this
-                        server, enabling click-to-tune, PTT, WSJT-X decodes, and APRS from anywhere.
-                      </div>
-                      <button
-                        type="button"
-                        onClick={async () => {
-                          try {
-                            const credRes = await fetch('/api/rig-bridge/relay/configure', {
-                              method: 'POST',
-                              headers: { 'Content-Type': 'application/json' },
-                              body: JSON.stringify({}),
-                            });
-                            const credData = await credRes.json();
-                            if (!credRes.ok) {
-                              alert(`Error: ${credData.error}`);
-                              return;
-                            }
-
-                            setCloudRelaySession(credData.session);
-                            // Persist in localStorage so all relay-consuming hooks
-                            // (WSJTX, MeshCom, APRS) immediately poll with this ID
-                            // instead of whatever random ID they generated earlier.
-                            setRelaySessionId(credData.session);
-                            // Mark cloud relay as explicitly configured so RigContext
-                            // enters cloud relay mode on next re-render (save triggers it).
-                            setRelayConfigured(true);
-
-                            // Copy config to clipboard for easy paste into rig-bridge
-                            const configText = JSON.stringify(credData.configPayload, null, 2);
-                            try {
-                              await navigator.clipboard.writeText(configText);
-                            } catch (e) {}
-
-                            alert(
-                              `Cloud Relay credentials generated!\n\n` +
-                                `Session: ${credData.session}\n` +
-                                `Server: ${credData.serverUrl}\n\n` +
-                                `Next steps:\n` +
-                                `1. Open Rig Bridge setup UI at http://localhost:5555\n` +
-                                `2. Go to the Plugins tab\n` +
-                                `3. Enable "Cloud Relay"\n` +
-                                `4. Paste these settings:\n` +
-                                `   Server URL: ${credData.serverUrl}\n` +
-                                `   API Key: ${credData.relayKey}\n` +
-                                `   Session: ${credData.session}\n` +
-                                `5. Restart rig-bridge\n` +
-                                `6. Click Save below in OHC settings\n\n` +
-                                `(Config copied to clipboard)`,
-                            );
-                          } catch (e) {
-                            alert(`Failed to get relay credentials: ${e.message}`);
-                          }
-                        }}
-                        style={{
-                          padding: '8px 16px',
-                          borderRadius: '4px',
-                          fontSize: '12px',
-                          fontWeight: '600',
-                          background: 'rgba(34, 197, 94, 0.15)',
-                          border: '1px solid rgba(34, 197, 94, 0.3)',
-                          color: '#22c55e',
-                          cursor: 'pointer',
-                        }}
-                      >
-                        Connect Cloud Relay
-                      </button>
-                      <div style={{ fontSize: '9px', color: 'var(--text-muted)', marginTop: '6px', opacity: 0.7 }}>
-                        Requires rig-bridge running locally and RIG_BRIDGE_RELAY_KEY set on this server.
-                      </div>
-                    </>
-                  )}
-                </div>
-              </>
-            )}
-          </div>
-        )}
+          )}
+        </div>
 
         {/* Buttons */}
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px', marginTop: '24px' }}>

--- a/src/utils/ariaTabKeyDown.js
+++ b/src/utils/ariaTabKeyDown.js
@@ -1,0 +1,23 @@
+/**
+ * Standard ARIA tablist keyboard handler (W3C APG Tabs pattern).
+ * Pass to onKeyDown on the role="tablist" container.
+ *
+ * @param {KeyboardEvent} e
+ * @param {string[]} tabs - ordered list of tab ids
+ * @param {string} activeTab
+ * @param {(id: string) => void} setActiveTab
+ * @param {React.RefObject<Record<string, HTMLElement>>} tabRefs - map of id → button element
+ */
+export function ariaTabKeyDown(e, tabs, activeTab, setActiveTab, tabRefs) {
+  let next = null;
+  const idx = tabs.indexOf(activeTab);
+  if (e.key === 'ArrowRight') next = tabs[(idx + 1) % tabs.length];
+  else if (e.key === 'ArrowLeft') next = tabs[(idx - 1 + tabs.length) % tabs.length];
+  else if (e.key === 'Home') next = tabs[0];
+  else if (e.key === 'End') next = tabs[tabs.length - 1];
+  if (next) {
+    e.preventDefault();
+    setActiveTab(next);
+    tabRefs.current?.[next]?.focus();
+  }
+}


### PR DESCRIPTION
## Summary

- Adds shared `src/utils/ariaTabKeyDown.js` utility for W3C APG arrow-key / Home / End navigation
- Converts all 7 tab-strip components to the full ARIA tablist pattern: `role="tablist"`, `role="tab"` + `aria-selected` + `aria-controls`, roving `tabIndex`, `role="tabpanel"` + `aria-labelledby`
- Removes `aria-pressed` from MeshComPanel (wrong pattern for tabs)

**Components updated:** SettingsPanel (9 tabs), MeshComPanel, PotaSotaPanel, DXFilterManager, ActivateFilterManager, PSKFilterManager, PSKReporterPanel

## Test plan

- [ ] Open Settings panel — screen reader announces "Settings tabs" tablist, each tab announces as selected/not selected, arrow keys move between tabs
- [ ] MeshCom panel — same pattern, no more aria-pressed
- [ ] POTA/SOTA panel — arrow keys navigate between POTA/WWFF/SOTA/WWBOTA
- [ ] DX Filter, Activate Filter, PSK Filter modals — tablist navigation works
- [ ] PSKReporter tx/rx sub-tabs — tablist with arrow keys
- [ ] Visual styling unchanged across all components

Closes #1031

🤖 Generated with [Claude Code](https://claude.com/claude-code)