### PR TITLE
fix(deps): upgrade tmp to 0.2.7 to fix CVE-2026-44705

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9327,9 +9327,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- Upgrades transitive dependency `tmp` from `0.2.5` → `0.2.7` via `package-lock.json`
- Resolves Dependabot alert [#68](https://github.com/accius/openhamclock/security/dependabot/68)
- Fixes [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65) (CVE-2026-44705): path traversal via unsanitized `prefix`/`postfix`/`dir` options in `tmp`

## Details
`tmp` is a transitive dev dependency pulled in by `tmp-promise`. No direct usage of `tmp` in application code — risk is confined to the build/dev toolchain. The `^0.2.0` range in `tmp-promise` accepts `0.2.7`, so only the lock file needed updating.

## Test plan
- [ ] CI passes
- [ ] `npm audit` no longer reports GHSA-ph9p-34f9-6g65

🤖 Generated with [Claude Code](https://claude.com/claude-code)