### PR TITLE
fix(setup-pi): resolve kiosk session type at install time (#1026)

### DIFF
--- a/scripts/setup-pi.sh
+++ b/scripts/setup-pi.sh
@@ -199,7 +199,11 @@ esac
 # Resolving here, at install time, lets the user see and override the
 # choice up front, and bakes a single constant into kiosk.sh.
 resolve_session_type() {
+    # Diagnostic output goes to stderr so it shows in install logs without
+    # polluting the function's stdout (which is the resolved value). Useful
+    # while we're still ironing out why auto-detect picks wrong on some Pis.
     if [ "$SESSION_TYPE_OVERRIDE" = "x11" ] || [ "$SESSION_TYPE_OVERRIDE" = "wayland" ]; then
+        echo "  [session-detect] CLI override: $SESSION_TYPE_OVERRIDE" >&2
         echo "$SESSION_TYPE_OVERRIDE"
         return
     fi
@@ -208,16 +212,28 @@ resolve_session_type() {
         # shellcheck disable=SC1091
         local codename
         codename=$(. /etc/os-release && echo "${VERSION_CODENAME:-}")
+        echo "  [session-detect] /etc/os-release VERSION_CODENAME='$codename'" >&2
         case "$codename" in
-            bookworm|bullseye|buster) echo "x11"; return ;;
-            trixie) echo "wayland"; return ;;
+            bookworm|bullseye|buster)
+                echo "  [session-detect] codename matched debian X11 line, picking x11" >&2
+                echo "x11"; return ;;
+            trixie)
+                echo "  [session-detect] codename matched trixie, picking wayland" >&2
+                echo "wayland"; return ;;
         esac
+        echo "  [session-detect] codename '$codename' did not match any known release, falling through" >&2
+    else
+        echo "  [session-detect] /etc/os-release not readable, falling through" >&2
     fi
 
+    echo "  [session-detect] XDG_SESSION_TYPE='${XDG_SESSION_TYPE:-}'" >&2
     case "${XDG_SESSION_TYPE:-}" in
-        x11|wayland) echo "$XDG_SESSION_TYPE"; return ;;
+        x11|wayland)
+            echo "  [session-detect] falling back to XDG_SESSION_TYPE: $XDG_SESSION_TYPE" >&2
+            echo "$XDG_SESSION_TYPE"; return ;;
     esac
 
+    echo "  [session-detect] no signal matched, defaulting to x11" >&2
     echo "x11"
 }
 

--- a/scripts/setup-pi.sh
+++ b/scripts/setup-pi.sh
@@ -83,8 +83,8 @@
 #   and baked into kiosk.sh as a constant. Order of precedence:
 #
 #     1. --session-type=x11|wayland on the setup-pi.sh CLI
-#     2. /etc/os-release codename (bookworm/bullseye → x11, trixie → wayland)
-#     3. $XDG_SESSION_TYPE from the installer's shell
+#     2. $XDG_SESSION_TYPE from the installer's shell (if x11 or wayland)
+#     3. /etc/os-release codename (bookworm/bullseye → x11, trixie → wayland)
 #     4. x11 as a last-resort default
 #
 #   The resolved SESSION_TYPE selects the display path:
@@ -189,8 +189,10 @@ esac
 # Resolve the display server type that will be baked into kiosk.sh.
 # Order of precedence:
 #   1. --session-type=x11|wayland on the CLI
-#   2. /etc/os-release codename (bookworm/bullseye → x11, trixie → wayland)
-#   3. $XDG_SESSION_TYPE from the current shell
+#   2. $XDG_SESSION_TYPE from the current shell (if x11 or wayland — what's
+#      actually running beats what the OS defaults to; e.g. Pi 3B+ users on
+#      Trixie often stay on X11 because labwc is slow on VideoCore IV)
+#   3. /etc/os-release codename (bookworm/bullseye → x11, trixie → wayland)
 #   4. x11 (last-resort default — never silently pick wayland)
 #
 # Boot-time auto-detection was previously done inside kiosk.sh but proved
@@ -207,6 +209,19 @@ resolve_session_type() {
         echo "$SESSION_TYPE_OVERRIDE"
         return
     fi
+
+    # XDG_SESSION_TYPE comes first because it reflects what's *actually*
+    # running. The codename heuristic only knows what the OS would default
+    # to; it gets this wrong on Trixie Pi 3B+ boxes that stay on X11
+    # because labwc is too slow on VideoCore IV (see #1026 follow-up).
+    # SSH installs report XDG=tty and fall through to codename, which is
+    # the right behaviour for headless first-installs.
+    echo "  [session-detect] XDG_SESSION_TYPE='${XDG_SESSION_TYPE:-}'" >&2
+    case "${XDG_SESSION_TYPE:-}" in
+        x11|wayland)
+            echo "  [session-detect] using XDG_SESSION_TYPE: $XDG_SESSION_TYPE" >&2
+            echo "$XDG_SESSION_TYPE"; return ;;
+    esac
 
     if [ -r /etc/os-release ]; then
         # shellcheck disable=SC1091
@@ -225,13 +240,6 @@ resolve_session_type() {
     else
         echo "  [session-detect] /etc/os-release not readable, falling through" >&2
     fi
-
-    echo "  [session-detect] XDG_SESSION_TYPE='${XDG_SESSION_TYPE:-}'" >&2
-    case "${XDG_SESSION_TYPE:-}" in
-        x11|wayland)
-            echo "  [session-detect] falling back to XDG_SESSION_TYPE: $XDG_SESSION_TYPE" >&2
-            echo "$XDG_SESSION_TYPE"; return ;;
-    esac
 
     echo "  [session-detect] no signal matched, defaulting to x11" >&2
     echo "x11"

--- a/scripts/setup-pi.sh
+++ b/scripts/setup-pi.sh
@@ -79,8 +79,15 @@
 #   The kiosk launcher (~openhamclock/kiosk.sh) is placed in
 #   ~/.config/autostart/ and runs on every desktop login.
 #
-#   At runtime kiosk.sh reads $XDG_SESSION_TYPE to choose the
-#   correct display path:
+#   The display server (X11 vs Wayland) is resolved at install time
+#   and baked into kiosk.sh as a constant. Order of precedence:
+#
+#     1. --session-type=x11|wayland on the setup-pi.sh CLI
+#     2. /etc/os-release codename (bookworm/bullseye → x11, trixie → wayland)
+#     3. $XDG_SESSION_TYPE from the installer's shell
+#     4. x11 as a last-resort default
+#
+#   The resolved SESSION_TYPE selects the display path:
 #
 #     Wayland  →  Chromium launched with --ozone-platform=wayland
 #                 xset / unclutter are NOT called (X11-only tools)
@@ -89,6 +96,10 @@
 #                 from the autostart context), then xset disables the
 #                 screensaver and unclutter hides the cursor
 #
+#   To switch the baked-in value after install without re-running setup,
+#   either edit the SESSION_TYPE= line in ~/openhamclock/kiosk.sh or set
+#   OPENHAMCLOCK_SESSION_TYPE=x11|wayland in /etc/environment.
+#
 #   If the OpenHamClock server does not respond within 60 seconds,
 #   kiosk.sh exits with an error rather than looping forever.
 #
@@ -96,10 +107,11 @@
 # USAGE
 # ═══════════════════════════════════════════════════════════════════
 #
-#   scripts/setup-pi.sh               # server only (no kiosk)
-#   scripts/setup-pi.sh --kiosk       # server + fullscreen kiosk on boot
-#   scripts/setup-pi.sh --server      # headless server, no GUI packages
-#   scripts/setup-pi.sh --help        # show option summary
+#   scripts/setup-pi.sh                            # server only (no kiosk)
+#   scripts/setup-pi.sh --kiosk                    # server + fullscreen kiosk on boot
+#   scripts/setup-pi.sh --kiosk --session-type=x11 # force X11 if auto-detect picks wrong
+#   scripts/setup-pi.sh --server                   # headless server, no GUI packages
+#   scripts/setup-pi.sh --help                     # show option summary
 #
 #   After installation, edit ~/openhamclock/.env to set your
 #   CALLSIGN and LOCATOR before (re)starting the service.
@@ -138,24 +150,76 @@ echo -e "${NC}"
 # Parse arguments
 KIOSK_MODE=false
 SERVER_MODE=false
+SESSION_TYPE_OVERRIDE=""
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --kiosk) KIOSK_MODE=true ;;
         --server) SERVER_MODE=true ;;
-        --help) 
+        --session-type=*) SESSION_TYPE_OVERRIDE="${1#*=}" ;;
+        --session-type)
+            SESSION_TYPE_OVERRIDE="$2"
+            shift
+            ;;
+        --help)
             echo "Usage: ./setup-pi.sh [OPTIONS]"
             echo ""
             echo "Options:"
-            echo "  --kiosk     Enable kiosk mode (fullscreen, auto-start)"
-            echo "  --server    Install as headless server only"
-            echo "  --help      Show this help message"
+            echo "  --kiosk                  Enable kiosk mode (fullscreen, auto-start)"
+            echo "  --server                 Install as headless server only"
+            echo "  --session-type=TYPE      Force kiosk display server: auto|x11|wayland"
+            echo "                           (default: auto — detected from OS release)"
+            echo "  --help                   Show this help message"
             exit 0
             ;;
         *) echo "Unknown option: $1"; exit 1 ;;
     esac
     shift
 done
+
+# Validate --session-type argument
+case "$SESSION_TYPE_OVERRIDE" in
+    ""|auto|x11|wayland) ;;
+    *)
+        echo "Error: --session-type must be one of: auto, x11, wayland (got: $SESSION_TYPE_OVERRIDE)"
+        exit 1
+        ;;
+esac
+
+# Resolve the display server type that will be baked into kiosk.sh.
+# Order of precedence:
+#   1. --session-type=x11|wayland on the CLI
+#   2. /etc/os-release codename (bookworm/bullseye → x11, trixie → wayland)
+#   3. $XDG_SESSION_TYPE from the current shell
+#   4. x11 (last-resort default — never silently pick wayland)
+#
+# Boot-time auto-detection was previously done inside kiosk.sh but proved
+# unreliable on Bookworm where stray WAYLAND_DISPLAY values caused it to
+# pick the wayland branch and produce a white screen at boot (#1026).
+# Resolving here, at install time, lets the user see and override the
+# choice up front, and bakes a single constant into kiosk.sh.
+resolve_session_type() {
+    if [ "$SESSION_TYPE_OVERRIDE" = "x11" ] || [ "$SESSION_TYPE_OVERRIDE" = "wayland" ]; then
+        echo "$SESSION_TYPE_OVERRIDE"
+        return
+    fi
+
+    if [ -r /etc/os-release ]; then
+        # shellcheck disable=SC1091
+        local codename
+        codename=$(. /etc/os-release && echo "${VERSION_CODENAME:-}")
+        case "$codename" in
+            bookworm|bullseye|buster) echo "x11"; return ;;
+            trixie) echo "wayland"; return ;;
+        esac
+    fi
+
+    case "${XDG_SESSION_TYPE:-}" in
+        x11|wayland) echo "$XDG_SESSION_TYPE"; return ;;
+    esac
+
+    echo "x11"
+}
 
 # Check if running on Raspberry Pi
 check_raspberry_pi() {
@@ -379,37 +443,41 @@ EOF
 # Setup kiosk mode
 setup_kiosk() {
     echo -e "${CYAN}>>> Configuring kiosk mode...${NC}"
-    
+
+    local resolved_session_type
+    resolved_session_type=$(resolve_session_type)
+    echo -e "${GREEN}✓ Kiosk display server: $resolved_session_type${NC}"
+    if [ -z "$SESSION_TYPE_OVERRIDE" ] || [ "$SESSION_TYPE_OVERRIDE" = "auto" ]; then
+        echo "  (override with --session-type=x11|wayland if this is wrong)"
+    fi
+
     # Disable screen blanking (0 = disable, 1 = enable — keep the screen on for kiosk)
     sudo raspi-config nonint do_blanking 0 2>/dev/null || true
-    
+
     # Create autostart directory
     mkdir -p "$HOME/.config/autostart"
-    
-    # Create kiosk launcher script
-    cat > "$INSTALL_DIR/kiosk.sh" << 'EOF'
+
+    # Create kiosk launcher script.
+    # First heredoc (unquoted) bakes in the resolved SESSION_TYPE so the
+    # launcher does no runtime detection — install-time resolution is more
+    # reliable than reading $XDG_SESSION_TYPE / $WAYLAND_DISPLAY at autostart
+    # (see #1026 for the boot-time false-wayland case on Bookworm).
+    cat > "$INSTALL_DIR/kiosk.sh" << EOF
 #!/bin/bash
 # OpenHamClock Kiosk Launcher
 # Supports Raspberry Pi OS Bookworm (X11) and Trixie (Wayland/labwc)
+#
+# SESSION_TYPE is baked in by setup-pi.sh at install time. To switch
+# without re-running setup, edit the line below or set
+# OPENHAMCLOCK_SESSION_TYPE=x11|wayland in /etc/environment.
+SESSION_TYPE="\${OPENHAMCLOCK_SESSION_TYPE:-$resolved_session_type}"
+EOF
+    cat >> "$INSTALL_DIR/kiosk.sh" << 'EOF'
 
 # Wait for the desktop environment to be ready
 sleep 5
 
-# ------------------------------------------------------------------
-# Detect display server: Wayland or X11
-# $XDG_SESSION_TYPE is set by the session manager on both Bookworm and Trixie.
-# Fall back to checking $WAYLAND_DISPLAY in case the variable isn't exported.
-# ------------------------------------------------------------------
-SESSION_TYPE="${XDG_SESSION_TYPE:-}"
-if [ -z "$SESSION_TYPE" ] && [ -n "$WAYLAND_DISPLAY" ]; then
-    SESSION_TYPE="wayland"
-fi
-if [ -z "$SESSION_TYPE" ]; then
-    # Last resort: default to x11 so the script always does something useful
-    SESSION_TYPE="x11"
-fi
-
-echo "OpenHamClock kiosk: detected session type = $SESSION_TYPE"
+echo "OpenHamClock kiosk: session type = $SESSION_TYPE"
 
 if [ "$SESSION_TYPE" = "wayland" ]; then
     # ------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1026 (white screen at boot on Pi 3B+ / Bookworm with `--kiosk`).

## Root cause

The generated `kiosk.sh` was detecting the display server at boot via `XDG_SESSION_TYPE` plus a `WAYLAND_DISPLAY` fallback. On Michael's Bookworm 64-bit Pi (X11) that fallback picked the wayland branch and Chromium came up with `--ozone-platform=wayland` against an X server — hence the white screen.

## Fix

Move the X11-vs-Wayland choice from boot time to install time:

1. New CLI flag: `--session-type=auto|x11|wayland` on `setup-pi.sh`. Default `auto`.
2. New `resolve_session_type` function picks via:
   - explicit override
   - `/etc/os-release` codename (bookworm/bullseye/buster → x11, trixie → wayland)
   - `XDG_SESSION_TYPE` from the installer's shell
   - `x11` as the last-resort default (never silently picks wayland)
3. The generated `kiosk.sh` now bakes the resolved value in as a single constant, with a runtime override via `OPENHAMCLOCK_SESSION_TYPE` env var if anyone needs to flip it without re-running setup.

This means Michael's Bookworm case would have resolved to `x11` at install time and never hit the boot-time wayland path that was producing the white screen.

## Test plan

Smoke-tested locally:
- `bash -n` passes
- `resolve_session_type` returns the right value for fake `/etc/os-release` codenames (bookworm/bullseye → x11, trixie → wayland), explicit overrides win, garbage values rejected by the validator
- Generated `kiosk.sh` runs end-to-end with both baked-in defaults; `OPENHAMCLOCK_SESSION_TYPE` override works

Needs a real-Pi test to fully validate — Michael, would you mind re-running `scripts/setup-pi.sh --kiosk` from this branch on the same Pi 3B+ Bookworm box and confirming it comes up clean at next boot? The installer should print `Kiosk display server: x11` and `~/openhamclock/kiosk.sh` should contain `SESSION_TYPE="${OPENHAMCLOCK_SESSION_TYPE:-x11}"`.

If the codename detection still misses your setup, `--session-type=x11` on the CLI is the explicit escape hatch.

K0CJH