### PR TITLE
Iturhfprop action ctx fix

### DIFF
--- a/.github/workflows/docker-dxspider-proxy.yml
+++ b/.github/workflows/docker-dxspider-proxy.yml
@@ -29,6 +29,7 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/docker-dxspider-proxy.yml
+++ b/.github/workflows/docker-dxspider-proxy.yml
@@ -70,7 +70,7 @@ jobs:
         id: push
         uses: docker/build-push-action@v7
         with:
-          context: .
+          context: ./dxspider-proxy
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-iturhfprop-service.yml
+++ b/.github/workflows/docker-iturhfprop-service.yml
@@ -29,6 +29,7 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/docker-iturhfprop-service.yml
+++ b/.github/workflows/docker-iturhfprop-service.yml
@@ -70,7 +70,7 @@ jobs:
         id: push
         uses: docker/build-push-action@v7
         with:
-          context: .
+          context: ./iturhfprop-service
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-openhamclock.yml
+++ b/.github/workflows/docker-openhamclock.yml
@@ -29,6 +29,7 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
## What does this PR do?

This fixes the iturhfprop and dxspider container build actions having the incorrect build context path set (this is making them just build OHC instead)

I also added some sane timeouts to the jobs so that if there is a runner issue with qemu or the like they dont hang forever.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1. Check that build action output looks correct.
