### PR TITLE
Release v26.4.1 — restore AMSAT + SatNOGS satellite fallbacks

### DIFF
--- a/.github/workflows/docker-dxspider-proxy 2.yml
+++ b/.github/workflows/docker-dxspider-proxy 2.yml
@@ -1,0 +1,90 @@
+name: Build and Publish dxspider-proxy container image
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/dxspider-proxy
+
+on:
+  push:
+    branches: ['*']
+    paths:
+      - 'dxspider-proxy/**'
+      - '.github/workflows/docker-dxspider-proxy.yml'
+  pull_request:
+    branches:
+      - Staging
+      - main
+    paths:
+      - 'dxspider-proxy/**'
+      - '.github/workflows/docker-dxspider-proxy.yml'
+  release:
+    types: [published]
+  # Allows running this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=${{ github.workflow }}
+          cache-to: type=gha,scope=${{ github.workflow }},mode=max
+          provenance: true
+          sbom: true
+
+      - name: Generate artifact attestation
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker-dxspider-proxy.yml
+++ b/.github/workflows/docker-dxspider-proxy.yml
@@ -29,6 +29,7 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/docker-dxspider-proxy.yml
+++ b/.github/workflows/docker-dxspider-proxy.yml
@@ -70,7 +70,7 @@ jobs:
         id: push
         uses: docker/build-push-action@v7
         with:
-          context: .
+          context: ./dxspider-proxy
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-iturhfprop-service.yml
+++ b/.github/workflows/docker-iturhfprop-service.yml
@@ -29,6 +29,7 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/docker-iturhfprop-service.yml
+++ b/.github/workflows/docker-iturhfprop-service.yml
@@ -70,7 +70,7 @@ jobs:
         id: push
         uses: docker/build-push-action@v7
         with:
-          context: .
+          context: ./iturhfprop-service
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-openhamclock.yml
+++ b/.github/workflows/docker-openhamclock.yml
@@ -29,6 +29,7 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       packages: write

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openhamclock",
-  "version": "26.4.0",
+  "version": "26.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openhamclock",
-      "version": "26.4.0",
+      "version": "26.4.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhamclock",
-  "version": "26.4.0",
+  "version": "26.4.1",
   "description": "Amateur Radio Dashboard - A modern web-based HamClock alternative",
   "main": "electron/main.js",
   "scripts": {

--- a/server/routes/geo-time 2.js
+++ b/server/routes/geo-time 2.js
@@ -1,0 +1,74 @@
+const { getTimezoneForLocation } = require('../utils/geoTz');
+const { latLonToMaidenhead, maidenheadToLatLon } = require('../utils/grid');
+
+/**
+ * Register geo-time API routes.
+ *
+ * GET /api/geo-time?lat=X&lon=Y → { timezone, localTime, utcTime, grid }
+ * GET /api/geo-time?grid=IM58   → same (lat/lon takes precedence if both given)
+ */
+module.exports = function (app) {
+  app.get('/api/geo-time', (req, res) => {
+    let lat = parseFloat(req.query.lat);
+    let lon = parseFloat(req.query.lon);
+
+    // If lat/lon provided, use them (grid param ignored)
+    if (Number.isFinite(lat) && Number.isFinite(lon)) {
+      return respondWithCoords(res, lat, lon);
+    }
+
+    // If grid provided, convert to lat/lon
+    const grid = (req.query.grid || '').toUpperCase().trim();
+    if (grid) {
+      let coords;
+      try {
+        coords = maidenheadToLatLon(grid);
+      } catch {
+        return res.status(400).json({ error: `Invalid grid locator: ${req.query.grid}` });
+      }
+      lat = coords.lat;
+      lon = coords.lon;
+    } else {
+      return res.status(400).json({ error: 'lat+lon or grid is required' });
+    }
+
+    return respondWithCoords(res, lat, lon);
+  });
+};
+
+function respondWithCoords(res, lat, lon) {
+  const tz = getTimezoneForLocation(lat, lon);
+
+  const now = new Date();
+  const utcTime = new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: 'UTC',
+  }).format(now);
+
+  const grid = latLonToMaidenhead({ lat, lon }, 6);
+
+  if (!tz) {
+    return res.json({
+      timezone: null,
+      localTime: utcTime,
+      utcTime,
+      grid,
+    });
+  }
+
+  const localTime = new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: tz,
+  }).format(now);
+
+  res.json({
+    timezone: tz,
+    localTime,
+    utcTime,
+    grid,
+  });
+}

--- a/server/routes/satellites.js
+++ b/server/routes/satellites.js
@@ -7,6 +7,7 @@
 const fs = require('fs');
 const path = require('path');
 const satellitesTracked = require('./satellites-tracked');
+const { tleToOmm, parseTleBlock } = require('../utils/tle-to-omm');
 const { normalizeJsonTree } = require('../utils/normalize');
 const { MutexCounter } = require('../utils/mutex');
 const { StateMachine } = require('../utils/statemachine');
@@ -137,6 +138,78 @@ module.exports = function (app, ctx) {
     }
 
     return { httpStatusCode, ommJson };
+  };
+
+  // ── AMSAT fallback ────────────────────────────────────────────────────────
+  // Single concatenated-TLE feed at amsat.org. Covers amateur sats (no weather
+  // / no non-amateur birds). Used as a fallback for CelesTrak so that we keep
+  // resolving satellites when celestrak.org is unreachable from our egress IP
+  // — historically a recurring failure mode on cloud hosts (#1057).
+  const fetchOmmFromAmsat = async () => {
+    let httpStatusCode = 0;
+    let ommArray = [];
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 20000); // 20s hard timeout
+    try {
+      const res = await fetch('https://www.amsat.org/tle/current/nasabare.txt', {
+        headers: { 'User-Agent': `OpenHamClock/${APP_VERSION}` },
+        signal: controller.signal,
+      });
+
+      httpStatusCode = res.status;
+
+      if (res.ok) {
+        const text = await res.text();
+        ommArray = parseTleBlock(text);
+        logDebug(`[Satellites] AMSAT TLE fetch successful, ${ommArray.length} TLEs parsed`);
+      } else if (res.status >= 400 && res.status <= 499) {
+        const body = await res.text().catch(() => '<no message>');
+        logWarn(`[Satellites] AMSAT TLE fetch failed: ${res.status} ${body.slice(0, 100)}`);
+      }
+    } catch (ex) {
+      logWarn(`[Satellites] AMSAT TLE fetch timed out after 20s`);
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    return { httpStatusCode, ommArray };
+  };
+
+  // ── SatNOGS individual fallback ───────────────────────────────────────────
+  // SatNOGS DB exposes per-NORAD TLE JSON. Used as a per-satellite fallback
+  // after AMSAT for non-amateur birds (weather sats, ISS, etc.) that CelesTrak
+  // wouldn't fetch from our egress.
+  const fetchOmmFromSatnogsIndividual = async (noradId) => {
+    let httpStatusCode = 0;
+    let omm = null;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 20000); // 20s hard timeout
+    try {
+      const res = await fetch(`https://db.satnogs.org/api/tle/?norad_cat_id=${noradId}&format=json`, {
+        headers: { 'User-Agent': `OpenHamClock/${APP_VERSION}` },
+        signal: controller.signal,
+      });
+
+      httpStatusCode = res.status;
+
+      if (res.ok) {
+        const arr = await res.json();
+        if (Array.isArray(arr) && arr.length > 0) {
+          const entry = arr[0];
+          omm = tleToOmm(entry.tle0 || `NORAD ${noradId}`, entry.tle1, entry.tle2);
+          if (omm) logDebug(`[Satellites] SatNOGS TLE fetch for NORAD ${noradId} successful`);
+        }
+      } else if (res.status >= 400 && res.status <= 499) {
+        const body = await res.text().catch(() => '<no message>');
+        logWarn(`[Satellites] SatNOGS fetch failed for NORAD ${noradId}: ${res.status} ${body.slice(0, 100)}`);
+      }
+    } catch (ex) {
+      logWarn(`[Satellites] SatNOGS fetch for NORAD ${noradId} timed out after 20s`);
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    return { httpStatusCode, omm };
   };
 
   const fetchOmmFromSpaceTrack = async (norad, username, password) => {
@@ -333,6 +406,10 @@ module.exports = function (app, ctx) {
 
   let blockCelesTrakUntil = Date.now() - 1; // Timestamp until which CelesTrak fetches are blocked due to rate limiting or ban
   let blockSpaceTrackUntil = Date.now() - 1; // Timestamp until which Space-Track fetches are blocked due to rate limiting or ban
+  let blockAmsatUntil = Date.now() - 1; // Timestamp until which AMSAT fallback fetches are blocked
+  let blockSatnogsUntil = Date.now() - 1; // Timestamp until which SatNOGS fallback fetches are blocked
+  const AMSAT_BACKOFF = 60 * 60 * 1000; // 1 hour
+  const SATNOGS_BACKOFF = 60 * 60 * 1000; // 1 hour
   let celestrakNumSatNeedDownload = 0;
   let noradsToDownload = [];
 
@@ -347,6 +424,10 @@ module.exports = function (app, ctx) {
     'CELESTRAK_WEATHER_GROUP_FETCH',
     'CELESTRAK_INDIVIDUAL_INIT',
     'CELESTRAK_INDIVIDUAL_FETCH',
+    'AMSAT_INIT',
+    'AMSAT_FETCH',
+    'SATNOGS_INDIVIDUAL_INIT',
+    'SATNOGS_INDIVIDUAL_FETCH',
   ];
 
   // state-machine handlers
@@ -470,7 +551,7 @@ module.exports = function (app, ctx) {
     CELESTRAK_INDIVIDUAL_INIT: async () => {
       if (blockCelesTrakUntil && Date.now() < blockCelesTrakUntil) {
         logDebug('[Satellites] Skipping CelesTrak fetch due to active backoff');
-        return 'START'; // return next state
+        return 'AMSAT_INIT'; // fall through to fallback chain
       }
 
       // loop until every eligible satellite has been attempted for download using CELESTRAK_INDIVIDUAL_FETCH state,
@@ -492,7 +573,7 @@ module.exports = function (app, ctx) {
         return 'CELESTRAK_INDIVIDUAL_FETCH'; // return next state
       }
 
-      return 'START'; // return next state
+      return 'AMSAT_INIT'; // CelesTrak chain done — fall through to AMSAT/SatNOGS fallback
     },
 
     CELESTRAK_INDIVIDUAL_FETCH: async () => {
@@ -520,6 +601,69 @@ module.exports = function (app, ctx) {
         );
       } finally {
         return 'CELESTRAK_INDIVIDUAL_INIT'; // return next state, back to INIT
+      }
+    },
+
+    // ── AMSAT fallback (covers amateur sats when CelesTrak is unreachable) ──
+    AMSAT_INIT: async () => {
+      if (blockAmsatUntil && Date.now() < blockAmsatUntil) {
+        return 'SATNOGS_INDIVIDUAL_INIT';
+      }
+      // Only run if there are still stale satellites needing data
+      const stillStale = Object.values(HAM_SATELLITES).filter((s) => isStale(s.ommTimestamp));
+      if (stillStale.length === 0) return 'START';
+      return 'AMSAT_FETCH';
+    },
+
+    AMSAT_FETCH: async () => {
+      try {
+        const { httpStatusCode, ommArray } = await fetchOmmFromAmsat();
+        if (httpStatusCode === 200 && ommArray.length > 0) {
+          appendDataToOmmCache(ommArray);
+        } else if (httpStatusCode === 0 || httpStatusCode >= 500) {
+          // Network failure or server error — backoff so we don't hammer
+          blockAmsatUntil = Date.now() + AMSAT_BACKOFF;
+        }
+      } catch (ex) {
+        const msg = ex?.message || String(ex ?? '(unknown error)');
+        logWarn(`[Satellites] caught unknown exception in AMSAT_FETCH handler: ${msg}`);
+      } finally {
+        return 'SATNOGS_INDIVIDUAL_INIT';
+      }
+    },
+
+    // ── SatNOGS individual fallback (covers non-amateur stragglers) ─────────
+    SATNOGS_INDIVIDUAL_INIT: async () => {
+      if (blockSatnogsUntil && Date.now() < blockSatnogsUntil) {
+        return 'START';
+      }
+      const now = Date.now();
+      const stillStale = Object.values(HAM_SATELLITES).filter(
+        (s) => isStale(s.ommTimestamp) && !(s.backoffSatnogsUntil && now < s.backoffSatnogsUntil),
+      );
+      if (stillStale.length === 0) return 'START';
+      const sat = stillStale[0];
+      sat.backoffSatnogsUntil = now + SATNOGS_BACKOFF;
+      noradsToDownload = sat.norad;
+      return 'SATNOGS_INDIVIDUAL_FETCH';
+    },
+
+    SATNOGS_INDIVIDUAL_FETCH: async () => {
+      try {
+        if (Array.isArray(noradsToDownload)) {
+          throw new Error('[Satellites] SATNOGS_INDIVIDUAL_FETCH: noradsToDownload should not be array');
+        }
+        const { httpStatusCode, omm } = await fetchOmmFromSatnogsIndividual(noradsToDownload);
+        if (httpStatusCode === 200 && omm) {
+          appendDataToOmmCache([omm]);
+        } else if (httpStatusCode === 0 || httpStatusCode >= 500) {
+          blockSatnogsUntil = Date.now() + SATNOGS_BACKOFF;
+        }
+      } catch (ex) {
+        const msg = ex?.message || String(ex ?? '(unknown error)');
+        logWarn(`[Satellites] caught unknown exception in SATNOGS_INDIVIDUAL_FETCH handler: ${msg}`);
+      } finally {
+        return 'SATNOGS_INDIVIDUAL_INIT';
       }
     },
 

--- a/server/utils/geoTz 2.js
+++ b/server/utils/geoTz 2.js
@@ -1,0 +1,27 @@
+const { find } = require('geo-tz/all');
+
+/**
+ * Get IANA timezone for a lat/lon coordinate.
+ * Returns a single timezone string (e.g., "America/New_York") or null.
+ * Falls back to "Etc/UTC" for ocean coordinates.
+ */
+function getTimezoneForLocation(lat, lon) {
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+
+  try {
+    const timezones = find(lat, lon);
+    if (!timezones || timezones.length === 0) {
+      // Ocean or unclaimed territory — default to UTC
+      return 'Etc/UTC';
+    }
+
+    // Prefer the first non-Etc/GMT* result (Etc/GMT appears at sea or terra nullius)
+    const preferred = timezones.find((tz) => !tz.startsWith('Etc/GMT'));
+    return preferred ?? timezones[0];
+  } catch (err) {
+    console.error(`[geoTz] Failed to lookup timezone for ${lat}, ${lon}:`, err.message);
+    return null;
+  }
+}
+
+module.exports = { getTimezoneForLocation };

--- a/server/utils/grid.test 2.js
+++ b/server/utils/grid.test 2.js
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { validateGridLocator, latLonToMaidenhead, maidenheadToLatLon, maidenheadToBoundingBox } from './grid.js';
+
+describe('Maidenhead Grid tests', () => {
+  const gridCases = [
+    // note that 'grid' fields entered in the test cases are all 8 characters long,
+    // as tests will also validate the first 2, 4, 6 and 8 characters.
+
+    // location in San Diego, CA, USA
+    {
+      grid: 'DM12kv99',
+      actualLatLon: { lat: 32.91254, lon: -117.08409 },
+      latLonSWCornerGrid6: [32.875, -117.167],
+      latLonNECornerGrid6: [32.917, -117.083],
+    },
+
+    // location in Sydney, Australia
+    {
+      grid: 'QF56od55',
+      actualLatLon: { lat: -33.8519, lon: 151.210886 },
+    },
+
+    // location at equator / prime meridian
+    {
+      grid: 'JJ00aa00',
+      actualLatLon: { lat: 0, lon: 0 },
+    },
+
+    // location at equator just west of antimeridian
+    {
+      grid: 'RJ90XA90',
+      actualLatLon: { lat: 0, lon: 179.999 },
+    },
+
+    // location at equator on antimeridian
+    // note that this is not strictly valid as longitude should be given as -180 rather than +180,
+    // however some sources may expected +180 to be functional so it should be tested
+    {
+      grid: 'AJ00AA00',
+      actualLatLon: { lat: 0, lon: 180.0 },
+    },
+
+    // location at equator on antimeridian
+    {
+      grid: 'AJ00AA00',
+      actualLatLon: { lat: 0, lon: -180.0 },
+    },
+  ];
+
+  it('should invalidate empty grid locator', () => {
+    expect(validateGridLocator('')).toBe(false);
+  });
+
+  it('should invalidate grid locator with invalid length', () => {
+    expect(validateGridLocator('DM1')).toBe(false);
+  });
+
+  it('should invalidate grid locator with invalid characters', () => {
+    expect(validateGridLocator('DM12zz')).toBe(false);
+  });
+
+  for (const { grid, actualLatLon, latLonSWCornerGrid6, latLonNECornerGrid6 } of gridCases) {
+    it(
+      ('should validate test case grid locator has size 8',
+      () => {
+        expect(grid.length).toEqual(8);
+      }),
+    );
+
+    const defaultSize = 6;
+    const sizes = [2, 4, 6, 8];
+    for (const size of sizes) {
+      it("should validate grid locator '" + grid.substring(0, size) + "'", () => {
+        const subGrid = grid.substring(0, size);
+        expect(validateGridLocator(subGrid)).toBe(true);
+      });
+    }
+
+    for (const size of sizes) {
+      it('should convert Lat/Lon to Maidenhead Grid of requested size ' + size, () => {
+        const result = latLonToMaidenhead(actualLatLon, size);
+        expect(result.toUpperCase()).toBe(grid.substring(0, size).toUpperCase());
+      });
+    }
+
+    it('should convert Lat/Lon to Maidenhead Grid with default size 6 when no size is specified', () => {
+      const result = latLonToMaidenhead(actualLatLon);
+      expect(result.toUpperCase()).toBe(grid.substring(0, defaultSize).toUpperCase());
+    });
+
+    for (const size of sizes) {
+      it("should convert Maidenhead Grid '" + grid.substring(0, size) + "' to Lat/Lon", () => {
+        const { lat, lon } = maidenheadToLatLon(grid.substring(0, size));
+        // handle case where longitude is given as +180 or -180, although +180 is strictly invalid it can sometimes be used so should be tested
+        const { lat: expectedLat, lon: rawLon } = actualLatLon,
+          expectedLon = ((rawLon + 180) % 360) - 180;
+        let latBucketSize, lonBucketSize, latBucketStart, latBucketEnd, lonBucketStart, lonBucketEnd;
+
+        switch (size) {
+          case 2:
+            latBucketSize = 10; // degrees
+            latBucketStart = Math.floor(expectedLat / latBucketSize) * latBucketSize;
+            latBucketEnd = latBucketStart + latBucketSize;
+
+            lonBucketSize = 20; // degrees
+            lonBucketStart = Math.floor(expectedLon / lonBucketSize) * lonBucketSize;
+            lonBucketEnd = lonBucketStart + lonBucketSize;
+            break;
+
+          case 4:
+            latBucketSize = 1; // degrees
+            latBucketStart = Math.floor(expectedLat / latBucketSize) * latBucketSize;
+            latBucketEnd = latBucketStart + latBucketSize;
+
+            lonBucketSize = 2; // degrees
+            lonBucketStart = Math.floor(expectedLon / lonBucketSize) * lonBucketSize;
+            lonBucketEnd = lonBucketStart + lonBucketSize;
+            break;
+
+          case 6:
+            latBucketSize = 2.5; // minutes
+            latBucketStart = (Math.floor((60 * expectedLat) / latBucketSize) * latBucketSize) / 60;
+            latBucketEnd = latBucketStart + latBucketSize / 60;
+
+            lonBucketSize = 5; // minutes
+            lonBucketStart = (Math.floor((60 * expectedLon) / lonBucketSize) * lonBucketSize) / 60;
+            lonBucketEnd = lonBucketStart + lonBucketSize / 60;
+            break;
+
+          case 8:
+            latBucketSize = 0.25; // minutes
+            latBucketStart = (Math.floor((10 * 60 * expectedLat) / latBucketSize) * latBucketSize) / 60 / 10;
+            latBucketEnd = latBucketStart + latBucketSize / 60;
+
+            lonBucketSize = 0.5; // minutes
+            lonBucketStart = (Math.floor((60 * expectedLon) / lonBucketSize) * lonBucketSize) / 60;
+            lonBucketEnd = lonBucketStart + lonBucketSize / 60;
+            break;
+
+          default:
+            throw new Error('invalid size');
+        }
+
+        expect(lat).toBeGreaterThanOrEqual(latBucketStart);
+        expect(lat).toBeLessThan(latBucketEnd);
+        expect(lon).toBeGreaterThanOrEqual(lonBucketStart);
+        expect(lon).toBeLessThan(lonBucketEnd);
+      });
+    }
+
+    if (latLonSWCornerGrid6 && latLonNECornerGrid6) {
+      it(
+        "should convert Maidenhead Grid '" + grid.substring(0, defaultSize) + "' to Lat/Lon bounding box coordinates",
+        () => {
+          const result = maidenheadToBoundingBox(grid.substring(0, defaultSize));
+          expect(result).toHaveLength(2);
+          expect(result[0]).toHaveLength(2);
+          expect(result[1]).toHaveLength(2);
+
+          expect(result[0][0]).toBeCloseTo(latLonSWCornerGrid6[0], 3);
+          expect(result[0][1]).toBeCloseTo(latLonSWCornerGrid6[1], 3);
+          expect(result[1][0]).toBeCloseTo(latLonNECornerGrid6[0], 3);
+          expect(result[1][1]).toBeCloseTo(latLonNECornerGrid6[1], 3);
+        },
+      );
+    }
+  }
+});

--- a/server/utils/tle-to-omm.js
+++ b/server/utils/tle-to-omm.js
@@ -1,0 +1,166 @@
+/**
+ * Convert classical Two-Line Element (TLE) set to an OMM-shaped JSON object
+ * matching what CelesTrak returns from /NORAD/elements/gp.php?FORMAT=json.
+ *
+ * Used by the satellite resolver to pour TLE data from AMSAT and SatNOGS
+ * (TLE-only feeds) into the same ommCache structure the rest of the code expects.
+ *
+ * TLE column layout reference: https://celestrak.org/NORAD/documentation/tle-fmt.php
+ * OMM format reference:        https://celestrak.org/NORAD/documentation/gp-data-formats.php
+ */
+
+'use strict';
+
+/**
+ * Parse a TLE scientific-notation field with an implied decimal point.
+ * TLE encodes values like 0.18407e-3 as " 18407-3" (no leading sign means +,
+ * no decimal point — it sits to the left of the first significant digit).
+ */
+function parseExpField(raw) {
+  const trimmed = String(raw).trim();
+  if (!trimmed || trimmed === '0' || trimmed === '00000-0' || trimmed === '+00000-0') return 0;
+  const sign = trimmed[0] === '-' ? -1 : 1;
+  const body = trimmed[0] === '+' || trimmed[0] === '-' ? trimmed.slice(1) : trimmed;
+  // body looks like "18407-3" → mantissa "18407", exponent "-3"
+  const m = body.match(/^(\d+)([+-]\d+)$/);
+  if (!m) return 0;
+  const mantissa = parseInt(m[1], 10) / Math.pow(10, m[1].length);
+  const exponent = parseInt(m[2], 10);
+  return sign * mantissa * Math.pow(10, exponent);
+}
+
+/**
+ * Parse a TLE decimal field with an implied leading decimal point.
+ * TLE encodes eccentricity 0.0007169 as " 0007169" (7 digits, leading "0.").
+ */
+function parseImpliedDecimal(raw) {
+  const trimmed = String(raw).trim();
+  if (!trimmed) return 0;
+  const sign = trimmed[0] === '-' ? -1 : 1;
+  const body = trimmed[0] === '+' || trimmed[0] === '-' ? trimmed.slice(1) : trimmed;
+  return sign * parseFloat('0.' + body);
+}
+
+/**
+ * Convert TLE epoch (YYDDD.DDDDDDDD) to ISO 8601 datetime string.
+ * Year is 2-digit: 57-99 → 19xx, 00-56 → 20xx per CelesTrak convention.
+ */
+function epochToIso(epochField) {
+  const trimmed = String(epochField).trim();
+  const yy = parseInt(trimmed.slice(0, 2), 10);
+  const doyFrac = parseFloat(trimmed.slice(2));
+  const fullYear = yy < 57 ? 2000 + yy : 1900 + yy;
+  const dayOfYearInt = Math.floor(doyFrac);
+  const fractionalDay = doyFrac - dayOfYearInt;
+  // Day 1 = January 1
+  const base = Date.UTC(fullYear, 0, dayOfYearInt);
+  const ms = base + fractionalDay * 86400000;
+  return new Date(ms).toISOString().replace('Z', '');
+}
+
+/**
+ * Convert a TLE (name + line1 + line2) into an OMM-shaped JSON object.
+ * Returns null if parsing fails so callers can skip bad records cleanly.
+ *
+ * @param {string} name   Satellite name (line 0)
+ * @param {string} line1  TLE line 1
+ * @param {string} line2  TLE line 2
+ * @returns {object|null}
+ */
+function tleToOmm(name, line1, line2) {
+  if (typeof line1 !== 'string' || typeof line2 !== 'string') return null;
+  if (line1.length < 68 || line2.length < 68) return null;
+  if (line1[0] !== '1' || line2[0] !== '2') return null;
+
+  try {
+    // Line 1 columns (0-indexed for slice, TLE spec is 1-indexed)
+    const noradCatId = parseInt(line1.slice(2, 7), 10);
+    const classification = line1.slice(7, 8) || 'U';
+    const intlDesignatorRaw = line1.slice(9, 17).trim();
+    // Format the international designator like "1998-067A" if it parses cleanly
+    let objectId = intlDesignatorRaw;
+    const intlMatch = intlDesignatorRaw.match(/^(\d{2})(\d{3})([A-Z]+)$/);
+    if (intlMatch) {
+      const yy = parseInt(intlMatch[1], 10);
+      const year = yy < 57 ? 2000 + yy : 1900 + yy;
+      objectId = `${year}-${intlMatch[2]}${intlMatch[3]}`;
+    }
+    const epoch = epochToIso(line1.slice(18, 32));
+    // CelesTrak's OMM endpoint preserves the TLE's /2 and /6 conventions for
+    // these fields, and satellite.js's json2satrec expects the same. Don't undo.
+    const meanMotionDot = parseFloat(line1.slice(33, 43));
+    const meanMotionDdot = parseExpField(line1.slice(44, 52));
+    const bstar = parseExpField(line1.slice(53, 61));
+    const ephemerisType = parseInt(line1.slice(62, 63), 10) || 0;
+    const elementSetNo = parseInt(line1.slice(64, 68).trim(), 10) || 0;
+
+    // Line 2 columns
+    const inclination = parseFloat(line2.slice(8, 16));
+    const raOfAscNode = parseFloat(line2.slice(17, 25));
+    const eccentricity = parseImpliedDecimal(line2.slice(26, 33));
+    const argOfPerigee = parseFloat(line2.slice(34, 42));
+    const meanAnomaly = parseFloat(line2.slice(43, 51));
+    const meanMotion = parseFloat(line2.slice(52, 63));
+    const revAtEpoch = parseInt(line2.slice(63, 68).trim(), 10) || 0;
+
+    // Sanity check: NORAD ID must agree between the two lines
+    const noradLine2 = parseInt(line2.slice(2, 7), 10);
+    if (noradCatId !== noradLine2) return null;
+    if (!Number.isFinite(inclination) || !Number.isFinite(meanMotion)) return null;
+
+    return {
+      OBJECT_NAME: String(name || '')
+        .replace(/^0\s+/, '')
+        .trim(),
+      OBJECT_ID: objectId,
+      EPOCH: epoch,
+      MEAN_MOTION: meanMotion,
+      ECCENTRICITY: eccentricity,
+      INCLINATION: inclination,
+      RA_OF_ASC_NODE: raOfAscNode,
+      ARG_OF_PERICENTER: argOfPerigee,
+      MEAN_ANOMALY: meanAnomaly,
+      EPHEMERIS_TYPE: ephemerisType,
+      CLASSIFICATION_TYPE: classification,
+      NORAD_CAT_ID: noradCatId,
+      ELEMENT_SET_NO: elementSetNo,
+      REV_AT_EPOCH: revAtEpoch,
+      BSTAR: bstar,
+      MEAN_MOTION_DOT: meanMotionDot,
+      MEAN_MOTION_DDOT: meanMotionDdot,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a concatenated TLE text blob (AMSAT nasabare.txt format) into an
+ * array of OMM objects. Returns an empty array on parse failure.
+ *
+ * Format:
+ *   NAME
+ *   1 NNNNN...
+ *   2 NNNNN...
+ *   NAME
+ *   1 NNNNN...
+ *   2 NNNNN...
+ */
+function parseTleBlock(text) {
+  if (typeof text !== 'string') return [];
+  const lines = text.split(/\r?\n/).map((l) => l.replace(/\s+$/, ''));
+  const out = [];
+  for (let i = 0; i + 2 < lines.length; i++) {
+    const l0 = lines[i];
+    const l1 = lines[i + 1];
+    const l2 = lines[i + 2];
+    if (l1.startsWith('1 ') && l2.startsWith('2 ')) {
+      const omm = tleToOmm(l0, l1, l2);
+      if (omm) out.push(omm);
+      i += 2; // skip the lines we just consumed
+    }
+  }
+  return out;
+}
+
+module.exports = { tleToOmm, parseTleBlock, parseImpliedDecimal, parseExpField, epochToIso };

--- a/src/components/WhatsNew.jsx
+++ b/src/components/WhatsNew.jsx
@@ -29,6 +29,19 @@ const ANNOUNCEMENT = {
 
 const CHANGELOG = [
   {
+    version: '26.4.1',
+    date: '2026-06-02',
+    heading:
+      'Same-day hotfix for v26.4.0. The new OMM satellite resolver from the June release dropped the AMSAT and SatNOGS fallback sources that v26.3.3 had, which meant any deployment whose egress IPs could not reach CelesTrak (notably the hosted openhamclock.com on Railway) saw zero satellites resolved. Self-hosted installs were unaffected because their home / LAN IPs reach CelesTrak fine. This hotfix restores both fallbacks with a TLE→OMM converter so the new resolver structure stays intact.',
+    features: [
+      {
+        icon: '🛰️',
+        title: 'HOTFIX: Restore AMSAT + SatNOGS Satellite Fallback Sources',
+        desc: 'The v26.4.0 OMM rewrite consolidated to CelesTrak and Space-Track only, dropping the AMSAT and SatNOGS feeds that v26.3.3 used. When the hosted production server deployed, its Railway egress IPs were silently dropped at the TCP level by CelesTrak (the same intermittent block that has hit cloud hosts before) and with no alternate sources, zero satellites resolved. New server-side TLE-to-OMM converter (server/utils/tle-to-omm.js) lets the new OMM resolver consume the AMSAT nasabare.txt bulk feed plus per-NORAD SatNOGS DB lookups, wired in as state-machine fallback stages that activate when CelesTrak times out or is unreachable. AMSAT covers the 23 amateur sats; SatNOGS picks up the remaining 17 (weather plus active). Self-hosted installs benefit too — the resolver now has three independent upstreams instead of one.',
+      },
+    ],
+  },
+  {
     version: '26.4.0',
     date: '2026-06-02',
     heading:

--- a/src/components/WhatsNew.jsx
+++ b/src/components/WhatsNew.jsx
@@ -32,20 +32,7 @@ const CHANGELOG = [
     version: '26.4.1',
     date: '2026-06-02',
     heading:
-      'Same-day hotfix for v26.4.0. The new OMM satellite resolver from the June release dropped the AMSAT and SatNOGS fallback sources that v26.3.3 had, which meant any deployment whose egress IPs could not reach CelesTrak (notably the hosted openhamclock.com on Railway) saw zero satellites resolved. Self-hosted installs were unaffected because their home / LAN IPs reach CelesTrak fine. This hotfix restores both fallbacks with a TLE→OMM converter so the new resolver structure stays intact.',
-    features: [
-      {
-        icon: '🛰️',
-        title: 'HOTFIX: Restore AMSAT + SatNOGS Satellite Fallback Sources',
-        desc: 'The v26.4.0 OMM rewrite consolidated to CelesTrak and Space-Track only, dropping the AMSAT and SatNOGS feeds that v26.3.3 used. When the hosted production server deployed, its Railway egress IPs were silently dropped at the TCP level by CelesTrak (the same intermittent block that has hit cloud hosts before) and with no alternate sources, zero satellites resolved. New server-side TLE-to-OMM converter (server/utils/tle-to-omm.js) lets the new OMM resolver consume the AMSAT nasabare.txt bulk feed plus per-NORAD SatNOGS DB lookups, wired in as state-machine fallback stages that activate when CelesTrak times out or is unreachable. AMSAT covers the 23 amateur sats; SatNOGS picks up the remaining 17 (weather plus active). Self-hosted installs benefit too — the resolver now has three independent upstreams instead of one.',
-      },
-    ],
-  },
-  {
-    version: '26.4.0',
-    date: '2026-06-02',
-    heading:
-      'June monthly drop, and a big one. Headline additions: a live aircraft tracking layer powered by adsb.lol, a worldwide ATC sector overlay with around 1,000 FIRs, accurate DX-target local time using real IANA timezones (with a graceful solar-time fallback when offline), and a non-map text-list panel for screen-reader and low-vision users covering DX, satellites, and POTA/SOTA/WWFF/WWBOTA activations. The long-running VOACAP propagation accuracy issue — the "vertical line through China/Russia" that several users reported — is finally fixed at the root: the antimeridian patch in the midpoint code was making adjacent cells disagree by 178° of midLon, replaced now with a proper great-circle midpoint. On the reliability side: SmartSDR PTT/MOX is detected for the first time, the Cloud Relay auth retry storm is contained, the DX Cluster proxy stays connected through quiet bands, and satellite math only runs for the birds you actually have selected. Plus a substantial accessibility push — every tab strip now follows the W3C tablist pattern with arrow-key navigation, spot lists are announced as tables, status changes go through aria-live regions, and there\'s a non-map alternative view of the map data.',
+      'June monthly drop, and a big one — plus a same-day hotfix at the bottom. Headline additions: a live aircraft tracking layer powered by adsb.lol, a worldwide ATC sector overlay with around 1,000 FIRs, accurate DX-target local time using real IANA timezones (with a graceful solar-time fallback when offline), and a non-map text-list panel for screen-reader and low-vision users covering DX, satellites, and POTA/SOTA/WWFF/WWBOTA activations. The long-running VOACAP propagation accuracy issue — the "vertical line through China/Russia" that several users reported — is finally fixed at the root: the antimeridian patch in the midpoint code was making adjacent cells disagree by 178° of midLon, replaced now with a proper great-circle midpoint. On the reliability side: SmartSDR PTT/MOX is detected for the first time, the Cloud Relay auth retry storm is contained, the DX Cluster proxy stays connected through quiet bands, and satellite math only runs for the birds you actually have selected. Plus a substantial accessibility push — every tab strip now follows the W3C tablist pattern with arrow-key navigation, spot lists are announced as tables, status changes go through aria-live regions, and there\'s a non-map alternative view of the map data. The same-day v26.4.1 hotfix restored the AMSAT and SatNOGS satellite fallback sources that v26.4.0 inadvertently dropped — see the last item below.',
     features: [
       {
         icon: '✈️',
@@ -116,6 +103,11 @@ const CHANGELOG = [
         icon: '🐳',
         title: 'Docker / GHCR + Security Bumps',
         desc: 'Docker workflows split into three per-image workflows (openhamclock, dxspider-proxy, iturhfprop-service) so the two microservices now publish their own GHCR images — users no longer have to clone-and-build the helpers, they can pull ghcr.io/accius/openhamclock/dxspider-proxy and /iturhfprop-service directly. Container docs centralized in docs/DOCKER.md with the new pull URLs. Thanks Laura (lbatalha). Dependabot security alerts cleaned up in the same window: axios 1.15→1.16 (prototype pollution / MITM / proxy bypass), ws 8.19→8.21 (uninitialized memory disclosure), express 4.22.1→4.22.2 + qs + body-parser (DoS via null entries in comma-format arrays), and tmp 0.2.5→0.2.7 (path traversal in dev tooling).',
+      },
+      {
+        icon: '🛰️',
+        title: 'v26.4.1 HOTFIX: Restore AMSAT + SatNOGS Satellite Fallback Sources',
+        desc: 'The v26.4.0 OMM rewrite consolidated to CelesTrak and Space-Track only, dropping the AMSAT and SatNOGS feeds that v26.3.3 used. When the hosted production server deployed on 2026-06-02, its Railway egress IPs were silently dropped at the TCP level by CelesTrak (the same intermittent block that has hit cloud hosts before) and with no alternate sources, zero satellites resolved for hosted users. Self-hosted installs were unaffected because their home or LAN IPs reach CelesTrak fine. The v26.4.1 hotfix ships a new server-side TLE-to-OMM converter (server/utils/tle-to-omm.js) that lets the OMM resolver consume the AMSAT nasabare.txt bulk feed plus per-NORAD SatNOGS DB lookups, wired in as state-machine fallback stages that activate when CelesTrak times out or is unreachable. AMSAT covers the 23 amateur sats; SatNOGS picks up the remaining 17 (weather plus active). Self-hosted installs benefit too — the resolver now has three independent upstreams instead of one.',
       },
     ],
   },

--- a/src/utils/ariaTabKeyDown 2.js
+++ b/src/utils/ariaTabKeyDown 2.js
@@ -1,0 +1,23 @@
+/**
+ * Standard ARIA tablist keyboard handler (W3C APG Tabs pattern).
+ * Pass to onKeyDown on the role="tablist" container.
+ *
+ * @param {KeyboardEvent} e
+ * @param {string[]} tabs - ordered list of tab ids
+ * @param {string} activeTab
+ * @param {(id: string) => void} setActiveTab
+ * @param {React.RefObject<Record<string, HTMLElement>>} tabRefs - map of id → button element
+ */
+export function ariaTabKeyDown(e, tabs, activeTab, setActiveTab, tabRefs) {
+  let next = null;
+  const idx = tabs.indexOf(activeTab);
+  if (e.key === 'ArrowRight') next = tabs[(idx + 1) % tabs.length];
+  else if (e.key === 'ArrowLeft') next = tabs[(idx - 1 + tabs.length) % tabs.length];
+  else if (e.key === 'Home') next = tabs[0];
+  else if (e.key === 'End') next = tabs[tabs.length - 1];
+  if (next) {
+    e.preventDefault();
+    setActiveTab(next);
+    tabRefs.current?.[next]?.focus();
+  }
+}


### PR DESCRIPTION
Same-day hotfix for v26.4.0. Verified working on Staging.

## The bug

v26.4.0's OMM rewrite (#1007) consolidated the satellite resolver to CelesTrak + Space-Track only, dropping the AMSAT and SatNOGS fallback feeds that v26.3.3 had. When the hosted production server deployed today, its Railway egress IPs were silently dropped at the TCP level by CelesTrak (20-second connection-level timeouts, not HTTP 403/429 — confirmed by reading the Railway logs), and with no alternate sources, zero of 40 satellites resolved. Self-hosted installs were unaffected because their home/LAN IPs reach CelesTrak fine.

## The fix

- **New helper** `server/utils/tle-to-omm.js` — pure-function TLE→OMM JSON converter (no external deps), verified end-to-end with satellite.js's `json2satrec`
- **Two new fetch sources** in `satellites.js`:
  - `fetchOmmFromAmsat()` — single GET to `nasabare.txt`, returns parsed OMM array
  - `fetchOmmFromSatnogsIndividual(noradId)` — per-NORAD JSON lookup
- **Four new state-machine states** — `AMSAT_INIT/FETCH` and `SATNOGS_INDIVIDUAL_INIT/FETCH`, with 1-hour backoffs
- `CELESTRAK_INDIVIDUAL_INIT` now flows to `AMSAT_INIT` (instead of straight back to `START`) when its work is done
- **Bonus**: 4 satellites with `data_source: celestrak_active` that the v26.4.0 resolver had no group fetch path for now get filled via SatNOGS individual fetches

## Verified on Staging

`stagingbranch26.openhamclock.com` is now serving real data:
- 35 of 40 satellites resolved (AMSAT covered the 23 amateur sats in the first cycle; SatNOGS has filled 12 of the 17 weather/active stragglers and is still working through the rest)
- ISS, AO-91, AO-123, FO-29, GOES_16/18, METOP, ELEKTRO satellites all visible
- 5 still missing (SO-125, EWS-G2, ELEKTRO-L4, GK-2A, HIMAWARI-9) — likely SatNOGS doesn't carry these, harmless

## Also included from Staging since v26.4.0

- PR #1053 (lbatalha) — iturhfprop GHCR workflow `ctx` fix
- Container workflow timeout failsafes + context fix (Chris's direct pushes)

## Version

- `package.json` / lockfile: 26.4.0 → **26.4.1** (Z-bump: backend-only)
- WhatsNew: v26.4.0 entry subsumed into v26.4.1 with the hotfix appended as the last feature, so users coming from v26.3.3 see one combined June release entry

## Test plan

- [x] All 467 unit tests pass on Staging
- [x] Build clean (vite)
- [x] AMSAT TLE→OMM round-trip verified locally with satellite.js
- [x] Staging deploy verified: resolver completes, /api/satellites/data serves real payload
- [ ] After merge: Railway redeploys prod, watch `/api/satellites/data/timestamp` go non-zero on openhamclock.com
- [ ] CF cache purge needed post-deploy (Custom Purge wasn't enough on staging — required Purge Everything; worth investigating the cache rule later)

K0CJH