### PR TITLE
fix(contests): replace dead fwcont.php fallback URL

### DIFF
--- a/server/routes/contests.js
+++ b/server/routes/contests.js
@@ -395,6 +395,7 @@ module.exports = function (app, ctx) {
         end: endTime.toISOString(),
         mode: contest.mode,
         status: now >= next && now <= endTime ? 'active' : 'upcoming',
+        url: `https://www.contestcalendar.com/weeklycont.php`,
       });
     });
 
@@ -424,6 +425,7 @@ module.exports = function (app, ctx) {
             end: endDate.toISOString(),
             mode: contest.mode,
             status: status,
+            url: `https://www.contestcalendar.com/alphabetical.php`,
           });
           break; // Only add next occurrence
         }

--- a/src/components/ContestPanel.jsx
+++ b/src/components/ContestPanel.jsx
@@ -28,8 +28,8 @@ export const ContestPanel = ({ data, loading }) => {
   // Build WA7BNM URL: use RSS link if available, otherwise link to calendar
   const getContestUrl = (contest) => {
     if (contest.url) return contest.url;
-    // Fallback: link to WA7BNM current contest listing
-    return 'https://www.contestcalendar.com/fwcont.php';
+    // Fallback: link to WA7BNM 8-day contest listing
+    return 'https://www.contestcalendar.com/weeklycont.php';
   };
 
   const handleContestClick = (contest, e) => {


### PR DESCRIPTION
## Summary

- Replace `fwcont.php` (returns 404) with `weeklycont.php` (8-day calendar, works) as the fallback URL in `ContestPanel.jsx`
- Add a `url` field to both weekly and major contest objects in `calculateUpcomingContests()` so clicking calculated fallback contests also opens a working page

## Test plan

- [ ] Click a contest title with links enabled — should open the WA7BNM contest detail page
- [ ] Simulate RSS failure (or use calculated contests) — clicking any title should open `weeklycont.php` instead of 404ing
- [ ] Verify the link toggle (🔗) still enables/disables clicks correctly

Fixes #1057

🤖 Generated with [Claude Code](https://claude.com/claude-code)