### PR TITLE
[fix] error __satWinToggleMinimize remove unnecessary onclick

### DIFF
--- a/src/plugins/layers/useSatelliteLayer.js
+++ b/src/plugins/layers/useSatelliteLayer.js
@@ -212,7 +212,7 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
         <span data-drag-handle="true" style="font-family:var(--font-mono); font-size:13px; font-weight:700; color:var(--accent-blue); letter-spacing:0.05em;">
           🛰 ${!winMinimized ? `${activeSats.length} ${activeSats.length !== 1 ? t('station.settings.satellites.name_plural') : t('station.settings.satellites.name')}` : ''}
         </span>
-        <button class="sat-data-window-minimize" onclick="window.__satWinToggleMinimize()" title="${winMinimized ? 'Expand' : 'Minimize'}" aria-label="${winMinimized ? 'Expand' : 'Minimize'}" aria-pressed="${winMinimized}" style="background:none; border:none; color:var(--text-secondary); cursor:pointer; font-size:10px; line-height:1; padding:2px 4px; margin:0;">
+        <button class="sat-data-window-minimize" title="${winMinimized ? 'Expand' : 'Minimize'}" aria-label="${winMinimized ? 'Expand' : 'Minimize'}" aria-pressed="${winMinimized}" style="background:none; border:none; color:var(--text-secondary); cursor:pointer; font-size:10px; line-height:1; padding:2px 4px; margin:0;">
           ${winMinimized ? '▶' : '▼'}
         </button>
       </div>`;


### PR DESCRIPTION
## What does this PR do?

- message = `?log=debug:1 Uncaught TypeError: window.__satWinToggleMinimize is not a function
    at HTMLButtonElement.onclick (?log=debug:1:8)`
- remove unnecessary onclick

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test
1.
2.
3.

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)
