### PR TITLE
fix(a11y): announce rig connect/disconnect and mode changes via aria-live (#1000)

### DIFF
--- a/src/contexts/RigContext.jsx
+++ b/src/contexts/RigContext.jsx
@@ -542,6 +542,41 @@ export const RigProvider = ({ children, rigConfig }) => {
     [rigState.mode, rigConfig, setFreq, setMode],
   );
 
+  // ── Accessibility: aria-live announcements for status changes (#1000) ───────
+  // Two separate regions: assertive for urgent (connect/disconnect), polite for
+  // informational (mode/band changes). Clearing after 1 s allows the same
+  // message to re-trigger if the state bounces (e.g. reconnect after brief drop).
+  const [connectionAnnouncement, setConnectionAnnouncement] = useState('');
+  const [modeAnnouncement, setModeAnnouncement] = useState('');
+  const prevConnected = useRef(null); // null = initial mount, skip first announcement
+  const prevMode = useRef('');
+
+  useEffect(() => {
+    if (prevConnected.current === null) {
+      prevConnected.current = rigState.connected;
+      return;
+    }
+    if (prevConnected.current === rigState.connected) return;
+    prevConnected.current = rigState.connected;
+    const label = isCloudRelay ? 'Cloud relay' : 'Rig';
+    setConnectionAnnouncement(rigState.connected ? `${label} connected` : `${label} disconnected`);
+    const t = setTimeout(() => setConnectionAnnouncement(''), 1000);
+    return () => clearTimeout(t);
+  }, [rigState.connected, isCloudRelay]);
+
+  useEffect(() => {
+    if (!prevMode.current || prevMode.current === rigState.mode) {
+      prevMode.current = rigState.mode;
+      return;
+    }
+    prevMode.current = rigState.mode;
+    if (rigState.mode) {
+      setModeAnnouncement(`Mode changed to ${rigState.mode}`);
+      const t = setTimeout(() => setModeAnnouncement(''), 1000);
+      return () => clearTimeout(t);
+    }
+  }, [rigState.mode]);
+
   const value = {
     ...rigState,
     enabled: rigConfig?.enabled,
@@ -558,5 +593,17 @@ export const RigProvider = ({ children, rigConfig }) => {
     tuneTo,
   };
 
-  return <RigContext.Provider value={value}>{children}</RigContext.Provider>;
+  return (
+    <RigContext.Provider value={value}>
+      {children}
+      {/* Assertive: rig/relay connect-disconnect is urgent — announced immediately */}
+      <div className="visually-hidden" aria-live="assertive" aria-atomic="true" data-testid="rig-connection-announcer">
+        {connectionAnnouncement}
+      </div>
+      {/* Polite: mode/band changes are informational — wait for current speech to finish */}
+      <div className="visually-hidden" aria-live="polite" aria-atomic="true" data-testid="rig-mode-announcer">
+        {modeAnnouncement}
+      </div>
+    </RigContext.Provider>
+  );
 };


### PR DESCRIPTION
## Summary

Adds two visually-hidden `aria-live` regions to `RigProvider`, covering the rig/relay connection and mode change events raised in #1000.

- **`aria-live=\"assertive\"`** — rig connect/disconnect (both local and cloud relay modes). Disconnect mid-QSO is urgent and should interrupt whatever the screen reader is currently speaking.
- **`aria-live=\"polite\"`** — mode/band changes. Informational, waits for current speech to finish.

Both regions clear after 1 s so the same message can re-trigger if the state bounces (e.g. reconnect after a brief drop).

Initial mount is skipped via a `null`-initialised ref so there is no spurious "disconnected" announcement when the page loads.

The existing `.visually-hidden` class from `main.css` is reused — no new CSS required.

## What this does NOT cover yet

- Satellite pass start/end
- Lightning proximity alerts
- Weather alerts (WeatherPanel already has `role="alert"` on individual cards; a live-region wrapper for new-alert arrivals is a follow-on)

Those require understanding the hooks that supply satellite/lightning data — scoping that now; will follow up in a separate PR or an additional commit on this branch if reviewers prefer.

## Test plan

- [ ] Connect a screen reader (NVDA/JAWS on Windows; VoiceOver on Mac/iOS)
- [ ] Connect/disconnect rig-bridge — screen reader should announce "Rig connected" / "Rig disconnected" immediately
- [ ] Enable cloud relay, connect/disconnect — should announce "Cloud relay connected" / "Cloud relay disconnected"
- [ ] Change mode (e.g. USB → CW) — screen reader should announce "Mode changed to CW" after current speech
- [ ] Confirm no announcement fires on initial page load

**Note:** I don't have a screen reader setup to test cadence (too chatty vs. too quiet) — feedback from screen reader users on the announcement wording would be very welcome.

Closes part of #1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)