### PR TITLE
fix: restore title= hover tooltips on icon-only buttons (#1051 follow-up)

### DIFF
--- a/src/components/CallsignLink.jsx
+++ b/src/components/CallsignLink.jsx
@@ -118,6 +118,7 @@ export default function CallsignLink({
         rel="noopener noreferrer"
         onClick={(e) => e.stopPropagation()}
         aria-label={`Look up ${call} in callbook (opens in new tab)`}
+        title={`Look up ${call} in callbook`}
         style={{
           color,
           fontWeight,

--- a/src/components/DonateButton.jsx
+++ b/src/components/DonateButton.jsx
@@ -29,6 +29,7 @@ export default function DonateButton({ compact = false, fontSize = '12px', paddi
         type="button"
         onClick={() => setOpen(true)}
         aria-label="Support OpenHamClock"
+        title="Support OpenHamClock"
         tabIndex={tabIndex}
         style={{
           background: 'linear-gradient(135deg, #ff813f 0%, #ffdd00 100%)',
@@ -91,6 +92,7 @@ export default function DonateButton({ compact = false, fontSize = '12px', paddi
                 type="button"
                 onClick={close}
                 aria-label="Close support dialog"
+                title="Close"
                 style={{
                   background: 'none',
                   border: 'none',

--- a/src/components/KeybindingsPanel.jsx
+++ b/src/components/KeybindingsPanel.jsx
@@ -228,6 +228,7 @@ export const KeybindingsPanel = ({ isOpen, onClose, keybindings, nodeId }) => {
             type="button"
             onClick={onClose}
             aria-label="Close keyboard shortcuts"
+            title="Close"
             style={{
               background: 'none',
               border: 'none',

--- a/src/components/RigControlPanel.jsx
+++ b/src/components/RigControlPanel.jsx
@@ -41,7 +41,7 @@ const RigControlPanel = () => {
           <span className="icon">📻</span> {t('app.rigControl.title')}
         </h3>
         <div className="panel-controls">
-          <span className={`status-led ${statusColor}`} role="status" aria-label={statusTitle} />
+          <span className={`status-led ${statusColor}`} role="status" aria-label={statusTitle} title={statusTitle} />
         </div>
       </div>
 

--- a/src/components/SidebarMenu.jsx
+++ b/src/components/SidebarMenu.jsx
@@ -203,6 +203,7 @@ export default function SidebarMenu({
             type="button"
             onClick={cycleMode}
             aria-label={modeTitle}
+            title={modeTitle}
             aria-pressed={mode === MODE_PINNED}
             tabIndex={isVisible ? 0 : -1}
             style={{
@@ -228,6 +229,7 @@ export default function SidebarMenu({
               type="button"
               onClick={() => onSettingsClick(item.id)}
               aria-label={item.label}
+              title={item.label}
               tabIndex={isVisible ? 0 : -1}
               style={{
                 display: 'flex',
@@ -274,6 +276,7 @@ export default function SidebarMenu({
               type="button"
               onClick={onToggleLayoutLock}
               aria-label={layoutLocked ? 'Unlock layout — allow drag, resize, close' : 'Lock layout — prevent changes'}
+              title={layoutLocked ? 'Unlock layout — allow drag, resize, close' : 'Lock layout — prevent changes'}
               aria-pressed={layoutLocked}
               tabIndex={isVisible ? 0 : -1}
               style={{
@@ -295,6 +298,7 @@ export default function SidebarMenu({
               onClick={onResetLayout}
               disabled={layoutLocked}
               aria-label={layoutLocked ? 'Unlock layout to reset' : 'Reset panel layout to default'}
+              title={layoutLocked ? 'Unlock layout to reset' : 'Reset panel layout to default'}
               tabIndex={isVisible ? 0 : -1}
               style={{
                 ...actionBtnStyle(false),
@@ -338,6 +342,7 @@ export default function SidebarMenu({
               onClick={onUpdateClick}
               disabled={updateInProgress}
               aria-label={updateInProgress ? 'Update in progress' : 'Run update now'}
+              title={updateInProgress ? 'Update in progress...' : 'Run update now'}
               tabIndex={isVisible ? 0 : -1}
               style={{
                 ...actionBtnStyle(updateInProgress),
@@ -356,6 +361,7 @@ export default function SidebarMenu({
             type="button"
             onClick={onFullscreenToggle}
             aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+            title={isFullscreen ? 'Exit Fullscreen' : 'Enter Fullscreen'}
             tabIndex={isVisible ? 0 : -1}
             style={actionBtnStyle(isFullscreen)}
           >
@@ -373,6 +379,7 @@ export default function SidebarMenu({
             type="button"
             onClick={() => onSettingsClick()}
             aria-label="Open Settings"
+            title="Open Settings"
             tabIndex={isVisible ? 0 : -1}
             style={actionBtnStyle(false)}
           >

--- a/src/components/ThemeSelector.jsx
+++ b/src/components/ThemeSelector.jsx
@@ -18,6 +18,7 @@ export default function ThemeSelector({ id, theme, setTheme }) {
             onClick={() => setTheme(key)}
             aria-pressed={theme === key}
             aria-label={`${t.label} theme`}
+            title={`${t.label} theme`}
           >
             <span aria-hidden="true" className="icon">
               {t.icon}


### PR DESCRIPTION
## Summary

Follow-up to #1051 (WCAG 2.1 AA accessibility pass). As @accius noted in the review, the PR added `aria-label` to all icon-only interactive elements but removed the pre-existing `title=` attributes in the process. `aria-label` is sufficient for AT users, but sighted mouse users rely on the hover tooltip to discover what icon-only controls do — especially first-time users who don't know what each icon means.

The `DXClusterPanel` map toggle was already correct (kept both `title=` and `aria-label=`). This PR brings everything else in line with that pattern.

**Files changed (6):**

| File | Buttons fixed |
|------|--------------|
| `CallsignLink.jsx` | Callbook lookup `<a>` |
| `DonateButton.jsx` | Support trigger + modal close |
| `KeybindingsPanel.jsx` | Modal close |
| `RigControlPanel.jsx` | Status LED |
| `SidebarMenu.jsx` | Mode toggle, 9 nav items, layout lock, reset layout, update, fullscreen, settings |
| `ThemeSelector.jsx` | All theme selector buttons |

Every `title=` added matches the corresponding `aria-label` (or the original tooltip text where they differ slightly). No visual changes; build passes `vite build ✓`.

## Test plan

- [ ] Hover over each sidebar icon-only button — verify tooltip appears
- [ ] Hover over the status LED in RigControl — verify connection state tooltip
- [ ] Hover over a callsign link — verify "Look up {call} in callbook" tooltip
- [ ] Hover over the Support button and its modal close — verify tooltips
- [ ] Hover over the Keybindings modal close — verify "Close" tooltip
- [ ] Hover over each ThemeSelector button — verify "{Theme} theme" tooltip
- [ ] Confirm DXClusterPanel map toggle still has tooltip (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)