### PR TITLE
fix(stats): resolve real client IP via CF-Connecting-IP behind Cloudflare (prod hotfix)

### DIFF
--- a/server/middleware/index.js
+++ b/server/middleware/index.js
@@ -7,7 +7,7 @@ const compression = require('compression');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 const express = require('express');
-const { formatBytes } = require('../utils/helpers');
+const { formatBytes, getClientIP } = require('../utils/helpers');
 
 /**
  * Apply all middleware to the Express app.
@@ -84,6 +84,7 @@ function applyMiddleware(app, ctx) {
     standardHeaders: true,
     legacyHeaders: false,
     message: { error: 'Too many requests, please try again later' },
+    keyGenerator: getClientIP,
   });
   app.use('/api/', apiLimiter);
 
@@ -94,6 +95,7 @@ function applyMiddleware(app, ctx) {
     standardHeaders: true,
     legacyHeaders: false,
     message: { error: 'Too many requests' },
+    keyGenerator: getClientIP,
   });
 
   // Body parser

--- a/server/routes/presence.js
+++ b/server/routes/presence.js
@@ -4,6 +4,8 @@
  * their callsign and grid square. Other users see them on the map.
  */
 
+const { getClientIP } = require('../utils/helpers');
+
 module.exports = function (app, ctx) {
   const { logDebug, logInfo } = ctx;
 
@@ -38,7 +40,7 @@ module.exports = function (app, ctx) {
 
     // POST remote address, lockout if repeat activity within remoteAddress_lockout_period
     const remoteAddress_lockout_period = 1 * 60 * 1000; // 1 minute
-    const remoteAddress = req.ip || {};
+    const remoteAddress = getClientIP(req);
     let remoteAddressLockout = remoteAddresses.has(remoteAddress)
       ? Date.now() < remoteAddresses.get(remoteAddress).createTime + remoteAddress_lockout_period
       : false;

--- a/server/routes/pskreporter.js
+++ b/server/routes/pskreporter.js
@@ -5,6 +5,7 @@
 
 const mqttLib = require('mqtt');
 const { maidenheadToLatLon, getBandFromHz } = require('../utils/grid');
+const { getClientIP } = require('../utils/helpers');
 
 module.exports = function (app, ctx) {
   const {
@@ -611,9 +612,7 @@ module.exports = function (app, ctx) {
   const sseConnectionsByIP = new Map();
 
   app.get('/api/pskreporter/stream/:identifier', (req, res) => {
-    // Use req.ip which respects the trust proxy setting, consistent with express-rate-limit.
-    // Manual x-forwarded-for parsing is trivially spoofable on installs without a reverse proxy.
-    const ip = req.ip || req.connection?.remoteAddress || 'unknown';
+    const ip = getClientIP(req);
     const current = sseConnectionsByIP.get(ip) || 0;
     if (current >= MAX_SSE_PER_IP) {
       return res.status(429).json({ error: 'Too many open SSE connections from this IP' });

--- a/server/routes/rig-bridge.js
+++ b/server/routes/rig-bridge.js
@@ -13,6 +13,7 @@
 const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
+const { getClientIP } = require('../utils/helpers');
 const crypto = require('crypto');
 const { validateCustomHost } = require('../utils/ssrf');
 
@@ -535,7 +536,7 @@ module.exports = function (app, ctx) {
         return res.json({ commands: [] });
       }
 
-      const clientIP = req.ip || req.socket?.remoteAddress || 'unknown';
+      const clientIP = getClientIP(req);
       const ipCount = relayPollCountByIP.get(clientIP) ?? 0;
       if (ipCount >= MAX_LONG_POLL_PER_IP) {
         return res.status(429).json({ error: 'Too many concurrent long-polls from this IP' });

--- a/server/services/visitor-stats.js
+++ b/server/services/visitor-stats.js
@@ -6,7 +6,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { formatDuration } = require('../utils/helpers');
+const { formatDuration, getClientIP } = require('../utils/helpers');
 
 /**
  * Initialize and return the visitor stats service.
@@ -364,7 +364,7 @@ function createVisitorStatsService(ctx) {
   function visitorMiddleware(req, res, next) {
     rolloverVisitorStats();
 
-    const rawIp = req.ip || req.connection?.remoteAddress || 'unknown';
+    const rawIp = getClientIP(req);
     const isTrackable = req.path !== '/api/health' && !req.path.startsWith('/assets/');
 
     if (isTrackable) {

--- a/server/utils/helpers.js
+++ b/server/utils/helpers.js
@@ -16,4 +16,15 @@ function formatDuration(ms) {
   return `${Math.floor(ms / 3600000)}h ${Math.floor((ms % 3600000) / 60000)}m`;
 }
 
-module.exports = { formatBytes, formatDuration };
+// Cloudflare strips client-supplied CF-Ray / CF-Connecting-IP at its edge, so
+// the presence of CF-Ray is a reliable signal the request actually transited
+// CF. Without that guard, anyone hitting the Railway origin URL directly could
+// forge CF-Connecting-IP and bypass per-IP rate limits and lockouts.
+function getClientIP(req) {
+  if (req.headers['cf-ray'] && req.headers['cf-connecting-ip']) {
+    return req.headers['cf-connecting-ip'];
+  }
+  return req.ip || req.socket?.remoteAddress || req.connection?.remoteAddress || 'unknown';
+}
+
+module.exports = { formatBytes, formatDuration, getClientIP };


### PR DESCRIPTION
## Summary

Cherry-pick of `dd21b78` from Staging onto main, ahead of the next bundled release, so prod metrics start reflecting actual users.

`req.ip` was resolving to the Cloudflare colo IP because trust proxy = 1 only peeled one of the CF → Railway → app hops. That collapsed every real user into ~20 hashed buckets, so `/api/health` reported `sessions.concurrent` ~20 regardless of real load, unique-visitor stats were wildly under-counted, and per-IP rate limits + presence lockout + PSK SSE cap + rig-bridge long-poll cap all keyed on the colo IP instead of the user.

New `getClientIP()` helper in `server/utils/helpers.js` prefers `CF-Connecting-IP` when `CF-Ray` is also present (CF strips both at its edge, so requiring CF-Ray prevents spoofing through the direct Railway origin URL), falls back to `req.ip` otherwise. Wired into the visitor-stats session tracker, both `express-rate-limit` instances (`keyGenerator`), the presence per-IP lockout, the PSK SSE per-IP cap, and the rig-bridge cloud-relay long-poll cap.

## Why now

Want to see the real concurrent-user count on prod before the next bundled release ships. Self-hosters are unaffected (no CF in front → falls through to `req.ip`, same behavior as today).

## Conflict resolution

One hunk in `server/middleware/index.js` conflicted because Staging also has the rate-limit-skip for `/api/health` (commit `d93bbcf`, separate fix for the watchtower probe). I left that out of this cherry-pick on purpose, since the watchtower probe still points at Staging per the existing plan. Only the `keyGenerator: getClientIP` line is carried over from that hunk.

## Test plan

- [ ] After deploy, hit `https://openhamclock.com/api/health?key=<API_WRITE_KEY>&format=json`
- [ ] Confirm `sessions.concurrent` is meaningfully larger than ~20
- [ ] Confirm `visitors.today.uniqueVisitors` starts climbing at a realistic rate
- [ ] Spot-check that legitimate users aren't being 429'd (per-IP rate limits now key on real IPs, which is the intended behavior)