### PR TITLE
feat(a11y): announce satellite rise/set events via aria-live (#997)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,6 +54,7 @@ import useLocalInstall from './hooks/app/useLocalInstall';
 import useVersionCheck from './hooks/app/useVersionCheck';
 import usePresence from './hooks/app/usePresence';
 import useAudioAlerts from './hooks/app/useAudioAlerts';
+import { useSatelliteAnnouncements } from './hooks/app/useSatelliteAnnouncements';
 import WhatsNew from './components/WhatsNew.jsx';
 import { initCtyLookup } from './utils/ctyLookup.js';
 import { getAllLayers } from './plugins/layerRegistry.js';
@@ -326,6 +327,7 @@ const App = () => {
   const filterState = useSatelliteFilterState();
   const { satelliteFilters, setSatelliteFilters } = filterState;
   const satellites = useSatellites(config.location, config.satellite, satelliteFilters);
+  const { riseAnnouncement, setAnnouncement: satelliteSetAnnouncement } = useSatelliteAnnouncements(satellites.data);
   const localWeather = useWeather(config.location, config.allUnits);
   const dxWeather = useWeather(dxLocation, config.allUnits);
   const localAlerts = useWeatherAlerts(config.location);
@@ -804,6 +806,14 @@ const App = () => {
         onClose={() => setShowWwbotaFilters(false)}
       />
       <WhatsNew showWhatsNew={config.showWhatsNew} />
+      {/* Assertive: satellite rising above horizon is time-critical for a ham operator */}
+      <div className="visually-hidden" aria-live="assertive" aria-atomic="true" data-testid="satellite-rise-announcer">
+        {riseAnnouncement}
+      </div>
+      {/* Polite: satellite setting is informational */}
+      <div className="visually-hidden" aria-live="polite" aria-atomic="true" data-testid="satellite-set-announcer">
+        {satelliteSetAnnouncement}
+      </div>
     </main>
   );
 };

--- a/src/hooks/app/useSatelliteAnnouncements.js
+++ b/src/hooks/app/useSatelliteAnnouncements.js
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Announces satellite rise and set events via aria-live regions (#997).
+ * Follows the same pattern as the rig-status announcements in RigContext.
+ *
+ * Rise (assertive): satellite newly above the user's minimum elevation.
+ * Set  (polite):    satellite that was visible has dropped below minimum elevation.
+ */
+export function useSatelliteAnnouncements(satellites) {
+  const [riseAnnouncement, setRiseAnnouncement] = useState('');
+  const [setAnnouncement, setSetAnnouncement] = useState('');
+  // null on first render so we establish a baseline without announcing
+  const prevVisibleRef = useRef(null);
+
+  useEffect(() => {
+    if (!satellites || satellites.length === 0) return;
+
+    const nowVisible = new Set(satellites.filter((s) => s.isVisible).map((s) => s.name));
+
+    if (prevVisibleRef.current === null) {
+      prevVisibleRef.current = nowVisible;
+      return;
+    }
+
+    const prev = prevVisibleRef.current;
+    const risen = satellites.filter((s) => s.isVisible && !prev.has(s.name));
+    const set = [...prev].filter((name) => !nowVisible.has(name));
+    prevVisibleRef.current = nowVisible;
+
+    const cleanups = [];
+
+    if (risen.length > 0) {
+      const names =
+        risen.length === 1
+          ? risen[0].name
+          : risen
+              .slice(0, -1)
+              .map((s) => s.name)
+              .join(', ') +
+            ' and ' +
+            risen[risen.length - 1].name;
+      setRiseAnnouncement(`${names} now overhead`);
+      const t = setTimeout(() => setRiseAnnouncement(''), 4000);
+      cleanups.push(() => clearTimeout(t));
+    }
+
+    if (set.length > 0) {
+      const names = set.length === 1 ? set[0] : set.slice(0, -1).join(', ') + ' and ' + set[set.length - 1];
+      setSetAnnouncement(`${names} passed below horizon`);
+      const t = setTimeout(() => setSetAnnouncement(''), 4000);
+      cleanups.push(() => clearTimeout(t));
+    }
+
+    if (cleanups.length > 0) return () => cleanups.forEach((fn) => fn());
+  }, [satellites]);
+
+  return { riseAnnouncement, setAnnouncement };
+}

--- a/src/hooks/app/useSatelliteAnnouncements.test.jsx
+++ b/src/hooks/app/useSatelliteAnnouncements.test.jsx
@@ -1,0 +1,148 @@
+/**
+ * useSatelliteAnnouncements — Vitest + React 18
+ *
+ * Verifies aria-live announcement text for satellite rise and set events.
+ * Uses a thin wrapper component rendered with createRoot/act (no @testing-library/react needed).
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import React, { useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { useSatelliteAnnouncements } from './useSatelliteAnnouncements';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function Harness({ satellites }) {
+  const { riseAnnouncement, setAnnouncement } = useSatelliteAnnouncements(satellites);
+  return (
+    <>
+      <div data-testid="rise">{riseAnnouncement}</div>
+      <div data-testid="set">{setAnnouncement}</div>
+    </>
+  );
+}
+
+// Wrapper that lets tests push new satellite arrays via setSats()
+let root;
+let container;
+let setSats;
+
+function ControlledHarness({ initial }) {
+  const [sats, setSatsState] = useState(initial);
+  setSats = setSatsState;
+  const { riseAnnouncement, setAnnouncement } = useSatelliteAnnouncements(sats);
+  return (
+    <>
+      <div data-testid="rise">{riseAnnouncement}</div>
+      <div data-testid="set">{setAnnouncement}</div>
+    </>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.useRealTimers();
+});
+
+const makeSat = (name, isVisible) => ({ name, isVisible, elevation: isVisible ? 15 : -5 });
+
+describe('useSatelliteAnnouncements', () => {
+  it('makes no announcement on first render', () => {
+    act(() => {
+      root.render(<Harness satellites={[makeSat('ISS', true)]} />);
+    });
+    expect(container.querySelector('[data-testid="rise"]').textContent).toBe('');
+    expect(container.querySelector('[data-testid="set"]').textContent).toBe('');
+  });
+
+  it('announces a single rising satellite', () => {
+    act(() => {
+      root.render(<ControlledHarness initial={[makeSat('ISS', false)]} />);
+    });
+    act(() => {
+      setSats([makeSat('ISS', true)]);
+    });
+    expect(container.querySelector('[data-testid="rise"]').textContent).toBe('ISS now overhead');
+    expect(container.querySelector('[data-testid="set"]').textContent).toBe('');
+  });
+
+  it('announces a single setting satellite', () => {
+    act(() => {
+      root.render(<ControlledHarness initial={[makeSat('ISS', true)]} />);
+    });
+    act(() => {
+      setSats([makeSat('ISS', false)]);
+    });
+    expect(container.querySelector('[data-testid="rise"]').textContent).toBe('');
+    expect(container.querySelector('[data-testid="set"]').textContent).toBe('ISS passed below horizon');
+  });
+
+  it('lists two rising satellites with "and"', () => {
+    act(() => {
+      root.render(<ControlledHarness initial={[makeSat('ISS', false), makeSat('AO-91', false)]} />);
+    });
+    act(() => {
+      setSats([makeSat('ISS', true), makeSat('AO-91', true)]);
+    });
+    expect(container.querySelector('[data-testid="rise"]').textContent).toBe('ISS and AO-91 now overhead');
+  });
+
+  it('lists three setting satellites with Oxford comma pattern', () => {
+    act(() => {
+      root.render(
+        <ControlledHarness initial={[makeSat('ISS', true), makeSat('AO-91', true), makeSat('FO-29', true)]} />,
+      );
+    });
+    act(() => {
+      setSats([makeSat('ISS', false), makeSat('AO-91', false), makeSat('FO-29', false)]);
+    });
+    expect(container.querySelector('[data-testid="set"]').textContent).toBe(
+      'ISS, AO-91 and FO-29 passed below horizon',
+    );
+  });
+
+  it('clears rise announcement after 4 s', () => {
+    act(() => {
+      root.render(<ControlledHarness initial={[makeSat('ISS', false)]} />);
+    });
+    act(() => {
+      setSats([makeSat('ISS', true)]);
+    });
+    expect(container.querySelector('[data-testid="rise"]').textContent).toBe('ISS now overhead');
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(container.querySelector('[data-testid="rise"]').textContent).toBe('');
+  });
+
+  it('does not announce when satellite stays visible across renders', () => {
+    act(() => {
+      root.render(<ControlledHarness initial={[makeSat('ISS', true)]} />);
+    });
+    act(() => {
+      setSats([makeSat('ISS', true)]);
+    });
+    expect(container.querySelector('[data-testid="rise"]').textContent).toBe('');
+    expect(container.querySelector('[data-testid="set"]').textContent).toBe('');
+  });
+
+  it('handles empty satellite array without crashing', () => {
+    act(() => {
+      root.render(<ControlledHarness initial={[]} />);
+    });
+    act(() => {
+      setSats([]);
+    });
+    expect(container.querySelector('[data-testid="rise"]').textContent).toBe('');
+    expect(container.querySelector('[data-testid="set"]').textContent).toBe('');
+  });
+});


### PR DESCRIPTION
## What this does

Adds `useSatelliteAnnouncements` — a small hook that diffs the visible satellite set on each update cycle and announces transitions via two `aria-live` regions rendered in `App.jsx`.

- **Rise** (assertive): satellite newly above the user's configured minimum elevation → *"ISS now overhead"*
- **Set** (polite): satellite that was visible drops below minimum elevation → *"ISS passed below horizon"*
- Multiple satellites in one tick are joined naturally: *"ISS and AO-91 now overhead"*
- First render establishes a silent baseline (same pattern as `RigContext` rig-status announcements from #1000)
- Announcement text clears after 4 s so the same satellite can re-trigger on its next pass

## Why

Sub-issue of #997 (screen-reader accessibility umbrella). A blind operator using a screen reader can see the satellite list via the Map Data panel (#1002), but gets no prompt when a satellite becomes workable. This gives them a timely, spoken alert.

## Files changed

| File | Change |
|---|---|
| `src/hooks/app/useSatelliteAnnouncements.js` | New hook |
| `src/hooks/app/useSatelliteAnnouncements.test.jsx` | 8 tests — first render no-op, single rise, single set, multi-satellite phrasing, 4 s cleardown, stable-visible no-op, empty array guard |
| `src/App.jsx` | Import + call hook; two `visually-hidden` `aria-live` divs before `</main>` |

## Test plan

- [ ] Run `npm test -- --run src/hooks/app/useSatelliteAnnouncements.test.jsx` — 8 tests pass
- [ ] Enable a satellite layer (e.g. ISS) and wait for a pass — NVDA/VoiceOver should announce the rise and set
- [ ] Confirm no announcement fires on page load (baseline suppression)
- [ ] Confirm existing rig-status aria-live announcements are unaffected