### PR TITLE
feat(a11y): announce lightning proximity alerts via aria-live (#997)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,6 +59,7 @@ import WhatsNew from './components/WhatsNew.jsx';
 import { initCtyLookup } from './utils/ctyLookup.js';
 import { getAllLayers } from './plugins/layerRegistry.js';
 import ActivateFilterManager from './components/ActivateFilterManager.jsx';
+import { useLightningAnnouncements } from './hooks/app/useLightningAnnouncements';
 
 // Load DXCC entity database on app startup (non-blocking)
 initCtyLookup();
@@ -321,6 +322,8 @@ const App = () => {
     dxpeditions: dxpeditions.data?.dxpeditions,
     contests: contests.data,
   });
+
+  const { announcement: lightningAnnouncement } = useLightningAnnouncements();
 
   const propagation = usePropagation(config.location, dxLocation, config.propagation);
   const mySpots = useMySpots(config.callsign);
@@ -813,6 +816,10 @@ const App = () => {
       {/* Polite: satellite setting is informational */}
       <div className="visually-hidden" aria-live="polite" aria-atomic="true" data-testid="satellite-set-announcer">
         {satelliteSetAnnouncement}
+      </div>
+      {/* Assertive: lightning proximity is a safety alert — announce immediately */}
+      <div className="visually-hidden" aria-live="assertive" aria-atomic="true" data-testid="lightning-announcer">
+        {lightningAnnouncement}
       </div>
     </main>
   );

--- a/src/hooks/app/useLightningAnnouncements.js
+++ b/src/hooks/app/useLightningAnnouncements.js
@@ -1,0 +1,44 @@
+import { useState, useEffect, useRef } from 'react';
+
+const THROTTLE_MS = 30000; // announce at most once per 30 seconds
+const CLEARDOWN_MS = 10000; // clear announcement after 10 seconds
+
+function preferredUnits() {
+  try {
+    const config = JSON.parse(localStorage.getItem('openhamclock_config') ?? '{}');
+    return config.units?.dist === 'imperial' ? 'imperial' : 'metric';
+  } catch {
+    return 'metric';
+  }
+}
+
+export function useLightningAnnouncements() {
+  const [announcement, setAnnouncement] = useState('');
+  const lastAnnouncedRef = useRef(0);
+  const clearTimerRef = useRef(null);
+
+  useEffect(() => {
+    function handleProximity(e) {
+      const now = Date.now();
+      if (now - lastAnnouncedRef.current < THROTTLE_MS) return;
+      lastAnnouncedRef.current = now;
+
+      const { distanceKm, distanceMiles, direction } = e.detail;
+      const units = preferredUnits();
+      const distStr = units === 'imperial' ? `${distanceMiles} miles` : `${distanceKm} kilometres`;
+
+      setAnnouncement(`Lightning alert: strike ${distStr} ${direction}`);
+
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+      clearTimerRef.current = setTimeout(() => setAnnouncement(''), CLEARDOWN_MS);
+    }
+
+    document.addEventListener('lightning:proximity', handleProximity);
+    return () => {
+      document.removeEventListener('lightning:proximity', handleProximity);
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    };
+  }, []);
+
+  return { announcement };
+}

--- a/src/hooks/app/useLightningAnnouncements.test.jsx
+++ b/src/hooks/app/useLightningAnnouncements.test.jsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { useLightningAnnouncements } from './useLightningAnnouncements';
+
+// Helper: mount the hook in a real DOM node and read its output via a testid div
+function mountHook() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  let root;
+  function Harness() {
+    const { announcement } = useLightningAnnouncements();
+    return <div data-testid="out">{announcement}</div>;
+  }
+
+  act(() => {
+    root = createRoot(container);
+    root.render(<Harness />);
+  });
+
+  return {
+    getText: () => container.querySelector('[data-testid="out"]')?.textContent ?? '',
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function fireProximity(distanceKm = 8, distanceMiles = 5.0, direction = 'north-west') {
+  act(() => {
+    document.dispatchEvent(
+      new CustomEvent('lightning:proximity', {
+        detail: { distanceKm, distanceMiles, direction },
+      }),
+    );
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  localStorage.clear();
+});
+
+describe('useLightningAnnouncements', () => {
+  it('starts with no announcement', () => {
+    const { getText, unmount } = mountHook();
+    expect(getText()).toBe('');
+    unmount();
+  });
+
+  it('announces closest strike in km by default', () => {
+    const { getText, unmount } = mountHook();
+    fireProximity(12, 7.5, 'south');
+    expect(getText()).toBe('Lightning alert: strike 12 kilometres south');
+    unmount();
+  });
+
+  it('announces in miles when imperial units configured', () => {
+    localStorage.setItem('openhamclock_config', JSON.stringify({ units: { dist: 'imperial' } }));
+    const { getText, unmount } = mountHook();
+    fireProximity(12, 7.5, 'north-east');
+    expect(getText()).toBe('Lightning alert: strike 7.5 miles north-east');
+    unmount();
+  });
+
+  it('clears after 10 seconds', () => {
+    const { getText, unmount } = mountHook();
+    fireProximity(5, 3.1, 'east');
+    expect(getText()).not.toBe('');
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(getText()).toBe('');
+    unmount();
+  });
+
+  it('throttles repeated events within 30 seconds', () => {
+    const { getText, unmount } = mountHook();
+    fireProximity(5, 3.1, 'north');
+    const first = getText();
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    fireProximity(2, 1.2, 'south');
+    expect(getText()).toBe(first); // second event suppressed — still the first text
+    unmount();
+  });
+
+  it('announces again after throttle window expires', () => {
+    const { getText, unmount } = mountHook();
+    fireProximity(5, 3.1, 'north');
+    act(() => {
+      vi.advanceTimersByTime(30000);
+    });
+    fireProximity(3, 1.9, 'west');
+    expect(getText()).toBe('Lightning alert: strike 3 kilometres west');
+    unmount();
+  });
+
+  it('ignores events when lightning plugin is not dispatching (no announcement emitted)', () => {
+    const { getText, unmount } = mountHook();
+    // No event fired
+    expect(getText()).toBe('');
+    unmount();
+  });
+});

--- a/src/plugins/layers/useLightning.js
+++ b/src/plugins/layers/useLightning.js
@@ -60,6 +60,21 @@ function calculateDistance(lat1, lon1, lat2, lon2) {
   return { km: Rkm * c, miles: Rmiles * c };
 }
 
+// Compass bearing from station to strike (0–360°)
+function calculateBearing(lat1, lon1, lat2, lon2) {
+  const φ1 = (lat1 * Math.PI) / 180;
+  const φ2 = (lat2 * Math.PI) / 180;
+  const Δλ = ((lon2 - lon1) * Math.PI) / 180;
+  const y = Math.sin(Δλ) * Math.cos(φ2);
+  const x = Math.cos(φ1) * Math.sin(φ2) - Math.sin(φ1) * Math.cos(φ2) * Math.cos(Δλ);
+  return (Math.atan2(y, x) * (180 / Math.PI) + 360) % 360;
+}
+
+function bearingToCardinal(deg) {
+  const dirs = ['north', 'north-east', 'east', 'south-east', 'south', 'south-west', 'west', 'north-west'];
+  return dirs[Math.round(deg / 45) % 8];
+}
+
 // Strike age colors (fading over time)
 function getStrikeColor(ageMinutes) {
   if (ageMinutes < 1) return '#FFD700'; // Gold (fresh, <1 min)
@@ -623,6 +638,24 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null, lowMemory
         if (lightningConf?.enabled) {
           playTone(lightningConf.tone, alertSettings.volume ?? 0.5);
         }
+
+        // Announce the closest nearby strike for screen-reader users
+        const closest = nearbyNewStrikes.reduce((a, b) => {
+          const da = calculateDistance(stationLat, stationLon, a.lat, a.lon);
+          const db = calculateDistance(stationLat, stationLon, b.lat, b.lon);
+          return da.km <= db.km ? a : b;
+        });
+        const dist = calculateDistance(stationLat, stationLon, closest.lat, closest.lon);
+        const bearing = calculateBearing(stationLat, stationLon, closest.lat, closest.lon);
+        document.dispatchEvent(
+          new CustomEvent('lightning:proximity', {
+            detail: {
+              distanceKm: Math.round(dist.km),
+              distanceMiles: Math.round(dist.miles * 10) / 10,
+              direction: bearingToCardinal(bearing),
+            },
+          }),
+        );
       } else {
         // No nearby strikes - restore normal appearance
         panel.style.border = '1px solid var(--border-color)';


### PR DESCRIPTION
## What this does

When the lightning plugin detects a new strike within 30 km of the station, it now dispatches a `lightning:proximity` browser event carrying distance (km/miles) and compass direction. A new `useLightningAnnouncements` hook subscribes to that event and surfaces the text via an `assertive` aria-live region in `App.jsx`.

Example announcement: *"Lightning alert: strike 8 kilometres north-west"*

## Why assertive

Lightning proximity is a safety alert — the operator may need to disconnect antennas and seek shelter immediately. `assertive` interrupts the screen reader rather than waiting for a pause. This matches the guidance in #997.

## Implementation notes

- Throttled to once per 30 seconds to prevent announcement storms during active cells
- Clears after 10 seconds
- Unit preference (km/miles) read from the existing `openhamclock_config` localStorage key
- The `CustomEvent` approach keeps the plugin self-contained — no changes needed to `PluginLayer.jsx` or `WorldMap.jsx`

## Tests

7 Vitest tests covering: km default, imperial miles, 10 s cleardown, 30 s throttle, post-throttle re-announcement, and no-event baseline. All passing.

Closes part of #997.