### PR TITLE
ci: add concurrency groups to prevent stale queued runs

### DIFF
--- a/.github/workflows/build-rig-listener.yml
+++ b/.github/workflows/build-rig-listener.yml
@@ -11,6 +11,10 @@ on:
   release:
     types: [created]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -17,6 +17,10 @@ on:
       - '.github/workflows/build-wasm.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write # push builds upload p533.{mjs,wasm} to the wasm-latest release
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, Staging]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/docker-dxspider-proxy.yml
+++ b/.github/workflows/docker-dxspider-proxy.yml
@@ -22,6 +22,10 @@ on:
   # Allows running this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/docker-iturhfprop-service.yml
+++ b/.github/workflows/docker-iturhfprop-service.yml
@@ -22,6 +22,10 @@ on:
   # Allows running this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/docker-openhamclock.yml
+++ b/.github/workflows/docker-openhamclock.yml
@@ -22,6 +22,10 @@ on:
   # Allows running this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/publish-p533-data.yml
+++ b/.github/workflows/publish-p533-data.yml
@@ -28,6 +28,10 @@ on:
         default: 'true'
         type: boolean
 
+concurrency:
+  group: publish-p533-data
+  cancel-in-progress: false
+
 permissions:
   contents: write # needed to create/update releases
 

--- a/.github/workflows/rig-listener-build.yml
+++ b/.github/workflows/rig-listener-build.yml
@@ -18,6 +18,10 @@ on:
         required: false
         default: 'dev'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Summary

All 8 build, test, and Docker workflows are missing `concurrency` groups. When several pushes arrive quickly (e.g. fixup commits during a review round), stale runs queue up and waste runner minutes.

This PR adds a `concurrency:` block to each affected workflow:

| Workflow | `cancel-in-progress` | Reason |
|---|---|---|
| `ci.yml` | `true` | Superseded test runs are redundant |
| `build-wasm.yml` | `true` | Path-filtered; only latest matters |
| `rig-listener-build.yml` | `true` | Tag/dispatch; duplicate runs add no value |
| `build-rig-listener.yml` | `true` | Release/dispatch; same reasoning |
| `docker-openhamclock.yml` | `true` | Docker builds are idempotent |
| `docker-dxspider-proxy.yml` | `true` | Same |
| `docker-iturhfprop-service.yml` | `true` | Same |
| `publish-p533-data.yml` | **`false`** | Publishes release assets — aborting mid-upload could leave the release in a broken state; queue instead |

**Intentionally excluded:** `auto-in-progress.yml`, `close-issue.yml`, `self-assign.yml`. These are short, event-driven API calls (label an issue, assign a user) — cancellation would silently drop an action a user just triggered.

## Test plan

- [ ] Confirm YAML is valid (no syntax errors introduced)
- [ ] Push two commits in quick succession to a Staging branch — verify only the latest `ci.yml` run completes; earlier run shows "cancelled"
- [ ] Verify `publish-p533-data.yml` is unchanged in behaviour (manual `workflow_dispatch` only)

Tested on: n/a — pure YAML change, no app logic.