### PR TITLE
Observability wiring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "mqtt": "^5.15.0",
         "node-fetch": "^2.7.0",
         "papaparse": "^5.5.3",
+        "prom-client": "^15.1.0",
         "react-colorful": "^5.6.1",
         "react-i18next": "^16.5.4",
         "rss-parser": "^3.13.0",
@@ -1587,6 +1588,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3054,6 +3064,12 @@
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/bl": {
       "version": "6.1.6",
@@ -8054,6 +8070,19 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
@@ -9263,6 +9292,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/temp": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "rss-parser": "^3.13.0",
     "satellite.js": "^6.0.0",
     "tough-cookie": "^6.0.1",
+    "prom-client": "^15.1.0",
     "ws": "^8.14.2"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -227,7 +227,7 @@ if (distExists) {
 
 app.use(express.static(publicDir, staticOptions));
 
-// ── Prometheus API metrics middleware (before routes) ──
+// ── Prometheus API metrics middleware (before routes, patterns extracted lazily) ──
 app.use(prometheus.apiMetricsMiddleware());
 
 // ── Register route modules ──

--- a/server.js
+++ b/server.js
@@ -78,6 +78,9 @@ process.on('unhandledRejection', (reason) => {
 const { LOG_LEVEL, logDebug, logInfo, logWarn, logErrorOnce, installRateLimiter } = require('./server/utils/logging');
 installRateLimiter();
 
+// ── Prometheus metrics (bootstrapped, references injected after services) ──
+const prometheus = require('./server/services/prometheus-metrics');
+
 // ── Upstream request manager ──
 const UpstreamManager = require('./server/utils/upstream-manager');
 const upstream = new UpstreamManager();
@@ -158,6 +161,10 @@ Object.assign(ctx, {
 });
 app.use(visitorStatsService.visitorMiddleware);
 
+// ── Inject references into Prometheus collect() functions ──
+prometheus.setSessionTracker(visitorStatsService.sessionTracker);
+prometheus.setVisitorStats(visitorStatsService.visitorStats);
+
 // ── Auto-update service ──
 const createAutoUpdateService = require('./server/services/auto-update');
 const autoUpdateService = createAutoUpdateService(ctx);
@@ -220,6 +227,9 @@ if (distExists) {
 
 app.use(express.static(publicDir, staticOptions));
 
+// ── Prometheus API metrics middleware (before routes) ──
+app.use(prometheus.apiMetricsMiddleware());
+
 // ── Register route modules ──
 // Order matters: modules that export shared state must come first
 
@@ -272,6 +282,18 @@ require('./server/routes/admin')(app, ctx);
 const health = require('./server/health');
 ctx.getSubsystemsHealth = health.getSubsystems;
 health.start(ctx);
+prometheus.setSubsystemsHealth(health.getSubsystems);
+
+// ── Prometheus metrics endpoint ──
+app.get('/metrics', async (req, res) => {
+  try {
+    res.set('Content-Type', prometheus.registry.contentType);
+    res.send(await prometheus.registry.metrics());
+  } catch (err) {
+    logErrorOnce('Prometheus', `Metrics collection failed: ${err.message}`);
+    res.status(500).send('Metrics collection failed');
+  }
+});
 
 // ── Catch-all for SPA ──
 app.get('*', (req, res) => {

--- a/server/services/prometheus-metrics.js
+++ b/server/services/prometheus-metrics.js
@@ -70,6 +70,22 @@ const apiDuration = new client.Histogram({
   buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
 });
 
+// API request body size histogram (bytes) — OpenTelemetry http.request.body.size
+const apiRequestSize = new client.Histogram({
+  name: 'ohc_api_request_body_size_bytes',
+  help: 'API request body size in bytes',
+  labelNames: ['route'],
+  buckets: [0, 64, 256, 1024, 4096, 16384, 65536],
+});
+
+// API response body size histogram (bytes) — OpenTelemetry http.response.body.size
+const apiResponseSize = new client.Histogram({
+  name: 'ohc_api_response_body_size_bytes',
+  help: 'API response body size in bytes',
+  labelNames: ['route'],
+  buckets: [0, 128, 512, 1024, 4096, 16384, 65536, 262144, 1048576],
+});
+
 // ── Subsystem health gauges ──────────────────────────────────────────────────
 // 1 = ok/unknown, 2 = degraded, 3 = down
 // Read at scrape time from ctx
@@ -88,32 +104,87 @@ const subsystemStatus = new client.Gauge({
   },
 });
 
+// ── Extract route patterns from Express app's internal router tree ───────────
+// Transforms :param → {param} for each route definition.
+// Used at boot to build a lookup for runtime route normalization.
+
+function extractRoutePatterns(app) {
+  const patterns = [];
+
+  function traverse(layer) {
+    if (layer.route) {
+      // Only process string paths (skip RegExp routes, catch-all, etc.)
+      if (typeof layer.route.path !== 'string') return;
+      if (layer.route.path === '*' || layer.route.path === '/*') return;
+      // /api/wsjtx/relay/download/:platform
+      //        → /api/wsjtx/relay/download/{platform}
+      const normalized = layer.route.path.replace(/\/:([^/]+)/g, '/{$1}');
+      patterns.push(normalized);
+    }
+    // Handle nested routers (express.Router instances)
+    if (layer.handle && layer.handle.stack) {
+      layer.handle.stack.forEach(traverse);
+    }
+  }
+
+  app._router.stack.forEach(traverse);
+  return patterns;
+}
+
+// ── Match a request path against known route patterns ────────────────────────
+// Returns the normalized pattern if matched, otherwise returns the original path.
+
+function normalizeRoute(reqPath, patterns) {
+  const segments = reqPath.split('/').filter(Boolean);
+
+  for (const pattern of patterns) {
+    const patSegments = pattern.split('/').filter(Boolean);
+    if (patSegments.length !== segments.length) continue;
+
+    let match = true;
+    for (let i = 0; i < patSegments.length; i++) {
+      if (patSegments[i].startsWith('{')) continue; // param — match anything
+      if (patSegments[i] !== segments[i]) {
+        match = false;
+        break;
+      }
+    }
+
+    if (match) return pattern;
+  }
+
+  return reqPath; // no known pattern matches
+}
+
 // ── Middleware: track API requests ───────────────────────────────────────────
+// Patterns are extracted lazily on first request to avoid chicken-and-egg
+// (middleware must run before routes register, but patterns come from routes).
 
 function apiMetricsMiddleware() {
+  let patterns = null;
+
   return (req, res, next) => {
     // Skip metrics endpoint itself
     if (req.path === '/metrics') return next();
 
+    // Extract patterns on first request (one-time cost, cached thereafter)
+    if (!patterns) {
+      patterns = extractRoutePatterns(req.app);
+      console.log(`[Prometheus] Extracted ${patterns.length} route patterns from app router`);
+    }
+
     const startTime = Date.now();
-    const route = req.path.replace(/\/[A-Z0-9]{3,10}(-[A-Z0-9]+)?$/i, '/:param').replace(/\/\d+$/g, '/:id');
+    const route = normalizeRoute(req.path, patterns);
 
-    const originalJson = res.json;
-    const originalSend = res.send;
-
-    res.json = function (body) {
+    res.on('finish', () => {
       const duration = (Date.now() - startTime) / 1000;
       apiRequestsTotal.labels(route, req.method, String(res.statusCode)).inc();
       apiDuration.labels(route).observe(duration);
-      return originalJson.call(this, body);
-    };
-
-    res.send = function (body) {
-      const duration = (Date.now() - startTime) / 1000;
-      apiRequestsTotal.labels(route, req.method, String(res.statusCode)).inc();
-      apiDuration.labels(route).observe(duration);
-      return originalSend.call(this, body);
-    };
+      apiRequestSize.labels(route).observe(req.headers['content-length'] ? Number(req.headers['content-length']) : 0);
+      apiResponseSize
+        .labels(route)
+        .observe(res.getHeader('Content-Length') ? Number(res.getHeader('Content-Length')) : 0);
+    });
 
     next();
   };
@@ -146,6 +217,8 @@ module.exports = {
   upstreamFailures,
   apiRequestsTotal,
   apiDuration,
+  apiRequestSize,
+  apiResponseSize,
 
   // Injectors (call once at boot to wire collect() functions)
   setSessionTracker,
@@ -154,6 +227,9 @@ module.exports = {
 
   // Middleware
   apiMetricsMiddleware,
+
+  // Route extraction (called from server.js after all routes registered)
+  extractRoutePatterns,
 
   // Registry (for /metrics endpoint)
   registry: client.register,

--- a/server/services/prometheus-metrics.js
+++ b/server/services/prometheus-metrics.js
@@ -1,0 +1,160 @@
+/**
+ * Prometheus metrics service.
+ *
+ * Collects Node.js default metrics and defines custom business metrics.
+ * Uses the global default registry — all metrics are exposed by a single
+ * /metrics endpoint.
+ *
+ * Usage in other modules:
+ *   const { upstreamFailures } = require('../services/prometheus-metrics');
+ *   upstreamFailures.labels('pskreporter').inc();
+ */
+
+const client = require('prom-client');
+
+// ── Collect Node.js default metrics ──────────────────────────────────────────
+// These include process memory, GC, event loop lag, HTTP request metrics, etc.
+// Collected lazily on scrape — zero overhead between scrapes.
+client.collectDefaultMetrics({ prefix: 'ohc_' });
+
+// ── Custom metrics ───────────────────────────────────────────────────────────
+
+// Total failed upstream API calls, grouped by service name
+const upstreamFailures = new client.Counter({
+  name: 'ohc_upstream_failures_total',
+  help: 'Total number of failed upstream API calls',
+  labelNames: ['service'],
+});
+
+// Currently active user sessions (read at scrape time)
+let _sessionTracker = null;
+const sessionActive = new client.Gauge({
+  name: 'ohc_session_active',
+  help: 'Currently active user sessions',
+  collect() {
+    this.set(_sessionTracker?.activeSessions?.size ?? 0);
+  },
+});
+
+// All-time unique visitors (read at scrape time)
+let _visitorStats = null;
+const visitorsTotal = new client.Gauge({
+  name: 'ohc_visitors_total',
+  help: 'All-time unique visitors',
+  collect() {
+    this.set(_visitorStats?.allTimeVisitors ?? 0);
+  },
+});
+
+// Today's unique visitors (read at scrape time)
+const visitorsToday = new client.Gauge({
+  name: 'ohc_visitors_today',
+  help: 'Unique visitors today',
+  collect() {
+    this.set(_visitorStats?.uniqueVisitorsToday ?? 0);
+  },
+});
+
+// Total API requests (counted per-route)
+const apiRequestsTotal = new client.Counter({
+  name: 'ohc_api_requests_total',
+  help: 'Total API requests',
+  labelNames: ['route', 'method', 'status'],
+});
+
+// API response duration histogram (seconds)
+const apiDuration = new client.Histogram({
+  name: 'ohc_api_duration_seconds',
+  help: 'API response duration in seconds',
+  labelNames: ['route'],
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+});
+
+// ── Subsystem health gauges ──────────────────────────────────────────────────
+// 1 = ok/unknown, 2 = degraded, 3 = down
+// Read at scrape time from ctx
+
+let _subsystemsHealth = null;
+const subsystemStatus = new client.Gauge({
+  name: 'ohc_subsystem_status',
+  help: 'Subsystem health status (1=ok/unknown, 2=degraded, 3=down)',
+  labelNames: ['subsystem'],
+  collect() {
+    if (!_subsystemsHealth) return;
+    const severity = { ok: 1, unknown: 1, degraded: 2, down: 3 };
+    for (const [name, info] of Object.entries(_subsystemsHealth)) {
+      subsystemStatus.labels(name).set(severity[info.status] ?? 1);
+    }
+  },
+});
+
+// ── Middleware: track API requests ───────────────────────────────────────────
+
+function apiMetricsMiddleware() {
+  return (req, res, next) => {
+    // Skip metrics endpoint itself
+    if (req.path === '/metrics') return next();
+
+    const startTime = Date.now();
+    const route = req.path.replace(/\/[A-Z0-9]{3,10}(-[A-Z0-9]+)?$/i, '/:param').replace(/\/\d+$/g, '/:id');
+
+    const originalJson = res.json;
+    const originalSend = res.send;
+
+    res.json = function (body) {
+      const duration = (Date.now() - startTime) / 1000;
+      apiRequestsTotal.labels(route, req.method, String(res.statusCode)).inc();
+      apiDuration.labels(route).observe(duration);
+      return originalJson.call(this, body);
+    };
+
+    res.send = function (body) {
+      const duration = (Date.now() - startTime) / 1000;
+      apiRequestsTotal.labels(route, req.method, String(res.statusCode)).inc();
+      apiDuration.labels(route).observe(duration);
+      return originalSend.call(this, body);
+    };
+
+    next();
+  };
+}
+
+// ── Inject references into collect() functions ───────────────────────────────
+// collect() functions use closure variables (_sessionTracker, etc.) instead of
+// ctx to avoid circular dependency issues. These are set once at boot.
+
+function setSessionTracker(sessionTracker) {
+  _sessionTracker = sessionTracker;
+}
+
+function setVisitorStats(visitorStats) {
+  _visitorStats = visitorStats;
+}
+
+function setSubsystemsHealth(getSubsystems) {
+  _subsystemsHealth = null; // reset
+  // Snapshot is refreshed every 30s by server/health.js
+  setInterval(() => {
+    _subsystemsHealth = getSubsystems?.();
+  }, 5000); // read every 5s, stale between scrapes is fine
+}
+
+// ── Export ───────────────────────────────────────────────────────────────────
+
+module.exports = {
+  // Metrics (exported for direct use in other modules)
+  upstreamFailures,
+  apiRequestsTotal,
+  apiDuration,
+
+  // Injectors (call once at boot to wire collect() functions)
+  setSessionTracker,
+  setVisitorStats,
+  setSubsystemsHealth,
+
+  // Middleware
+  apiMetricsMiddleware,
+
+  // Registry (for /metrics endpoint)
+  registry: client.register,
+};


### PR DESCRIPTION
## What does this PR do?

This PR adds an initial base implementation of observability features.
It consists of adding a conventional prometheus-compatible metrics endpoint at `/metrics`

Current metrics implemented include:
- internal node.js metrics
  - eventloop, gc, etc..
- dynamic scraping of existing server routes - we dont need to manually configure scraping for new routes in the future
  - API requests total
  - API response duration
  - API request/response body size
- existing stats are also tracked - we should remove the built in stats system later when we have a full monitoring stack implemented as its redundant
- Subsystem health status - uses the same numbering but we should not have OK/Unknown be the same number (and OK should not be zero, thats uncommon) - to change later if we remove the builtin subsystem status

Metrics are lazy-loaded on scrape requests as is standard to optimize resource usage.

Care was taken (and must continue to be taken) to maintain minimal cardinality. URL path parameters are normalized the opentelemetry's standard {param_name} format in the `route` label so that we dont increase cardinality unbounded. Any future metrics we add MUST ensure we dont include high cardinality labels.


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1. Visit `/metrics`
2. Check that expected metrics appear
3. Check that making requests to an API endpoint updates related metrics

## Checklist

- [x] App loads without console errors
- [x] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [x] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

