### PR TITLE
fix(prometheus): restrict /metrics access & limit unknown route cardinality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,13 @@ HOST=localhost
 # REQUIRED for cloud/public deployments to prevent unauthorized access.
 # API_WRITE_KEY=your-secret-key-here
 
+# API key for the Prometheus /metrics endpoint.
+# When set, requires a matching ?key= query param or Authorization: Bearer <key> header.
+# Leave unset for public metrics (default, fine for local/private installs).
+# Useful for Railway deployments behind private networking — set this key so only
+# internal scrapers (e.g. Prometheus in the same Railway project) can access metrics.
+# METRICS_AUTH_KEY=your-secret-key-here
+
 # CORS allowed origins (comma-separated)
 # By default, only localhost and openhamclock.com/app origins are allowed.
 # Add your custom domain if you host OHC behind your own URL.

--- a/server.js
+++ b/server.js
@@ -31,6 +31,7 @@ const {
   PORT,
   HOST,
   API_WRITE_KEY,
+  METRICS_AUTH_KEY,
   ITURHFPROP_URL,
   WSJTX_ENABLED,
   WSJTX_UDP_PORT,
@@ -286,6 +287,12 @@ prometheus.setSubsystemsHealth(health.getSubsystems);
 
 // ── Prometheus metrics endpoint ──
 app.get('/metrics', async (req, res) => {
+  if (METRICS_AUTH_KEY) {
+    const token = req.query.key || req.headers.authorization?.replace('Bearer ', '');
+    if (token !== METRICS_AUTH_KEY) {
+      return res.status(401).json({ error: 'Metrics endpoint requires authentication' });
+    }
+  }
   try {
     res.set('Content-Type', prometheus.registry.contentType);
     res.send(await prometheus.registry.metrics());

--- a/server/config.js
+++ b/server/config.js
@@ -61,6 +61,11 @@ const TRUST_PROXY =
 // Security: API key for write operations
 const API_WRITE_KEY = process.env.API_WRITE_KEY || '';
 
+// Security: API key for the Prometheus metrics endpoint. When set, requires
+// a matching ?key= or Authorization: Bearer= header to access /metrics.
+// Leave unset for public metrics (default, safe for local/private installs).
+const METRICS_AUTH_KEY = process.env.METRICS_AUTH_KEY || '';
+
 // Get locator from env (support both LOCATOR and GRID_SQUARE)
 const locator = process.env.LOCATOR || process.env.GRID_SQUARE || '';
 
@@ -255,6 +260,7 @@ module.exports = {
   HOST,
   TRUST_PROXY,
   API_WRITE_KEY,
+  METRICS_AUTH_KEY,
   ITURHFPROP_URL,
   WSJTX_ENABLED,
   WSJTX_UDP_PORT,

--- a/server/services/prometheus-metrics.js
+++ b/server/services/prometheus-metrics.js
@@ -132,7 +132,8 @@ function extractRoutePatterns(app) {
 }
 
 // ── Match a request path against known route patterns ────────────────────────
-// Returns the normalized pattern if matched, otherwise returns the original path.
+// Returns the normalized pattern if matched, otherwise returns "{unknown}".
+// Unknown routes are grouped together to prevent unbounded time series cardinality.
 
 function normalizeRoute(reqPath, patterns) {
   const segments = reqPath.split('/').filter(Boolean);
@@ -153,7 +154,7 @@ function normalizeRoute(reqPath, patterns) {
     if (match) return pattern;
   }
 
-  return reqPath; // no known pattern matches
+  return '{unknown}'; // group all unknown routes together
 }
 
 // ── Middleware: track API requests ───────────────────────────────────────────
@@ -178,12 +179,18 @@ function apiMetricsMiddleware() {
 
     res.on('finish', () => {
       const duration = (Date.now() - startTime) / 1000;
+      const isUnknown = route === '{unknown}';
+
       apiRequestsTotal.labels(route, req.method, String(res.statusCode)).inc();
-      apiDuration.labels(route).observe(duration);
-      apiRequestSize.labels(route).observe(req.headers['content-length'] ? Number(req.headers['content-length']) : 0);
-      apiResponseSize
-        .labels(route)
-        .observe(res.getHeader('Content-Length') ? Number(res.getHeader('Content-Length')) : 0);
+
+      // Only record duration/size histograms for known routes.
+      if (!isUnknown) {
+        apiDuration.labels(route).observe(duration);
+        apiRequestSize.labels(route).observe(req.headers['content-length'] ? Number(req.headers['content-length']) : 0);
+        apiResponseSize
+          .labels(route)
+          .observe(res.getHeader('Content-Length') ? Number(res.getHeader('Content-Length')) : 0);
+      }
     });
 
     next();

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -11,6 +11,10 @@ export default defineConfig({
         target: 'http://localhost:3001',
         changeOrigin: true,
       },
+      '/metrics': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
## What does this PR do?
- Guard /metrics behind optional METRICS_AUTH_KEY env var — public by default, useful for Railway private-network and other deployments
- Collapse all unmatched API paths into {unknown} label so random requests no longer create unbounded time series

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. Verify that requests that are not part of our routes show up as `route={unknown}` in metrics
2. Verify that no histogram metrics are created for this type of route
3. Verify that setting the env var blocks access unless correct header is set

## Checklist

- [x] App loads without console errors
- [x] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [x] No `.bak`, `.old`, `console.log` debug lines, or test scripts included
