### PR TITLE
feat(a11y): announce new DX spot arrivals via aria-live (#997)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -61,6 +61,7 @@ import { initCtyLookup } from './utils/ctyLookup.js';
 import { getAllLayers } from './plugins/layerRegistry.js';
 import ActivateFilterManager from './components/ActivateFilterManager.jsx';
 import { useLightningAnnouncements } from './hooks/app/useLightningAnnouncements';
+import { useDXSpotAnnouncements } from './hooks/app/useDXSpotAnnouncements';
 
 // Load DXCC entity database on app startup (non-blocking)
 initCtyLookup();
@@ -325,6 +326,7 @@ const App = () => {
   });
 
   const { announcement: lightningAnnouncement } = useLightningAnnouncements();
+  const { announcement: dxSpotAnnouncement } = useDXSpotAnnouncements(dxClusterData.spots);
 
   const propagation = usePropagation(config.location, dxLocation, config.propagation);
   const mySpots = useMySpots(config.callsign);
@@ -828,6 +830,10 @@ const App = () => {
       {/* Assertive: lightning proximity is a safety alert — announce immediately */}
       <div className="visually-hidden" aria-live="assertive" aria-atomic="true" data-testid="lightning-announcer">
         {lightningAnnouncement}
+      </div>
+      {/* Polite: new DX spot matching active filters — informational */}
+      <div className="visually-hidden" aria-live="polite" aria-atomic="true" data-testid="dx-spot-announcer">
+        {dxSpotAnnouncement}
       </div>
     </main>
   );

--- a/src/hooks/app/useDXSpotAnnouncements.js
+++ b/src/hooks/app/useDXSpotAnnouncements.js
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState } from 'react';
+
+const COOLDOWN_MS = 10000; // min gap between successive announcements
+const CLEARDOWN_MS = 5000; // clear announcement after 5 seconds
+
+function formatFreq(freq) {
+  if (freq == null) return '';
+  const v = parseFloat(freq);
+  if (!Number.isFinite(v)) return String(freq);
+  const mhz = v > 1000 ? v / 1000 : v;
+  return `${mhz.toFixed(3)} MHz`;
+}
+
+/**
+ * Announces new DX spot arrivals via an aria-live region (#997).
+ * Follows the same pattern as useLightningAnnouncements / useSatelliteAnnouncements.
+ *
+ * Takes the already-filtered spot list from useDXClusterData so only spots
+ * matching the user's active filters are announced.
+ */
+export function useDXSpotAnnouncements(spots) {
+  const [announcement, setAnnouncement] = useState('');
+  const prevKeysRef = useRef(null); // null = baseline not yet established
+  const lastAnnouncedRef = useRef(0);
+  const clearTimerRef = useRef(null);
+
+  useEffect(() => {
+    // Always establish baseline on first call, even if the spot list is empty.
+    // Without this, the first non-empty update would set the baseline instead of announcing.
+    if (prevKeysRef.current === null) {
+      prevKeysRef.current = new Set((spots ?? []).map((s) => `${s.call}-${s.freq}-${s.spotter}`));
+      return;
+    }
+
+    if (!spots || spots.length === 0) return;
+
+    const prev = prevKeysRef.current;
+    const newSpots = spots.filter((s) => !prev.has(`${s.call}-${s.freq}-${s.spotter}`));
+    prevKeysRef.current = new Set(spots.map((s) => `${s.call}-${s.freq}-${s.spotter}`));
+
+    if (newSpots.length === 0) return;
+
+    const now = Date.now();
+    if (now - lastAnnouncedRef.current < COOLDOWN_MS) return;
+    lastAnnouncedRef.current = now;
+
+    const latest = newSpots[0];
+    const text =
+      newSpots.length === 1
+        ? `New DX spot: ${latest.call} on ${formatFreq(latest.freq)}`
+        : `${newSpots.length} new DX spots, latest: ${latest.call} on ${formatFreq(latest.freq)}`;
+
+    setAnnouncement(text);
+
+    if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    clearTimerRef.current = setTimeout(() => setAnnouncement(''), CLEARDOWN_MS);
+  }, [spots]);
+
+  useEffect(() => {
+    return () => {
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    };
+  }, []);
+
+  return { announcement };
+}

--- a/src/hooks/app/useDXSpotAnnouncements.test.jsx
+++ b/src/hooks/app/useDXSpotAnnouncements.test.jsx
@@ -1,0 +1,148 @@
+/**
+ * useDXSpotAnnouncements — Vitest + React 18
+ *
+ * Verifies aria-live announcement text for new DX cluster spot arrivals.
+ * Uses a thin wrapper component rendered with createRoot/act (no @testing-library/react needed).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { useDXSpotAnnouncements } from './useDXSpotAnnouncements';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let root;
+let container;
+let setSpots;
+
+function ControlledHarness({ initial }) {
+  const [spots, setSpots_] = useState(initial);
+  setSpots = setSpots_;
+  const { announcement } = useDXSpotAnnouncements(spots);
+  return <div data-testid="out">{announcement}</div>;
+}
+
+function makeSpot(call, freq, spotter = 'G3XYZ') {
+  return { call, freq, spotter };
+}
+
+function getText() {
+  return container.querySelector('[data-testid="out"]')?.textContent ?? '';
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.useRealTimers();
+});
+
+describe('useDXSpotAnnouncements', () => {
+  it('starts with no announcement on first render', () => {
+    act(() => {
+      root.render(<ControlledHarness initial={[makeSpot('G0ABC', '14.070')]} />);
+    });
+    expect(getText()).toBe('');
+  });
+
+  it('announces a single new spot', () => {
+    act(() => {
+      root.render(<ControlledHarness initial={[]} />);
+    });
+    act(() => {
+      setSpots([makeSpot('G0ABC', '14.070')]);
+    });
+    expect(getText()).toBe('New DX spot: G0ABC on 14.070 MHz');
+  });
+
+  it('announces multiple new spots with count and latest call', () => {
+    act(() => {
+      root.render(<ControlledHarness initial={[]} />);
+    });
+    act(() => {
+      setSpots([makeSpot('G0ABC', '14.070'), makeSpot('G0DEF', '7.074')]);
+    });
+    expect(getText()).toBe('2 new DX spots, latest: G0ABC on 14.070 MHz');
+  });
+
+  it('does not announce when spot list is unchanged', () => {
+    act(() => {
+      root.render(<ControlledHarness initial={[makeSpot('G0ABC', '14.070')]} />);
+    });
+    act(() => {
+      setSpots([makeSpot('G0ABC', '14.070')]);
+    });
+    expect(getText()).toBe('');
+  });
+
+  it('converts kHz frequency values to MHz', () => {
+    act(() => {
+      root.render(<ControlledHarness initial={[]} />);
+    });
+    act(() => {
+      setSpots([makeSpot('G0ABC', 14070)]);
+    });
+    expect(getText()).toBe('New DX spot: G0ABC on 14.070 MHz');
+  });
+
+  it('clears announcement after 5 seconds', () => {
+    act(() => {
+      root.render(<ControlledHarness initial={[]} />);
+    });
+    act(() => {
+      setSpots([makeSpot('G0ABC', '14.070')]);
+    });
+    expect(getText()).not.toBe('');
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(getText()).toBe('');
+  });
+
+  it('throttles a second announcement within the cooldown window', () => {
+    act(() => {
+      root.render(<ControlledHarness initial={[]} />);
+    });
+    act(() => {
+      setSpots([makeSpot('G0ABC', '14.070')]);
+    });
+    const first = getText();
+    expect(first).not.toBe('');
+    // Immediately add another new spot — still within cooldown, text must not change
+    act(() => {
+      setSpots([makeSpot('G0ABC', '14.070'), makeSpot('G0DEF', '7.074')]);
+    });
+    expect(getText()).toBe(first); // second announcement suppressed
+  });
+
+  it('announces again after cooldown expires', () => {
+    act(() => {
+      root.render(<ControlledHarness initial={[]} />);
+    });
+    act(() => {
+      setSpots([makeSpot('G0ABC', '14.070')]);
+    });
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    act(() => {
+      setSpots([makeSpot('G0ABC', '14.070'), makeSpot('G0DEF', '7.074')]);
+    });
+    expect(getText()).toMatch(/new DX spot/i);
+  });
+
+  it('handles empty spots list gracefully', () => {
+    act(() => {
+      root.render(<ControlledHarness initial={[]} />);
+    });
+    expect(getText()).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `useDXSpotAnnouncements` hook that watches the already-filtered spot list from `useDXClusterData` and emits a `polite` `aria-live` announcement when new spots arrive
- Single new spot: *"New DX spot: G0ABC on 14.070 MHz"*; multiple: *"3 new DX spots, latest: G0ABC on 14.070 MHz"*
- Throttled to at most one announcement per 10 seconds to avoid flooding on active bands; text clears after 5 seconds
- Follows the same pattern as `useLightningAnnouncements` and `useSatelliteAnnouncements`
- 9 unit tests covering: baseline (no announcement on mount), single/multi-spot announce, kHz→MHz conversion, cleardown, throttle/cooldown, and empty list

## Why `polite`

A new DX spot is interesting but not safety-critical. `assertive` would interrupt what the screen-reader is currently reading; `polite` waits for a natural pause, which is the right call here.

## Why the filtered list

The hook receives `dxClusterData.spots` — the list already filtered by the user's active DX filters. A user who has narrowed to, say, EU stations on 20 m FT8 wants announcements only for those spots, not every spot that arrives on the cluster.

## Test plan

- [ ] Add DX Cluster panel; set a band/mode filter; wait for new spots — screen reader should announce them without interrupting
- [ ] Verify no announcement fires on initial load (baseline behaviour)
- [ ] Confirm rapid spot batches are throttled (at most one announcement per 10 s)
- [ ] Run `npm test` — 488 passed, 0 regressions

Closes part of #997.