### PR TITLE
a11y: aria-live announcements for BandConditionsPanel (#997)

### DIFF
--- a/src/components/BandConditionsPanel.jsx
+++ b/src/components/BandConditionsPanel.jsx
@@ -30,6 +30,7 @@ export const BandConditionsPanel = ({ data, loading, extras }) => {
         {t('band.conditions')}
         {staleMinutes != null && (
           <span
+            role="alert"
             title={t('band.conditions.stale.tooltip', { mins: staleMinutes })}
             style={{
               fontSize: '10px',
@@ -47,11 +48,17 @@ export const BandConditionsPanel = ({ data, loading, extras }) => {
         )}
       </div>
       {loading ? (
-        <div style={{ display: 'flex', justifyContent: 'center', padding: '20px' }}>
-          <div className="loading-spinner" />
+        <div
+          role="status"
+          aria-label="Loading band conditions"
+          style={{ display: 'flex', justifyContent: 'center', padding: '20px' }}
+        >
+          <div className="loading-spinner" aria-hidden="true" />
         </div>
       ) : (
         <div
+          aria-live="polite"
+          aria-label={t('band.conditions')}
           style={{
             display: 'grid',
             gridTemplateColumns: 'repeat(auto-fill, minmax(50px, 1fr))',
@@ -60,9 +67,11 @@ export const BandConditionsPanel = ({ data, loading, extras }) => {
         >
           {data.map(({ band, condition }) => {
             const style = getConditionStyle(condition);
+            const conditionLabel = t(`band.conditions.${condition.toLowerCase()}`);
             return (
               <div
                 key={band}
+                aria-label={`${band}: ${conditionLabel}`}
                 style={{
                   textAlign: 'center',
                   padding: '6px 4px',
@@ -72,6 +81,7 @@ export const BandConditionsPanel = ({ data, loading, extras }) => {
                 }}
               >
                 <div
+                  aria-hidden="true"
                   style={{
                     fontSize: '12px',
                     fontWeight: '700',
@@ -82,6 +92,7 @@ export const BandConditionsPanel = ({ data, loading, extras }) => {
                   {band}
                 </div>
                 <div
+                  aria-hidden="true"
                   style={{
                     fontSize: '9px',
                     fontWeight: '600',
@@ -89,7 +100,7 @@ export const BandConditionsPanel = ({ data, loading, extras }) => {
                     marginTop: '2px',
                   }}
                 >
-                  {t(`band.conditions.${condition.toLowerCase()}`)}
+                  {conditionLabel}
                 </div>
               </div>
             );

--- a/src/components/BandConditionsPanel.test.jsx
+++ b/src/components/BandConditionsPanel.test.jsx
@@ -1,0 +1,95 @@
+/**
+ * BandConditionsPanel component tests
+ * Verifies aria-live and accessibility attributes added in P2-005.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { BandConditionsPanel } from './BandConditionsPanel.jsx';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, opts) => (opts && opts.defaultValue) || key,
+  }),
+}));
+
+const SAMPLE_DATA = [
+  { band: '40m', condition: 'GOOD' },
+  { band: '20m', condition: 'FAIR' },
+  { band: '10m', condition: 'POOR' },
+];
+
+function mount(props) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(<BandConditionsPanel {...props} />));
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      document.body.removeChild(container);
+    },
+  };
+}
+
+describe('BandConditionsPanel accessibility', () => {
+  it('loading state: status div has role=status and aria-label', () => {
+    const { container, unmount } = mount({ data: [], loading: true, extras: null });
+    const statusDiv = container.querySelector('[role="status"]');
+    expect(statusDiv).not.toBeNull();
+    expect(statusDiv.getAttribute('aria-label')).toBe('Loading band conditions');
+    unmount();
+  });
+
+  it('loading state: spinner is aria-hidden', () => {
+    const { container, unmount } = mount({ data: [], loading: true, extras: null });
+    const spinner = container.querySelector('.loading-spinner');
+    expect(spinner.getAttribute('aria-hidden')).toBe('true');
+    unmount();
+  });
+
+  it('data grid has aria-live=polite', () => {
+    const { container, unmount } = mount({ data: SAMPLE_DATA, loading: false, extras: null });
+    const grid = container.querySelector('[aria-live="polite"]');
+    expect(grid).not.toBeNull();
+    unmount();
+  });
+
+  it('each band cell has aria-label combining band and translated condition', () => {
+    const { container, unmount } = mount({ data: SAMPLE_DATA, loading: false, extras: null });
+    const cells = container.querySelectorAll('[aria-live="polite"] > div');
+    expect(cells.length).toBe(3);
+    expect(cells[0].getAttribute('aria-label')).toBe('40m: band.conditions.good');
+    expect(cells[1].getAttribute('aria-label')).toBe('20m: band.conditions.fair');
+    expect(cells[2].getAttribute('aria-label')).toBe('10m: band.conditions.poor');
+    unmount();
+  });
+
+  it('band name and condition text children are aria-hidden', () => {
+    const { container, unmount } = mount({ data: SAMPLE_DATA, loading: false, extras: null });
+    const cells = container.querySelectorAll('[aria-live="polite"] > div');
+    cells.forEach((cell) => {
+      const hidden = cell.querySelectorAll('[aria-hidden="true"]');
+      expect(hidden.length).toBe(2);
+    });
+    unmount();
+  });
+
+  it('stale badge has role=alert when data is stale', () => {
+    const extras = { stale: true, fetchedAt: Date.now() - 120_000 };
+    const { container, unmount } = mount({ data: SAMPLE_DATA, loading: false, extras });
+    const badge = container.querySelector('[role="alert"]');
+    expect(badge).not.toBeNull();
+    unmount();
+  });
+
+  it('no stale badge when extras is null', () => {
+    const { container, unmount } = mount({ data: SAMPLE_DATA, loading: false, extras: null });
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    unmount();
+  });
+});


### PR DESCRIPTION
## Summary

Closes part of #997.

The `BandConditionsPanel` had no ARIA attributes, making it silent to screen readers even though band conditions update hourly.

**Changes in `BandConditionsPanel.jsx`:**

- `aria-live="polite"` + `aria-label` on the conditions grid container — screen readers announce condition changes when the hourly data refreshes
- `aria-label="{band}: {condition}"` on each band cell (e.g. `"40m: Good"`) so the full meaning is conveyed; visual child divs marked `aria-hidden="true"` to prevent double-reading
- `role="status"` + `aria-label="Loading band conditions"` on the spinner wrapper; spinner itself is `aria-hidden="true"`
- `role="alert"` on the stale-data badge so assistive technology announces immediately when the server is serving error-fallback data

**New `BandConditionsPanel.test.jsx`:** 7 tests covering each aria attribute.

## Test plan

- [x] All 7 new component tests pass (`BandConditionsPanel.test.jsx`)
- [x] Full suite: 26 test files, 503 tests — no regressions
- [x] Visual output unchanged — all aria changes are additive attributes / markup additions only
- [ ] Manual screen reader test (NVDA / JAWS / VoiceOver) recommended before merge