### PR TITLE
Any time we use pass a callsign over http we need to encodeURIComponent()

### DIFF
--- a/src/plugins/layers/useRBN.js
+++ b/src/plugins/layers/useRBN.js
@@ -277,7 +277,7 @@ export function useLayer({
           mySpots.map(async (spot) => {
             if (spot.grid && spot.skimmerLat != null && spot.skimmerLon != null) return spot;
             try {
-              const locationResponse = await fetch(`/api/rbn/location/${spot.callsign}`);
+              const locationResponse = await fetch(`/api/rbn/location/${encodeURIComponent(spot.callsign)}`);
               if (locationResponse.ok) {
                 const loc = await locationResponse.json();
                 return {


### PR DESCRIPTION

## What does this PR do?

Any time we pass a callsign to the server API in `useRBN.js` we need to encode the callsign so callsigns with suffixes like `/P` don't screw things up.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

Watch an RBN skimmer for a known CW op operating with a suffix like `/P` that has also spotted in either DX Cluster or an ActivatorPanel type spot and verify that we get the proper location.

## Checklist

- [X] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

