### PR TITLE
Add SatNOGS transmitter metadata for satellites

### DIFF
--- a/server/routes/satellites.js
+++ b/server/routes/satellites.js
@@ -88,6 +88,8 @@ module.exports = function (app, ctx) {
   // SatNOGS Transmitter DB radio metadata.
   const SATNOGS_TRANSMITTER_CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
   const SATNOGS_TRANSMITTER_MAX_RECORDS = 500;
+  const SATNOGS_TRANSMITTER_REQUEST_TIMEOUT = 8000;
+  const SATNOGS_TRANSMITTER_CONCURRENCY = 4;
   const SATNOGS_TRANSMITTER_ATTRIBUTION = 'Radio metadata from SatNOGS Transmitter DB (CC BY-SA 4.0)';
 
   let satnogsTransmitterCache = {
@@ -98,6 +100,40 @@ module.exports = function (app, ctx) {
   };
 
   let satnogsTransmitterFetchInFlight = false;
+  const SATNOGS_OVERLAY_FIELDS = ['mode', 'downlink', 'uplink', 'tone', 'beacon', 'notes'];
+  const satnogsRegistryBaseMetadata = new Map();
+
+  const snapshotSatnogsBaseMetadata = (satellite) => {
+    const snapshot = {};
+    SATNOGS_OVERLAY_FIELDS.forEach((field) => {
+      if (Object.prototype.hasOwnProperty.call(satellite, field)) {
+        snapshot[field] = satellite[field];
+      }
+    });
+    return snapshot;
+  };
+
+  const getSatnogsBaseMetadataForSatellite = (satellite) => {
+    const key = String(satellite?.norad || '');
+    if (!key) return {};
+    if (!satnogsRegistryBaseMetadata.has(key)) {
+      satnogsRegistryBaseMetadata.set(key, snapshotSatnogsBaseMetadata(satellite));
+    }
+    return satnogsRegistryBaseMetadata.get(key);
+  };
+
+  const restoreSatnogsBaseMetadata = (satellite, baseMetadata) => {
+    if (!satellite) return;
+    SATNOGS_OVERLAY_FIELDS.forEach((field) => {
+      if (Object.prototype.hasOwnProperty.call(baseMetadata, field)) {
+        satellite[field] = baseMetadata[field];
+      } else {
+        delete satellite[field];
+      }
+    });
+    delete satellite.satnogs;
+    delete satellite.radioMetadataAttribution;
+  };
 
   const isSatnogsTransmitterMetadataStale = () =>
     !satnogsTransmitterCache.timestamp ||
@@ -280,7 +316,7 @@ module.exports = function (app, ctx) {
 
     for (const base of bases) {
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 20000);
+      const timeout = setTimeout(() => controller.abort(), SATNOGS_TRANSMITTER_REQUEST_TIMEOUT);
 
       try {
         const url = base + '?format=json&satellite__norad_cat_id=' + encodeURIComponent(String(noradId));
@@ -310,15 +346,35 @@ module.exports = function (app, ctx) {
 
   const applySatnogsMetadataToRegistry = (recordsByNorad) => {
     let applied = 0;
+    let cleared = 0;
 
     Object.entries(recordsByNorad || {}).forEach(([norad, transmitters]) => {
-      const metadata = buildSatnogsRadioMetadata(transmitters);
-      if (!metadata) return;
-
       const target = Object.values(HAM_SATELLITES).find((sat) => String(sat.norad) === String(norad));
       if (!target) return;
 
-      const existingNotes = String(target.notes || '').trim();
+      const baseMetadata = getSatnogsBaseMetadataForSatellite(target);
+      const metadata = buildSatnogsRadioMetadata(transmitters);
+
+      if (!metadata) {
+        let clearedThisNorad = false;
+
+        if (target.satnogs || target.radioMetadataAttribution) {
+          restoreSatnogsBaseMetadata(target, baseMetadata);
+          clearedThisNorad = true;
+        }
+
+        Object.values(ommCache || {}).forEach((entry) => {
+          if (String(entry.norad) === String(norad) && (entry.satnogs || entry.radioMetadataAttribution)) {
+            restoreSatnogsBaseMetadata(entry, baseMetadata);
+            clearedThisNorad = true;
+          }
+        });
+
+        if (clearedThisNorad) cleared++;
+        return;
+      }
+
+      const existingNotes = String(baseMetadata.notes || '').trim();
       if (existingNotes && !existingNotes.includes('SatNOGS Transmitter DB')) {
         metadata.notes = existingNotes + ' ' + SATNOGS_TRANSMITTER_ATTRIBUTION;
       } else if (!existingNotes) {
@@ -326,17 +382,15 @@ module.exports = function (app, ctx) {
       }
 
       Object.assign(target, metadata);
-
       Object.values(ommCache || {}).forEach((entry) => {
         if (String(entry.norad) === String(norad)) {
           Object.assign(entry, metadata);
         }
       });
-
       applied++;
     });
 
-    return applied;
+    return { applied, cleared };
   };
 
   const refreshSatnogsTransmitterMetadata = async (force = false) => {
@@ -344,7 +398,6 @@ module.exports = function (app, ctx) {
     if (!force && !isSatnogsTransmitterMetadataStale()) return;
 
     satnogsTransmitterFetchInFlight = true;
-
     try {
       const norads = [
         ...new Set(
@@ -357,14 +410,27 @@ module.exports = function (app, ctx) {
       const recordsByNorad = {};
       let totalRecords = 0;
 
-      for (const norad of norads) {
-        if (totalRecords >= SATNOGS_TRANSMITTER_MAX_RECORDS) break;
+      for (
+        let i = 0;
+        i < norads.length && totalRecords < SATNOGS_TRANSMITTER_MAX_RECORDS;
+        i += SATNOGS_TRANSMITTER_CONCURRENCY
+      ) {
+        const batch = norads.slice(i, i + SATNOGS_TRANSMITTER_CONCURRENCY);
+        const results = await Promise.all(
+          batch.map(async (norad) => ({
+            norad,
+            transmitters: await fetchSatnogsTransmittersForNorad(norad),
+          })),
+        );
 
-        const transmitters = await fetchSatnogsTransmittersForNorad(norad);
-        if (transmitters.length > 0) {
+        for (const { norad, transmitters } of results) {
+          const transmitterList = Array.isArray(transmitters) ? transmitters : [];
           const room = SATNOGS_TRANSMITTER_MAX_RECORDS - totalRecords;
-          recordsByNorad[norad] = transmitters.slice(0, room);
-          totalRecords += recordsByNorad[norad].length;
+          if (room <= 0) break;
+
+          const limitedTransmitters = transmitterList.slice(0, room);
+          recordsByNorad[norad] = limitedTransmitters;
+          totalRecords += limitedTransmitters.length;
         }
       }
 
@@ -375,15 +441,15 @@ module.exports = function (app, ctx) {
         lastError: null,
       };
 
-      const applied = applySatnogsMetadataToRegistry(recordsByNorad);
-
-      if (applied > 0) {
+      const { applied, cleared } = applySatnogsMetadataToRegistry(recordsByNorad);
+      if (applied > 0 || cleared > 0) {
         logInfo(
           '[Satellites] SatNOGS transmitter metadata updated: ' +
             applied +
             ' satellites, ' +
             totalRecords +
-            ' transmitter records',
+            ' transmitter records' +
+            (cleared > 0 ? ', ' + cleared + ' stale overlays cleared' : ''),
         );
       } else {
         logWarn('[Satellites] SatNOGS transmitter metadata refresh completed with no matching active transmitters');
@@ -1211,7 +1277,7 @@ module.exports = function (app, ctx) {
 
     res.json({
       satnogsTransmitters: {
-        ...(Number.isFinite(satnogsTransmitterCache.timestamp) && {
+        ...(satnogsTransmitterCache.timestamp > 0 && {
           lastFetch: formatSimpleAge(Date.now() - satnogsTransmitterCache.timestamp),
         }),
         totalRecords: satnogsTransmitterCache.totalRecords || 0,

--- a/server/routes/satellites.js
+++ b/server/routes/satellites.js
@@ -85,6 +85,319 @@ module.exports = function (app, ctx) {
     logInfo(`[Satellites] Routing CelesTrak/AMSAT/SatNOGS fetches via ${FLETCHER_URL}`);
   }
 
+  // SatNOGS Transmitter DB radio metadata.
+  // OpenHamClock issue: https://github.com/accius/openhamclock/issues/1009
+  const SATNOGS_TRANSMITTER_CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
+  const SATNOGS_TRANSMITTER_MAX_RECORDS = 500;
+  const SATNOGS_TRANSMITTER_ATTRIBUTION = 'Radio metadata from SatNOGS Transmitter DB (CC BY-SA 4.0)';
+
+  let satnogsTransmitterCache = {
+    timestamp: 0,
+    totalRecords: 0,
+    recordsByNorad: {},
+    lastError: null,
+  };
+
+  let satnogsTransmitterFetchInFlight = false;
+
+  const isSatnogsTransmitterMetadataStale = () =>
+    !satnogsTransmitterCache.timestamp ||
+    Date.now() - satnogsTransmitterCache.timestamp >= SATNOGS_TRANSMITTER_CACHE_DURATION;
+
+  const formatHzAsMHz = (value) => {
+    const hz = Number(value);
+    if (!Number.isFinite(hz) || hz <= 0) return '';
+    return (hz / 1000000).toFixed(3) + ' MHz';
+  };
+
+  const formatHzRangeAsMHz = (low, high) => {
+    const lowNum = Number(low);
+    const highNum = Number(high);
+    const lowStr = formatHzAsMHz(low);
+    const highStr = formatHzAsMHz(high);
+
+    if (!lowStr && !highStr) return '';
+    if (lowStr && (!highStr || lowNum === highNum)) return lowStr;
+    if (!lowStr) return highStr;
+
+    return lowStr.replace(' MHz', '') + ' - ' + highStr;
+  };
+
+  const uniqueCompactList = (values, maxItems = 4) => {
+    const unique = [];
+
+    values
+      .map((v) => String(v || '').trim())
+      .filter(Boolean)
+      .forEach((v) => {
+        if (!unique.includes(v)) unique.push(v);
+      });
+
+    if (unique.length <= maxItems) return unique.join(', ');
+    return unique.slice(0, maxItems).join(', ') + ' +' + (unique.length - maxItems) + ' more';
+  };
+
+  const describeSatnogsMode = (tx) => {
+    const mode = String(tx.mode || '').trim();
+    const type = String(tx.type || '').trim();
+    const description = String(tx.description || '').trim();
+
+    const downlinkLow = Number(tx.downlink_low);
+    const downlinkHigh = Number(tx.downlink_high);
+    const uplinkLow = Number(tx.uplink_low);
+    const uplinkHigh = Number(tx.uplink_high);
+
+    const hasDownlinkRange =
+      Number.isFinite(downlinkLow) &&
+      Number.isFinite(downlinkHigh) &&
+      downlinkLow > 0 &&
+      downlinkHigh > 0 &&
+      downlinkLow !== downlinkHigh;
+
+    const hasUplinkRange =
+      Number.isFinite(uplinkLow) &&
+      Number.isFinite(uplinkHigh) &&
+      uplinkLow > 0 &&
+      uplinkHigh > 0 &&
+      uplinkLow !== uplinkHigh;
+
+    const combined = [mode, type, description].join(' ').toLowerCase();
+
+    // SatNOGS may report the sideband used within a linear transponder as
+    // USB/LSB. For OHC's compact popup, a paired uplink/downlink frequency
+    // range is more usefully displayed as "Linear", matching the existing
+    // curated satellite metadata.
+    if (combined.includes('linear') || (hasDownlinkRange && hasUplinkRange)) {
+      return 'Linear';
+    }
+
+    const baud = Number(tx.baud);
+
+    if (mode && Number.isFinite(baud) && baud > 0 && !mode.includes(String(baud))) {
+      return mode + ' ' + baud + ' baud';
+    }
+
+    return mode || type;
+  };
+  const scoreSatnogsTransmitter = (tx) => {
+    const mode = String(tx.mode || '').toLowerCase();
+    const type = String(tx.type || '').toLowerCase();
+    const description = String(tx.description || '').toLowerCase();
+
+    const hasDownlink = Boolean(tx.downlink_low || tx.downlink_high);
+    const hasUplink = Boolean(tx.uplink_low || tx.uplink_high);
+
+    let score = 0;
+
+    // For the popup, prefer an actual radio path the operator can use.
+    // Telemetry-only/data beacons are useful metadata, but they should not
+    // crowd out an FM or linear transponder entry when one exists.
+    if (hasDownlink && hasUplink) score += 600;
+    else if (hasDownlink) score += 100;
+
+    if (type.includes('transceiver')) score += 350;
+    if (type.includes('transponder')) score += 300;
+    if (description.includes('transponder')) score += 250;
+    if (description.includes('linear')) score += 250;
+
+    if (mode.includes('linear')) score += 250;
+    if (mode.includes('ssb') || mode.includes('usb') || mode.includes('lsb')) score += 220;
+    if (mode.includes('fm')) score += 180;
+
+    if (mode.includes('cw')) score += hasUplink ? 80 : -10;
+
+    if (
+      mode.includes('fsk') ||
+      mode.includes('bpsk') ||
+      mode.includes('gmsk') ||
+      mode.includes('afsk') ||
+      mode.includes('doka') ||
+      mode.includes('telemetry') ||
+      description.includes('telemetry') ||
+      description.includes('beacon')
+    ) {
+      score -= hasUplink ? 25 : 125;
+    }
+
+    const updated = Date.parse(tx.updated || '');
+    if (Number.isFinite(updated)) score += Math.min(20, Math.floor(updated / 100000000000));
+
+    return score;
+  };
+
+  const activeSatnogsTransmitters = (transmitters) =>
+    (Array.isArray(transmitters) ? transmitters : [])
+      .filter((tx) => {
+        const status = String(tx.status || '').toLowerCase();
+        const alive = tx.alive === true || tx.alive === 'true';
+        return status === 'active' && alive;
+      })
+      .sort((a, b) => scoreSatnogsTransmitter(b) - scoreSatnogsTransmitter(a));
+  const buildSatnogsRadioMetadata = (transmitters) => {
+    const selected = activeSatnogsTransmitters(transmitters);
+    if (selected.length === 0) return null;
+
+    // Show one best/primary transmitter in the UI. SatNOGS often lists
+    // multiple active entries for the same satellite: telemetry beacons,
+    // data downlinks, CW beacons, and transponders. Listing all of them in
+    // the compact popup makes the radio metadata hard to use.
+    const best = selected[0];
+
+    const updatedTimes = selected.map((tx) => Date.parse(tx.updated || '')).filter((ts) => Number.isFinite(ts));
+
+    const metadata = {
+      satnogs: {
+        source: 'SatNOGS Transmitter DB',
+        transmitterCount: selected.length,
+        selectedTransmitter: best.uuid || best.description || best.mode || best.type || null,
+        updated: updatedTimes.length > 0 ? new Date(Math.max(...updatedTimes)).toISOString() : null,
+        attribution: SATNOGS_TRANSMITTER_ATTRIBUTION,
+      },
+      radioMetadataAttribution: SATNOGS_TRANSMITTER_ATTRIBUTION,
+    };
+
+    if (selected.length > 1) {
+      metadata.satnogs.alternateTransmitterCount = selected.length - 1;
+    }
+
+    const mode = describeSatnogsMode(best);
+    const downlink = formatHzRangeAsMHz(best.downlink_low, best.downlink_high);
+    const uplink = formatHzRangeAsMHz(best.uplink_low, best.uplink_high);
+    const tone = String(best.tone || best.uplink_tone || best.downlink_tone || '').trim();
+
+    if (mode) metadata.mode = mode;
+    if (downlink) metadata.downlink = downlink;
+    if (uplink) metadata.uplink = uplink;
+    if (tone) metadata.tone = tone;
+
+    return metadata;
+  };
+
+  const fetchSatnogsTransmittersForNorad = async (noradId) => {
+    const directBase = 'https://db.satnogs.org/api/transmitters/';
+    const proxyBase = FLETCHER_URL ? FLETCHER_URL.replace(/\/$/, '') + '/satnogs/api/transmitters/' : null;
+
+    const bases = proxyBase ? [proxyBase, directBase] : [directBase];
+
+    for (const base of bases) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 20000);
+
+      try {
+        const url = base + '?format=json&satellite__norad_cat_id=' + encodeURIComponent(String(noradId));
+
+        const res = await fetch(url, {
+          headers: { 'User-Agent': 'OpenHamClock/' + APP_VERSION },
+          signal: controller.signal,
+        });
+
+        if (!res.ok) {
+          continue;
+        }
+
+        const json = await res.json();
+        const transmitters = Array.isArray(json) ? json : Array.isArray(json.results) ? json.results : [];
+
+        return transmitters;
+      } catch {
+        // Try the next base URL, if any.
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+
+    return [];
+  };
+
+  const applySatnogsMetadataToRegistry = (recordsByNorad) => {
+    let applied = 0;
+
+    Object.entries(recordsByNorad || {}).forEach(([norad, transmitters]) => {
+      const metadata = buildSatnogsRadioMetadata(transmitters);
+      if (!metadata) return;
+
+      const target = Object.values(HAM_SATELLITES).find((sat) => String(sat.norad) === String(norad));
+      if (!target) return;
+
+      const existingNotes = String(target.notes || '').trim();
+      if (existingNotes && !existingNotes.includes('SatNOGS Transmitter DB')) {
+        metadata.notes = existingNotes + ' ' + SATNOGS_TRANSMITTER_ATTRIBUTION;
+      } else if (!existingNotes) {
+        metadata.notes = SATNOGS_TRANSMITTER_ATTRIBUTION;
+      }
+
+      Object.assign(target, metadata);
+
+      Object.values(ommCache || {}).forEach((entry) => {
+        if (String(entry.norad) === String(norad)) {
+          Object.assign(entry, metadata);
+        }
+      });
+
+      applied++;
+    });
+
+    return applied;
+  };
+
+  const refreshSatnogsTransmitterMetadata = async (force = false) => {
+    if (satnogsTransmitterFetchInFlight) return;
+    if (!force && !isSatnogsTransmitterMetadataStale()) return;
+
+    satnogsTransmitterFetchInFlight = true;
+
+    try {
+      const norads = [
+        ...new Set(
+          Object.values(HAM_SATELLITES)
+            .map((sat) => Number(sat.norad))
+            .filter((norad) => Number.isFinite(norad) && norad > 0),
+        ),
+      ].sort((a, b) => a - b);
+
+      const recordsByNorad = {};
+      let totalRecords = 0;
+
+      for (const norad of norads) {
+        if (totalRecords >= SATNOGS_TRANSMITTER_MAX_RECORDS) break;
+
+        const transmitters = await fetchSatnogsTransmittersForNorad(norad);
+        if (transmitters.length > 0) {
+          const room = SATNOGS_TRANSMITTER_MAX_RECORDS - totalRecords;
+          recordsByNorad[norad] = transmitters.slice(0, room);
+          totalRecords += recordsByNorad[norad].length;
+        }
+      }
+
+      satnogsTransmitterCache = {
+        timestamp: Date.now(),
+        totalRecords,
+        recordsByNorad,
+        lastError: null,
+      };
+
+      const applied = applySatnogsMetadataToRegistry(recordsByNorad);
+
+      if (applied > 0) {
+        logInfo(
+          '[Satellites] SatNOGS transmitter metadata updated: ' +
+            applied +
+            ' satellites, ' +
+            totalRecords +
+            ' transmitter records',
+        );
+      } else {
+        logWarn('[Satellites] SatNOGS transmitter metadata refresh completed with no matching active transmitters');
+      }
+    } catch (ex) {
+      const msg = ex?.message || String(ex ?? '(unknown error)');
+      satnogsTransmitterCache.lastError = msg;
+      logWarn('[Satellites] SatNOGS transmitter metadata refresh failed: ' + msg);
+    } finally {
+      satnogsTransmitterFetchInFlight = false;
+    }
+  };
+
   const fetchOmmFromCelesTrakGroups = async (group) => {
     let httpStatusCode = 0;
     let ommJson = {};
@@ -764,6 +1077,14 @@ module.exports = function (app, ctx) {
     sm.run();
   }, 15 * 1000);
 
+  // Refresh SatNOGS radio metadata in the background. This is deliberately
+  // independent of the TLE/OMM state machine because transmitter metadata
+  // changes much less frequently than orbital data.
+  refreshSatnogsTransmitterMetadata(false);
+  setInterval(() => {
+    refreshSatnogsTransmitterMetadata(false);
+  }, SATNOGS_TRANSMITTER_CACHE_DURATION);
+
   // satellites with a CelesTrak datasource that need data
   const celestrakSatsToDownload = (now) => {
     return Object.values(HAM_SATELLITES).filter(
@@ -890,6 +1211,12 @@ module.exports = function (app, ctx) {
       .sort((a, b) => a.norad - b.norad);
 
     res.json({
+      satnogsTransmitters: {
+        lastFetchAt: satnogsTransmitterCache.timestamp || null,
+        totalRecords: satnogsTransmitterCache.totalRecords || 0,
+        lastError: satnogsTransmitterCache.lastError || null,
+        attribution: SATNOGS_TRANSMITTER_ATTRIBUTION,
+      },
       totalInRegistry: Object.keys(HAM_SATELLITES).length,
       totalResolved: Object.keys(cached).length,
       totalMissing: all.filter((s) => !s.resolved).length,

--- a/server/routes/satellites.js
+++ b/server/routes/satellites.js
@@ -86,7 +86,6 @@ module.exports = function (app, ctx) {
   }
 
   // SatNOGS Transmitter DB radio metadata.
-  // OpenHamClock issue: https://github.com/accius/openhamclock/issues/1009
   const SATNOGS_TRANSMITTER_CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
   const SATNOGS_TRANSMITTER_MAX_RECORDS = 500;
   const SATNOGS_TRANSMITTER_ATTRIBUTION = 'Radio metadata from SatNOGS Transmitter DB (CC BY-SA 4.0)';
@@ -1212,7 +1211,7 @@ module.exports = function (app, ctx) {
 
     res.json({
       satnogsTransmitters: {
-                ...(Number.isFinite(satnogsTransmitterCache.timestamp) && {
+        ...(Number.isFinite(satnogsTransmitterCache.timestamp) && {
           lastFetch: formatSimpleAge(Date.now() - satnogsTransmitterCache.timestamp),
         }),
         totalRecords: satnogsTransmitterCache.totalRecords || 0,

--- a/server/routes/satellites.js
+++ b/server/routes/satellites.js
@@ -1212,7 +1212,9 @@ module.exports = function (app, ctx) {
 
     res.json({
       satnogsTransmitters: {
-        lastFetchAt: satnogsTransmitterCache.timestamp || null,
+                ...(Number.isFinite(satnogsTransmitterCache.timestamp) && {
+          lastFetch: formatSimpleAge(Date.now() - satnogsTransmitterCache.timestamp),
+        }),
         totalRecords: satnogsTransmitterCache.totalRecords || 0,
         lastError: satnogsTransmitterCache.lastError || null,
         attribution: SATNOGS_TRANSMITTER_ATTRIBUTION,


### PR DESCRIPTION
Adds satellite radio metadata from the SatNOGS Transmitter DB for tracked satellites.

Summary:
- Fetches active/alive SatNOGS transmitter records by NORAD ID
- Caches transmitter metadata for 24 hours
- Applies metadata to existing tracked satellites without replacing orbital data
- Selects one best/primary transmitter for the compact satellite popup
- Preserves curated fallback behavior when SatNOGS has no usable record
- Adds SatNOGS attribution text for CC BY-SA metadata
- Adds SatNOGS refresh status to the satellite debug endpoint

Tested locally:
- ISS shows FM downlink/uplink/tone metadata
- RS-44 shows Linear mode with uplink/downlink ranges
- TEVEL satellites avoid being mislabeled as Linear when they are FM single-frequency entries
- npm run build passes