### PR TITLE
chore(format): fix prettier drift in dxspider-proxy/README.md

### DIFF
--- a/dxspider-proxy/README.md
+++ b/dxspider-proxy/README.md
@@ -22,7 +22,7 @@ Many cloud hosting platforms (including Railway) don't support outbound telnet c
 
 ## Environment Variables
 
-| Variable   | Default | Description                                                          |
+| Variable   | Default | Description                                                         |
 | ---------- | ------- | ------------------------------------------------------------------- |
 | `PORT`     | 3001    | HTTP server port                                                    |
 | `CALLSIGN` | K0CJH   | Callsign for DX Spider login — **must be a valid amateur callsign** |


### PR DESCRIPTION
## What does this PR do?

Fixes the failing `format` CI check on main: `dxspider-proxy/README.md` landed with one table cell a space too wide in the Jul 1 dxcluster alignment commits. Whitespace-only, one character. `npx prettier --check .` now passes repo-wide with the pinned prettier 3.8.1.

## Type of change

- [x] Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)