### PR TITLE
[feat] satellite backup source env enable/disable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -186,6 +186,12 @@ LAYOUT=modern
 # CelesTrak.org data source is enabled by default, no username or password is needed.
 # CelesTrak can be disabled by setting CELESTRAK_ENABLED=false, but it is recommended to keep it enabled as a backup source.
 CELESTRAK_ENABLED=true
+# AMSAT TLE data source is enabled by default, no username or password is needed.
+# AMSAT TLE can be disabled by setting AMSAT_TLE_ENABLED=false, but it is recommended to keep it enabled as a backup source.
+#AMSAT_TLE_ENABLED=true
+# SATNOGS TLE data source is enabled by default, no username or password is needed.
+# SATNOGS TLE can be disabled by setting SATNOGS_TLE_ENABLED=false, but it is recommended to keep it enabled as a backup source.
+#SATNOGS_TLE_ENABLED=true
 # Space-Track.org is disabled by default, but can be enabled by providing a valid username and password.
 # To enable both username and password fields must be active.
 # When enabled Space-Track.org becomes primary data source for satellite data with CelesTrak as backup.

--- a/server/config.js
+++ b/server/config.js
@@ -137,6 +137,16 @@ const CONFIG = {
         return !(process.env.CELESTRAK_ENABLED && process.env.CELESTRAK_ENABLED === 'false');
       },
     },
+    amsat_tle: {
+      get enabled() {
+        return !(process.env.AMSAT_TLE_ENABLED && process.env.AMSAT_TLE_ENABLED === 'false');
+      },
+    },
+    satnogs_tle: {
+      get enabled() {
+        return !(process.env.SATNOGS_TLE_ENABLED && process.env.SATNOGS_TLE_ENABLED === 'false');
+      },
+    },
     spaceTrack: {
       // (do not expose usernames/passwords to frontend)
       _username: process.env.SPACE_TRACK_USERNAME || '',

--- a/server/routes/satellites.js
+++ b/server/routes/satellites.js
@@ -820,8 +820,12 @@ module.exports = function (app, ctx) {
 
   const isSpaceTrackEnabled = CONFIG.satellites.spaceTrack?.enabled || false; // default false if undefined
   const isCelestrakEnabled = CONFIG.satellites.celestrak?.enabled ?? true; // default true if undefined
+  const isAmsatTleEnabled = CONFIG.satellites.amsat_tle?.enabled ?? true; // default true if undefined
+  const isSatnogsTleEnabled = CONFIG.satellites.satnogs_tle?.enabled ?? true; // default true if undefined
   logDebug('[Satellites] Space-Track enabled: ' + isSpaceTrackEnabled);
   logDebug('[Satellites] CelesTrak enabled: ' + isCelestrakEnabled);
+  logDebug('[Satellites] AMSAT TLE enabled: ' + isAmsatTleEnabled);
+  logDebug('[Satellites] SatNOGS TLE enabled: ' + isSatnogsTleEnabled);
 
   let blockCelesTrakUntil = Date.now() - 1; // Timestamp until which CelesTrak fetches are blocked due to rate limiting or ban
   let blockSpaceTrackUntil = Date.now() - 1; // Timestamp until which Space-Track fetches are blocked due to rate limiting or ban
@@ -968,7 +972,7 @@ module.exports = function (app, ctx) {
     CELESTRAK_INDIVIDUAL_INIT: async () => {
       if (blockCelesTrakUntil && Date.now() < blockCelesTrakUntil) {
         logDebug('[Satellites] Skipping CelesTrak fetch due to active backoff');
-        return 'AMSAT_INIT'; // fall through to fallback chain
+        return isAmsatTleEnabled ? 'AMSAT_INIT' : isSatnogsTleEnabled ? 'SATNOGS_INDIVIDUAL_INIT' : 'START'; // return next state
       }
 
       // loop until every eligible satellite has been attempted for download using CELESTRAK_INDIVIDUAL_FETCH state,
@@ -990,7 +994,7 @@ module.exports = function (app, ctx) {
         return 'CELESTRAK_INDIVIDUAL_FETCH'; // return next state
       }
 
-      return 'AMSAT_INIT'; // CelesTrak chain done — fall through to AMSAT/SatNOGS fallback
+      return isAmsatTleEnabled ? 'AMSAT_INIT' : isSatnogsTleEnabled ? 'SATNOGS_INDIVIDUAL_INIT' : 'START'; // CelesTrak chain done — fall through to AMSAT/SatNOGS fallback
     },
 
     CELESTRAK_INDIVIDUAL_FETCH: async () => {
@@ -1024,8 +1028,9 @@ module.exports = function (app, ctx) {
     // AMSAT fallback (covers amateur sats when CelesTrak is unreachable)
     AMSAT_INIT: async () => {
       if (blockAmsatUntil && Date.now() < blockAmsatUntil) {
-        return 'SATNOGS_INDIVIDUAL_INIT';
+        return isSatnogsTleEnabled ? 'SATNOGS_INDIVIDUAL_INIT' : 'START'; // return next state
       }
+
       // Only run if there are still stale satellites needing data
       const stillStale = Object.values(HAM_SATELLITES).filter((s) => isStale(s.ommTimestamp));
       if (stillStale.length === 0) return 'START';
@@ -1053,7 +1058,7 @@ module.exports = function (app, ctx) {
         const msg = ex?.message || String(ex ?? '(unknown error)');
         logWarn(`[Satellites] caught unknown exception in AMSAT_FETCH handler: ${msg}`);
       } finally {
-        return 'SATNOGS_INDIVIDUAL_INIT';
+        return isSatnogsTleEnabled ? 'SATNOGS_INDIVIDUAL_INIT' : 'START'; // return next state
       }
     },
 


### PR DESCRIPTION
## What does this PR do?

- provides enable / disable flags in `.env` for AMSAT TLE and SatNOGS TLE sources
- these backup sources are questionable data sources, they are only utilized as secondary sources when CelesTrak data source is enabled
- by default, both backup sources are enabled unless explicitly disabled in `.env`
- `.env.example` updated to include `AMSAT_TLE_ENABLED` and `SATNOGS_TLE_ENABLED` flags

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

in `.env`,
`CELESTRAK_ENABLED=true`
`AMSAT_TLE_ENABLED=false`
`SATNOGS_TLE_ENABLED=false`

## Checklist

- [X] App loads without console errors
- [X] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [X] No `.bak`, `.old`, `console.log` debug lines, or test scripts included
