### PR TITLE
fix(dxcluster): keep DXpedition spots through RBN volume + 1h retention option

### DIFF
--- a/server/routes/dxcluster.js
+++ b/server/routes/dxcluster.js
@@ -1116,6 +1116,17 @@ module.exports = function (app, ctx) {
   const dxSpotPathsCacheByKey = new Map();
   const DXPATHS_CACHE_TTL = 25000; // 25 seconds cache (just under 30s poll interval to maximize cache hits)
   const DXPATHS_RETENTION = 30 * 60 * 1000; // 30 minute spot retention
+  // DXpedition-tagged paths get longer retention and are exempt from display
+  // caps: under RBN skimmer volume (OHC Cluster source) the newest-100 window
+  // spans only a few minutes, which starved the dxpeditionsOnly filter of the
+  // handful of spots it exists to surface.
+  const DXPEDITION_RETENTION = 60 * 60 * 1000;
+  const isPathLive = (p, now) => now - p.timestamp < (p.isDXpedition ? DXPEDITION_RETENTION : DXPATHS_RETENTION);
+  const capWithDXpeditions = (paths, limit) => {
+    const dxpeditions = paths.filter((p) => p.isDXpedition);
+    const regular = paths.filter((p) => !p.isDXpedition).slice(0, limit);
+    return [...dxpeditions, ...regular].sort((a, b) => b.timestamp - a.timestamp);
+  };
   const DXPATHS_MAX_KEYS = 100; // Hard cap on cache keys
 
   // Periodic cleanup: purge stale dxSpotPaths entries every 5 minutes
@@ -1901,8 +1912,8 @@ module.exports = function (app, ctx) {
 
       if (newSpots.length === 0) {
         // Return existing paths if fetch failed
-        const validPaths = pathsCache.allPaths.filter((p) => now - p.timestamp < DXPATHS_RETENTION);
-        return res.json(validPaths.slice(0, 50));
+        const validPaths = pathsCache.allPaths.filter((p) => isPathLive(p, now));
+        return res.json(capWithDXpeditions(validPaths, 50));
       }
 
       // Get unique callsigns to look up (sanitize and strip modifiers)
@@ -2149,7 +2160,7 @@ module.exports = function (app, ctx) {
         .filter(Boolean);
 
       // Merge with existing paths, removing expired and duplicates
-      const existingValidPaths = pathsCache.allPaths.filter((p) => now - p.timestamp < DXPATHS_RETENTION);
+      const existingValidPaths = pathsCache.allPaths.filter((p) => isPathLive(p, now));
 
       // Add new paths, avoiding duplicates (same dxCall+freq within 2 minutes)
       const mergedPaths = [...existingValidPaths];
@@ -2161,7 +2172,10 @@ module.exports = function (app, ctx) {
       }
 
       // Sort by timestamp (newest first) and limit
-      const sortedPaths = mergedPaths.sort((a, b) => b.timestamp - a.timestamp).slice(0, 100);
+      const sortedPaths = capWithDXpeditions(
+        mergedPaths.sort((a, b) => b.timestamp - a.timestamp),
+        100,
+      );
 
       logDebug(
         '[DX Paths]',
@@ -2192,12 +2206,12 @@ module.exports = function (app, ctx) {
 
       // Update cache
       dxSpotPathsCacheByKey.set(cacheKey, {
-        paths: sortedPaths.slice(0, 50), // Return 50 for display
+        paths: capWithDXpeditions(sortedPaths, 50), // Return 50 for display
         allPaths: sortedPaths, // Keep all for accumulation
         timestamp: now,
       });
 
-      res.json(sortedPaths.slice(0, 50));
+      res.json(capWithDXpeditions(sortedPaths, 50));
     } catch (error) {
       logErrorOnce('DX Paths', error.message);
       // Return cached data on error

--- a/src/components/DXFilterManager.jsx
+++ b/src/components/DXFilterManager.jsx
@@ -959,7 +959,7 @@ export const DXFilterManager = ({ filters, onFilterChange, isOpen, onClose, onCl
             <input
               type="range"
               min="5"
-              max="30"
+              max="60"
               step="5"
               value={retentionMinutes}
               onChange={(e) => onFilterChange({ ...filters, spotRetentionMinutes: parseInt(e.target.value) })}
@@ -991,7 +991,7 @@ export const DXFilterManager = ({ filters, onFilterChange, isOpen, onClose, onCl
             }}
           >
             <span>5 min (freshest)</span>
-            <span>30 min (default)</span>
+            <span>60 min (longest)</span>
           </div>
         </div>
 
@@ -1000,7 +1000,7 @@ export const DXFilterManager = ({ filters, onFilterChange, isOpen, onClose, onCl
             Quick Presets
           </div>
           <div style={{ display: 'flex', gap: '8px' }}>
-            {[5, 10, 15, 20, 30].map((mins) => (
+            {[5, 10, 15, 20, 30, 60].map((mins) => (
               <button
                 key={mins}
                 onClick={() => onFilterChange({ ...filters, spotRetentionMinutes: mins })}

--- a/src/hooks/useDXClusterData.js
+++ b/src/hooks/useDXClusterData.js
@@ -93,8 +93,14 @@ export const useDXClusterData = (filters = {}, config = {}) => {
               (item) => now - (item.timestamp || now) < effectiveRetentionMs,
             );
 
-            // Sort by timestamp (newest first) and limit
-            return validItems.sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0)).slice(0, 200);
+            // Sort by timestamp (newest first) and limit. DXpedition-tagged
+            // spots are rare and exempt from the cap — under RBN skimmer
+            // volume 200 spots span minutes, which would evict them long
+            // before their retention expires.
+            const sorted = validItems.sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
+            const dxpeditions = sorted.filter((item) => item.isDXpedition);
+            const regular = sorted.filter((item) => !item.isDXpedition).slice(0, 200);
+            return [...dxpeditions, ...regular].sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
           });
 
           lastFetchRef.current = now;


### PR DESCRIPTION
Hotfix for the "Show only DXpeditions" filter showing zero spots on the hosted site.

**Root cause:** the paths cache keeps only the newest 100 spots (client pool: 200). With the OHC Cluster source ingesting full RBN skimmer feeds, those caps span ~4 minutes of traffic (measured live), so DXpedition-tagged spots — a few per hour — were evicted almost immediately, and the filter had nothing to show. The tagging itself works (verified against the live calendar: 29 entries loaded; TY5FR/OX3LX/3G0YT/6O6X active).

**Fix:** DXpedition-tagged paths are exempt from the display caps on both server and client, and get 60-minute retention server-side. Also adds a 60-minute option to the spot retention setting (slider max + preset).

**Verified** with a simulated RBN flood (300 spots in 6 min + two DXpedition spots aged 25/45 min): both survive the caps and appear in the response; a 65-minute-old one correctly expires. All 75 dxClusterFilters tests pass.

Cherry-pick of `ea0aa718` from Staging. Chris requested this port to production ahead of tonight's SFDXA talk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)