### PR TITLE
[fix] `.env.example` minor update - follow up to 1105

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -188,10 +188,10 @@ LAYOUT=modern
 CELESTRAK_ENABLED=true
 # AMSAT TLE data source is enabled by default, no username or password is needed.
 # AMSAT TLE can be disabled by setting AMSAT_TLE_ENABLED=false, but it is recommended to keep it enabled as a backup source.
-#AMSAT_TLE_ENABLED=true
+AMSAT_TLE_ENABLED=true
 # SATNOGS TLE data source is enabled by default, no username or password is needed.
 # SATNOGS TLE can be disabled by setting SATNOGS_TLE_ENABLED=false, but it is recommended to keep it enabled as a backup source.
-#SATNOGS_TLE_ENABLED=true
+SATNOGS_TLE_ENABLED=true
 # Space-Track.org is disabled by default, but can be enabled by providing a valid username and password.
 # To enable both username and password fields must be active.
 # When enabled Space-Track.org becomes primary data source for satellite data with CelesTrak as backup.


### PR DESCRIPTION
- follow-up from https://github.com/accius/openhamclock/pull/1105
- minor update to remove comment markers in `.env.example`


