### PR TITLE
feat(callsign): per-user QRZ/HamQTH credentials on shared instances

### DIFF
--- a/server/routes/callsign.js
+++ b/server/routes/callsign.js
@@ -3,6 +3,7 @@
  * Lines ~4194-6094 of original server.js
  */
 
+const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const { lookupCall } = require('../../src/server/ctydat.js');
@@ -234,29 +235,32 @@ module.exports = function (app, ctx) {
   }
   loadQRZCredentials();
 
-  function isQRZConfigured() {
-    return !!(qrzSession.username && qrzSession.password);
+  // All QRZ session functions take a session object so the same code serves
+  // both the instance credentials (default) and per-user credentials sent
+  // from the browser on the hosted site.
+  function isQRZConfigured(session = qrzSession) {
+    return !!(session.username && session.password);
   }
 
   // Login to QRZ XML API and obtain a session key
-  async function qrzLogin() {
-    if (!isQRZConfigured()) return null;
+  async function qrzLogin(session = qrzSession) {
+    if (!isQRZConfigured(session)) return null;
 
     // Don't retry if credentials failed recently — avoids hammering QRZ with bad creds
-    if (Date.now() < qrzSession.authFailedUntil) {
+    if (Date.now() < session.authFailedUntil) {
       return null;
     }
 
     // Dedup: if a login is already in-flight, piggyback on it
-    if (qrzSession.loginInFlight) return qrzSession.loginInFlight;
+    if (session.loginInFlight) return session.loginInFlight;
 
-    qrzSession.loginInFlight = (async () => {
+    session.loginInFlight = (async () => {
       try {
-        const url = `https://xmldata.qrz.com/xml/current/?username=${encodeURIComponent(qrzSession.username)};password=${encodeURIComponent(qrzSession.password)};agent=OpenHamClock/${APP_VERSION}`;
+        const url = `https://xmldata.qrz.com/xml/current/?username=${encodeURIComponent(session.username)};password=${encodeURIComponent(session.password)};agent=OpenHamClock/${APP_VERSION}`;
         const response = await fetch(url, { signal: AbortSignal.timeout(10000) });
 
         if (!response.ok) {
-          qrzSession.lastError = `HTTP ${response.status}`;
+          session.lastError = `HTTP ${response.status}`;
           return null;
         }
 
@@ -268,14 +272,14 @@ module.exports = function (app, ctx) {
         const subExpMatch = xml.match(/<SubExp>([^<]+)<\/SubExp>/);
 
         if (errorMatch) {
-          qrzSession.lastError = errorMatch[1];
+          session.lastError = errorMatch[1];
           // Credential failures get a long cooldown — no point retrying until creds change
           if (
             errorMatch[1].includes('incorrect') ||
             errorMatch[1].includes('Invalid') ||
             errorMatch[1].includes('denied')
           ) {
-            qrzSession.authFailedUntil = Date.now() + qrzSession.authFailCooldown;
+            session.authFailedUntil = Date.now() + session.authFailCooldown;
             console.error(`[QRZ] Login failed: ${errorMatch[1]} — suppressing retries for 1 hour`);
           } else {
             console.error(`[QRZ] Login failed: ${errorMatch[1]}`);
@@ -284,46 +288,46 @@ module.exports = function (app, ctx) {
         }
 
         if (keyMatch) {
-          qrzSession.key = keyMatch[1];
-          qrzSession.expiry = Date.now() + qrzSession.maxAge;
-          qrzSession.lastError = null;
-          qrzSession.authFailedUntil = 0; // Clear cooldown on success
+          session.key = keyMatch[1];
+          session.expiry = Date.now() + session.maxAge;
+          session.lastError = null;
+          session.authFailedUntil = 0; // Clear cooldown on success
           const subInfo = subExpMatch ? subExpMatch[1] : 'unknown';
           console.log(`[QRZ] Session established (subscription: ${subInfo})`);
-          return qrzSession.key;
+          return session.key;
         }
 
-        qrzSession.lastError = 'No session key in response';
+        session.lastError = 'No session key in response';
         return null;
       } catch (err) {
         if (err.name !== 'AbortError') {
-          qrzSession.lastError = err.message;
+          session.lastError = err.message;
           logErrorOnce('QRZ', `Login error: ${err.message}`);
         }
         return null;
       } finally {
-        qrzSession.loginInFlight = null;
+        session.loginInFlight = null;
       }
     })();
 
-    return qrzSession.loginInFlight;
+    return session.loginInFlight;
   }
 
   // Get a valid QRZ session key (login if needed)
-  async function getQRZSessionKey() {
-    if (!isQRZConfigured()) return null;
+  async function getQRZSessionKey(session = qrzSession) {
+    if (!isQRZConfigured(session)) return null;
 
     // Reuse existing key if still fresh
-    if (qrzSession.key && Date.now() < qrzSession.expiry) {
-      return qrzSession.key;
+    if (session.key && Date.now() < session.expiry) {
+      return session.key;
     }
 
-    return qrzLogin();
+    return qrzLogin(session);
   }
 
   // Look up a callsign via QRZ XML API — returns rich data including geoloc source
-  async function qrzLookup(callsign) {
-    const sessionKey = await getQRZSessionKey();
+  async function qrzLookup(callsign, session = qrzSession) {
+    const sessionKey = await getQRZSessionKey(session);
     if (!sessionKey) return null;
 
     try {
@@ -340,11 +344,11 @@ module.exports = function (app, ctx) {
         const err = errorMatch[1];
         if (err.includes('Session') || err.includes('Invalid session')) {
           // Session expired — force re-login and retry
-          qrzSession.key = null;
-          qrzSession.expiry = 0;
-          const newKey = await qrzLogin();
+          session.key = null;
+          session.expiry = 0;
+          const newKey = await qrzLogin(session);
           if (newKey) {
-            return qrzLookup(callsign); // Retry with new key (recursive, max 1 deep)
+            return qrzLookup(callsign, session); // Retry with new key (recursive, max 1 deep)
           }
         }
         // "Not found" is not an error we need to log
@@ -365,7 +369,7 @@ module.exports = function (app, ctx) {
 
       if (!lat || !lon) return null;
 
-      qrzSession.lookupCount++;
+      session.lookupCount++;
 
       const result = {
         callsign: get('call') || callsign,
@@ -436,29 +440,31 @@ module.exports = function (app, ctx) {
   }
   loadHamQTHCredentials();
 
-  function isHamQTHConfigured() {
-    return !!(hamqthSession.username && hamqthSession.password);
+  // Like the QRZ functions above, these take a session object so per-user
+  // credentials from the hosted site reuse the same login/lookup code.
+  function isHamQTHConfigured(session = hamqthSession) {
+    return !!(session.username && session.password);
   }
 
   // Login to HamQTH XML API and obtain a session ID
-  async function hamqthLogin() {
-    if (!isHamQTHConfigured()) return null;
+  async function hamqthLogin(session = hamqthSession) {
+    if (!isHamQTHConfigured(session)) return null;
 
     // Don't retry if credentials failed recently
-    if (Date.now() < hamqthSession.authFailedUntil) {
+    if (Date.now() < session.authFailedUntil) {
       return null;
     }
 
     // Dedup: if a login is already in-flight, piggyback on it
-    if (hamqthSession.loginInFlight) return hamqthSession.loginInFlight;
+    if (session.loginInFlight) return session.loginInFlight;
 
-    hamqthSession.loginInFlight = (async () => {
+    session.loginInFlight = (async () => {
       try {
-        const url = `https://www.hamqth.com/xml.php?u=${encodeURIComponent(hamqthSession.username)}&p=${encodeURIComponent(hamqthSession.password)}`;
+        const url = `https://www.hamqth.com/xml.php?u=${encodeURIComponent(session.username)}&p=${encodeURIComponent(session.password)}`;
         const response = await fetch(url, { signal: AbortSignal.timeout(10000) });
 
         if (!response.ok) {
-          hamqthSession.lastError = `HTTP ${response.status}`;
+          session.lastError = `HTTP ${response.status}`;
           return null;
         }
 
@@ -467,13 +473,13 @@ module.exports = function (app, ctx) {
         // Check for error first (HamQTH wraps errors in <session>)
         const errorMatch = xml.match(/<error>([^<]+)<\/error>/);
         if (errorMatch) {
-          hamqthSession.lastError = errorMatch[1];
+          session.lastError = errorMatch[1];
           if (
             errorMatch[1].includes('incorrect') ||
             errorMatch[1].includes('Wrong') ||
             errorMatch[1].includes('denied')
           ) {
-            hamqthSession.authFailedUntil = Date.now() + hamqthSession.authFailCooldown;
+            session.authFailedUntil = Date.now() + session.authFailCooldown;
             console.error(`[HamQTH] Login failed: ${errorMatch[1]} — suppressing retries for 1 hour`);
           } else {
             console.error(`[HamQTH] Login failed: ${errorMatch[1]}`);
@@ -484,45 +490,45 @@ module.exports = function (app, ctx) {
         // Parse session ID
         const idMatch = xml.match(/<session_id>([^<]+)<\/session_id>/);
         if (idMatch) {
-          hamqthSession.id = idMatch[1];
-          hamqthSession.expiry = Date.now() + hamqthSession.maxAge;
-          hamqthSession.lastError = null;
-          hamqthSession.authFailedUntil = 0;
+          session.id = idMatch[1];
+          session.expiry = Date.now() + session.maxAge;
+          session.lastError = null;
+          session.authFailedUntil = 0;
           console.log('[HamQTH] Session established');
-          return hamqthSession.id;
+          return session.id;
         }
 
-        hamqthSession.lastError = 'No session ID in response';
+        session.lastError = 'No session ID in response';
         return null;
       } catch (err) {
         if (err.name !== 'AbortError') {
-          hamqthSession.lastError = err.message;
+          session.lastError = err.message;
           logErrorOnce('HamQTH', `Login error: ${err.message}`);
         }
         return null;
       } finally {
-        hamqthSession.loginInFlight = null;
+        session.loginInFlight = null;
       }
     })();
 
-    return hamqthSession.loginInFlight;
+    return session.loginInFlight;
   }
 
   // Get a valid HamQTH session ID (login if needed)
-  async function getHamQTHSessionId() {
-    if (!isHamQTHConfigured()) return null;
+  async function getHamQTHSessionId(session = hamqthSession) {
+    if (!isHamQTHConfigured(session)) return null;
 
     // Reuse existing key if still fresh
-    if (hamqthSession.id && Date.now() < hamqthSession.expiry) {
-      return hamqthSession.id;
+    if (session.id && Date.now() < session.expiry) {
+      return session.id;
     }
 
-    return hamqthLogin();
+    return hamqthLogin(session);
   }
 
   // Look up a callsign via HamQTH XML Search API — returns rich data
-  async function hamqthXmlSearch(callsign) {
-    const sessionId = await getHamQTHSessionId();
+  async function hamqthXmlSearch(callsign, session = hamqthSession) {
+    const sessionId = await getHamQTHSessionId(session);
     if (!sessionId) return null;
 
     try {
@@ -539,11 +545,11 @@ module.exports = function (app, ctx) {
         const err = errorMatch[1];
         if (err.includes('Session') || err.includes('expired') || err.includes('does not exist')) {
           // Session expired — force re-login and retry
-          hamqthSession.id = null;
-          hamqthSession.expiry = 0;
-          const newId = await hamqthLogin();
+          session.id = null;
+          session.expiry = 0;
+          const newId = await hamqthLogin(session);
           if (newId) {
-            return hamqthXmlSearch(callsign); // Retry with new session (recursive, max 1 deep)
+            return hamqthXmlSearch(callsign, session); // Retry with new session (recursive, max 1 deep)
           }
         }
         // "Callsign not found" is not an error we need to log
@@ -595,6 +601,90 @@ module.exports = function (app, ctx) {
       return null;
     }
   }
+
+  // ── Per-user callbook sessions (hosted multi-user support) ──
+  // Users may send their own QRZ / HamQTH credentials from the browser
+  // (X-QRZ-Auth / X-HamQTH-Auth headers, base64 "username:password").
+  // Sessions live only in memory, keyed by a credential hash, and lookup
+  // results are cached under the same hash so one subscriber's callbook data
+  // is never served to anyone else (QRZ terms: the account is personal).
+  const userCallbookSessions = new Map(); // credHash -> session object
+  const USER_CALLBOOK_SESSION_MAX = 500; // LRU cap on distinct credential sets
+
+  function makeUserCallbookSession(username, password) {
+    return {
+      key: null, // QRZ session key
+      id: null, // HamQTH session id
+      expiry: 0,
+      maxAge: 3600000,
+      username,
+      password,
+      loginInFlight: null,
+      lookupCount: 0,
+      lastError: null,
+      authFailedUntil: 0,
+      authFailCooldown: 60 * 60 * 1000,
+      lastUsed: Date.now(),
+    };
+  }
+
+  function getUserCallbookSession(provider, username, password) {
+    const hash = crypto.createHash('sha256').update(`${provider}\0${username}\0${password}`).digest('hex').slice(0, 32);
+    let session = userCallbookSessions.get(hash);
+    if (!session) {
+      if (userCallbookSessions.size >= USER_CALLBOOK_SESSION_MAX) {
+        let oldestKey = null;
+        let oldestUsed = Infinity;
+        for (const [k, v] of userCallbookSessions) {
+          if (v.lastUsed < oldestUsed) {
+            oldestUsed = v.lastUsed;
+            oldestKey = k;
+          }
+        }
+        userCallbookSessions.delete(oldestKey);
+      }
+      session = makeUserCallbookSession(username, password);
+      userCallbookSessions.set(hash, session);
+    }
+    session.lastUsed = Date.now();
+    return { session, hash };
+  }
+
+  // Parse an X-QRZ-Auth / X-HamQTH-Auth header value: base64("username:password")
+  function parseCallbookAuthHeader(value) {
+    if (!value || typeof value !== 'string' || value.length > 400) return null;
+    let decoded;
+    try {
+      decoded = Buffer.from(value, 'base64').toString('utf8');
+    } catch {
+      return null;
+    }
+    const sep = decoded.indexOf(':');
+    if (sep < 1) return null;
+    const username = decoded.slice(0, sep).trim();
+    const password = decoded.slice(sep + 1);
+    if (!username || !password || username.length > 64 || password.length > 128) return null;
+    return { username, password };
+  }
+
+  // Verify user-supplied callbook credentials without persisting them.
+  // Logs in with a per-user in-memory session; the browser stores the
+  // credentials locally and sends them on subsequent lookups.
+  app.post('/api/callsign/verify-credentials', writeLimiter, async (req, res) => {
+    const { provider, username, password } = req.body || {};
+    if ((provider !== 'qrz' && provider !== 'hamqth') || typeof username !== 'string' || typeof password !== 'string') {
+      return res.status(400).json({ error: 'provider (qrz|hamqth), username, and password are required' });
+    }
+    const user = username.trim();
+    if (!user || !password || user.length > 64 || password.length > 128) {
+      return res.status(400).json({ error: 'Invalid credentials format' });
+    }
+    const { session } = getUserCallbookSession(provider, user, password);
+    session.authFailedUntil = 0; // user just (re)entered these — try now
+    const token = provider === 'qrz' ? await qrzLogin(session) : await hamqthLogin(session);
+    if (token) return res.json({ success: true });
+    res.json({ success: false, error: session.lastError || 'Login failed' });
+  });
 
   // Look up via HamQTH DXCC JSON API (no auth, but only DXCC-level accuracy)
   async function hamqthLookup(callsign, _retried = false) {
@@ -848,8 +938,28 @@ module.exports = function (app, ctx) {
     // Extract base callsign: 5Z4/OZ6ABL → OZ6ABL, UA1TAN/M → UA1TAN
     const callsign = extractBaseCallsign(rawCallsign);
 
+    // Per-user callbook credentials (hosted): the user's own QRZ/HamQTH
+    // account serves their lookups. Results are cached per credential hash —
+    // an authenticated result must never be served to a different user.
+    const userQrzCreds = parseCallbookAuthHeader(req.headers['x-qrz-auth']);
+    const userHamqthCreds = parseCallbookAuthHeader(req.headers['x-hamqth-auth']);
+    let cacheSuffix = '';
+    let userQrzSession = null;
+    let userHamqthSession = null;
+    if (userQrzCreds) {
+      const { session, hash } = getUserCallbookSession('qrz', userQrzCreds.username, userQrzCreds.password);
+      userQrzSession = session;
+      cacheSuffix += `:q${hash}`;
+    }
+    if (userHamqthCreds) {
+      const { session, hash } = getUserCallbookSession('hamqth', userHamqthCreds.username, userHamqthCreds.password);
+      userHamqthSession = session;
+      cacheSuffix += `:h${hash}`;
+    }
+
     // Check cache first (check both raw and base forms)
-    const cached = callsignLookupCache.get(callsign) || callsignLookupCache.get(rawCallsign);
+    const cached =
+      callsignLookupCache.get(callsign + cacheSuffix) || callsignLookupCache.get(rawCallsign + cacheSuffix);
     if (cached && now - cached.timestamp < CALLSIGN_CACHE_TTL) {
       logDebug('[Callsign Lookup] Cache hit for:', callsign);
       return res.json(cached.data);
@@ -868,22 +978,32 @@ module.exports = function (app, ctx) {
     try {
       let result = null;
 
-      // 1. Try QRZ XML API (most accurate — user-supplied coords, geocoded, or grid-derived)
-      if (isQRZConfigured()) {
+      // 1. User-supplied QRZ credentials (their own subscription, sent from the browser)
+      if (userQrzSession) {
+        result = await qrzLookup(callsign, userQrzSession);
+      }
+
+      // 2. User-supplied HamQTH credentials
+      if (!result && userHamqthSession) {
+        result = await hamqthXmlSearch(callsign, userHamqthSession);
+      }
+
+      // 3. Instance QRZ XML API (most accurate — user-supplied coords, geocoded, or grid-derived)
+      if (!result && isQRZConfigured()) {
         result = await qrzLookup(callsign);
       }
 
-      // 2. Try HamQTH XML Search (if configured) — rich data with accurate coords
+      // 4. Instance HamQTH XML Search (if configured) — rich data with accurate coords
       if (!result && isHamQTHConfigured()) {
         result = await hamqthXmlSearch(callsign);
       }
 
-      // 3. Fall back to HamQTH DXCC (no auth, but only country-level accuracy)
+      // 5. Fall back to HamQTH DXCC (no auth, but only country-level accuracy)
       if (!result) {
         result = await hamqthLookup(callsign);
       }
 
-      // 4. Last resort: estimate from callsign prefix
+      // 6. Last resort: estimate from callsign prefix
       if (!result) {
         const estimated = estimateLocationFromPrefix(callsign);
         if (estimated) {
@@ -895,7 +1015,7 @@ module.exports = function (app, ctx) {
         logDebug(
           `[Callsign Lookup] ${callsign}: ${result.source} -> ${result.lat?.toFixed(2)}, ${result.lon?.toFixed(2)}`,
         );
-        cacheCallsignLookup(callsign, { data: result, timestamp: now });
+        cacheCallsignLookup(callsign + cacheSuffix, { data: result, timestamp: now });
         return res.json(result);
       }
 

--- a/server/routes/callsign.js
+++ b/server/routes/callsign.js
@@ -628,8 +628,20 @@ module.exports = function (app, ctx) {
     };
   }
 
-  function getUserCallbookSession(provider, username, password) {
-    const hash = crypto.createHash('sha256').update(`${provider}\0${username}\0${password}`).digest('hex').slice(0, 32);
+  // Derive the session/cache key with scrypt (async — runs on the libuv
+  // thread pool, not the event loop). The key partitions the in-memory
+  // session map and lookup cache per credential set; using a real password
+  // KDF means the key never weakens the password it was derived from.
+  function deriveCallbookKey(provider, username, password) {
+    return new Promise((resolve, reject) => {
+      crypto.scrypt(password, `ohc-callbook:${provider}:${username.toLowerCase()}`, 24, (err, buf) =>
+        err ? reject(err) : resolve(buf.toString('hex')),
+      );
+    });
+  }
+
+  async function getUserCallbookSession(provider, username, password) {
+    const hash = await deriveCallbookKey(provider, username, password);
     let session = userCallbookSessions.get(hash);
     if (!session) {
       if (userCallbookSessions.size >= USER_CALLBOOK_SESSION_MAX) {
@@ -679,11 +691,15 @@ module.exports = function (app, ctx) {
     if (!user || !password || user.length > 64 || password.length > 128) {
       return res.status(400).json({ error: 'Invalid credentials format' });
     }
-    const { session } = getUserCallbookSession(provider, user, password);
-    session.authFailedUntil = 0; // user just (re)entered these — try now
-    const token = provider === 'qrz' ? await qrzLogin(session) : await hamqthLogin(session);
-    if (token) return res.json({ success: true });
-    res.json({ success: false, error: session.lastError || 'Login failed' });
+    try {
+      const { session } = await getUserCallbookSession(provider, user, password);
+      session.authFailedUntil = 0; // user just (re)entered these — try now
+      const token = provider === 'qrz' ? await qrzLogin(session) : await hamqthLogin(session);
+      if (token) return res.json({ success: true });
+      res.json({ success: false, error: session.lastError || 'Login failed' });
+    } catch {
+      res.status(500).json({ error: 'Verification failed' });
+    }
   });
 
   // Look up via HamQTH DXCC JSON API (no auth, but only DXCC-level accuracy)
@@ -946,15 +962,26 @@ module.exports = function (app, ctx) {
     let cacheSuffix = '';
     let userQrzSession = null;
     let userHamqthSession = null;
-    if (userQrzCreds) {
-      const { session, hash } = getUserCallbookSession('qrz', userQrzCreds.username, userQrzCreds.password);
-      userQrzSession = session;
-      cacheSuffix += `:q${hash}`;
-    }
-    if (userHamqthCreds) {
-      const { session, hash } = getUserCallbookSession('hamqth', userHamqthCreds.username, userHamqthCreds.password);
-      userHamqthSession = session;
-      cacheSuffix += `:h${hash}`;
+    try {
+      if (userQrzCreds) {
+        const { session, hash } = await getUserCallbookSession('qrz', userQrzCreds.username, userQrzCreds.password);
+        userQrzSession = session;
+        cacheSuffix += `:q${hash}`;
+      }
+      if (userHamqthCreds) {
+        const { session, hash } = await getUserCallbookSession(
+          'hamqth',
+          userHamqthCreds.username,
+          userHamqthCreds.password,
+        );
+        userHamqthSession = session;
+        cacheSuffix += `:h${hash}`;
+      }
+    } catch {
+      // Key derivation failed — proceed as an unauthenticated lookup
+      userQrzSession = null;
+      userHamqthSession = null;
+      cacheSuffix = '';
     }
 
     // Check cache first (check both raw and base forms)

--- a/src/components/DXCallsignInput.jsx
+++ b/src/components/DXCallsignInput.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useId } from 'react';
+import { callbookAuthHeaders } from '../utils/callbookAuth.js';
 
 /**
  * Editable callsign field for the DX target section.
@@ -48,6 +49,7 @@ export function DXCallsignInput({ dxCallsign, onDXChange, dxLocked, style }) {
 
     try {
       const res = await fetch(`/api/callsign/${encodeURIComponent(trimmed)}`, {
+        headers: callbookAuthHeaders(),
         signal: controller.signal,
       });
 

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -24,6 +24,7 @@ import CustomThemeEditor from './CustomThemeEditor';
 import { emojiToIso2 } from '../utils/countryFlags';
 import { getAlertSettings, saveAlertSettings, playTone, TONE_PRESETS, ALERT_FEEDS } from '../utils/audioAlerts';
 import { setRelaySessionId, setRelayConfigured, clearRelaySession } from '../utils/relaySession';
+import { getCallbookCredentials, setCallbookCredentials } from '../utils/callbookAuth.js';
 import { CALLBOOKS, getCallbook } from '../utils/callbook.js';
 
 export const SettingsPanel = ({
@@ -227,14 +228,17 @@ export const SettingsPanel = ({
   const fileInputRef = useRef(null);
 
   // QRZ API state
-  const [qrzUsername, setQrzUsername] = useState('');
+  const [qrzUsername, setQrzUsername] = useState(() => getCallbookCredentials().qrzUsername || '');
   const [qrzPassword, setQrzPassword] = useState('');
+  // Per-browser callbook credentials (hosted instances) — see utils/callbookAuth.js
+  const [personalQrz, setPersonalQrz] = useState(() => !!getCallbookCredentials().qrzUsername);
+  const [personalHamqth, setPersonalHamqth] = useState(() => !!getCallbookCredentials().hamqthUsername);
   const [qrzStatus, setQrzStatus] = useState(null); // { configured, hasSession, source, ... }
   const [qrzTesting, setQrzTesting] = useState(false);
   const [qrzMessage, setQrzMessage] = useState(null); // { type: 'success'|'error', text }
 
   // HamQTH XML Search API state
-  const [hamqthUsername, setHamqthUsername] = useState('');
+  const [hamqthUsername, setHamqthUsername] = useState(() => getCallbookCredentials().hamqthUsername || '');
   const [hamqthPassword, setHamqthPassword] = useState('');
   const [hamqthStatus, setHamqthStatus] = useState(null); // { configured, hasSession, source, ... }
   const [hamqthTesting, setHamqthTesting] = useState(false);
@@ -3226,6 +3230,20 @@ export const SettingsPanel = ({
                     }}
                   >
                     <span>📻 QRZ.com Callsign Lookup</span>
+                    {!isLocalInstall && personalQrz && (
+                      <span
+                        style={{
+                          fontSize: '10px',
+                          fontWeight: '500',
+                          padding: '1px 6px',
+                          borderRadius: '3px',
+                          background: 'rgba(46, 204, 113, 0.15)',
+                          color: '#2ecc71',
+                        }}
+                      >
+                        ● Your login (this browser)
+                      </span>
+                    )}
                     {qrzStatus?.configured && (
                       <span
                         style={{
@@ -3255,8 +3273,10 @@ export const SettingsPanel = ({
                     user profiles (user-supplied coordinates, geocoded addresses, grid squares). Without this, locations
                     fall back to HamQTH (country-level only). Requires a QRZ Logbook Data subscription.
                     <br />
-                    <strong>Note</strong> this is a server setting and is not related to clicking a callsign to go to
-                    qrz.com. If you are not running a server, you will likely not have the permissions to change this.
+                    <strong>Note</strong>{' '}
+                    {isLocalInstall
+                      ? 'this is a server setting and is not related to clicking a callsign to go to qrz.com.'
+                      : 'on this shared instance, your QRZ login is stored only in this browser and used only for your own lookups — it is never saved on the server.'}
                   </div>
                   {qrzStatus?.source === 'env' ? (
                     <div
@@ -3288,7 +3308,6 @@ export const SettingsPanel = ({
                     <>
                       <div style={{ display: 'flex', gap: '8px', marginBottom: '8px' }}>
                         <input
-                          disabled={!isLocalInstall}
                           type="text"
                           placeholder="QRZ Username (callsign)"
                           value={qrzUsername}
@@ -3306,7 +3325,6 @@ export const SettingsPanel = ({
                           }}
                         />
                         <input
-                          disabled={!isLocalInstall}
                           type="password"
                           placeholder="QRZ Password"
                           value={qrzPassword}
@@ -3326,25 +3344,55 @@ export const SettingsPanel = ({
                       </div>
                       <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
                         <button
-                          disabled={!isLocalInstall || qrzTesting || !qrzUsername.trim() || !qrzPassword.trim()}
+                          disabled={qrzTesting || !qrzUsername.trim() || !qrzPassword.trim()}
                           onClick={async () => {
                             setQrzTesting(true);
                             setQrzMessage(null);
                             try {
-                              const res = await fetch('/api/qrz/configure', {
-                                method: 'POST',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ username: qrzUsername.trim(), password: qrzPassword.trim() }),
-                              });
-                              const data = await res.json();
-                              if (data.success) {
-                                setQrzMessage({ type: 'success', text: 'Connected to QRZ.com successfully!' });
-                                setQrzPassword('');
-                                // Refresh status
-                                const st = await fetch('/api/qrz/status').then((r) => r.json());
-                                setQrzStatus(st);
+                              if (!isLocalInstall) {
+                                // Shared/hosted instance: verify against QRZ, then keep the
+                                // credentials in this browser only (see utils/callbookAuth.js)
+                                const res = await fetch('/api/callsign/verify-credentials', {
+                                  method: 'POST',
+                                  headers: { 'Content-Type': 'application/json' },
+                                  body: JSON.stringify({
+                                    provider: 'qrz',
+                                    username: qrzUsername.trim(),
+                                    password: qrzPassword,
+                                  }),
+                                });
+                                const data = await res.json();
+                                if (data.success) {
+                                  setCallbookCredentials({
+                                    ...getCallbookCredentials(),
+                                    qrzUsername: qrzUsername.trim(),
+                                    qrzPassword,
+                                  });
+                                  setPersonalQrz(true);
+                                  setQrzPassword('');
+                                  setQrzMessage({
+                                    type: 'success',
+                                    text: 'Verified — stored in this browser only, used only for your lookups.',
+                                  });
+                                } else {
+                                  setQrzMessage({ type: 'error', text: data.error || 'Login failed' });
+                                }
                               } else {
-                                setQrzMessage({ type: 'error', text: data.error || 'Login failed' });
+                                const res = await fetch('/api/qrz/configure', {
+                                  method: 'POST',
+                                  headers: { 'Content-Type': 'application/json' },
+                                  body: JSON.stringify({ username: qrzUsername.trim(), password: qrzPassword.trim() }),
+                                });
+                                const data = await res.json();
+                                if (data.success) {
+                                  setQrzMessage({ type: 'success', text: 'Connected to QRZ.com successfully!' });
+                                  setQrzPassword('');
+                                  // Refresh status
+                                  const st = await fetch('/api/qrz/status').then((r) => r.json());
+                                  setQrzStatus(st);
+                                } else {
+                                  setQrzMessage({ type: 'error', text: data.error || 'Login failed' });
+                                }
                               }
                             } catch (e) {
                               setQrzMessage({ type: 'error', text: 'Connection error' });
@@ -3366,9 +3414,21 @@ export const SettingsPanel = ({
                         >
                           {qrzTesting ? 'Testing...' : 'Save & Test'}
                         </button>
-                        {qrzStatus?.configured && qrzStatus.source !== 'env' && (
+                        {((qrzStatus?.configured && qrzStatus.source !== 'env') ||
+                          (!isLocalInstall && personalQrz)) && (
                           <button
                             onClick={async () => {
+                              if (!isLocalInstall) {
+                                const creds = getCallbookCredentials();
+                                delete creds.qrzUsername;
+                                delete creds.qrzPassword;
+                                setCallbookCredentials(creds);
+                                setPersonalQrz(false);
+                                setQrzUsername('');
+                                setQrzPassword('');
+                                setQrzMessage(null);
+                                return;
+                              }
                               await fetch('/api/qrz/remove', { method: 'POST' });
                               setQrzUsername('');
                               setQrzPassword('');
@@ -3434,6 +3494,20 @@ export const SettingsPanel = ({
                     }}
                   >
                     <span>📡 HamQTH Callsign Lookup</span>
+                    {!isLocalInstall && personalHamqth && (
+                      <span
+                        style={{
+                          fontSize: '10px',
+                          fontWeight: '500',
+                          padding: '1px 6px',
+                          borderRadius: '3px',
+                          background: 'rgba(46, 204, 113, 0.15)',
+                          color: '#2ecc71',
+                        }}
+                      >
+                        ● Your login (this browser)
+                      </span>
+                    )}
                     {hamqthStatus?.configured && (
                       <span
                         style={{
@@ -3461,11 +3535,12 @@ export const SettingsPanel = ({
                       HamQTH.com
                     </a>{' '}
                     user profiles (names, user-supplied details, grid squares). Without this, data falls back to the
-                    simple HamQTH DXCC API.
+                    simple HamQTH DXCC API. A free HamQTH account is all you need.
                     <br />
-                    <strong>Note</strong> this is a server setting and is related to the extra data in popup shown when
-                    clicking callsigns. If you are not running a server, you will likely not have the permissions to
-                    change this.
+                    <strong>Note</strong>{' '}
+                    {isLocalInstall
+                      ? 'this is a server setting and is related to the extra data in popup shown when clicking callsigns.'
+                      : 'on this shared instance, your HamQTH login is stored only in this browser and used only for your own lookups — it is never saved on the server.'}
                   </div>
                   {hamqthStatus?.source === 'env' ? (
                     <div
@@ -3491,7 +3566,6 @@ export const SettingsPanel = ({
                     <>
                       <div style={{ display: 'flex', gap: '8px', marginBottom: '8px' }}>
                         <input
-                          disabled={!isLocalInstall}
                           type="text"
                           placeholder="HamQTH Username (callsign)"
                           value={hamqthUsername}
@@ -3509,7 +3583,6 @@ export const SettingsPanel = ({
                           }}
                         />
                         <input
-                          disabled={!isLocalInstall}
                           type="password"
                           placeholder="HamQTH Password"
                           value={hamqthPassword}
@@ -3529,29 +3602,57 @@ export const SettingsPanel = ({
                       </div>
                       <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
                         <button
-                          disabled={
-                            !isLocalInstall || hamqthTesting || !hamqthUsername.trim() || !hamqthPassword.trim()
-                          }
+                          disabled={hamqthTesting || !hamqthUsername.trim() || !hamqthPassword.trim()}
                           onClick={async () => {
                             setHamqthTesting(true);
                             setHamqthMessage(null);
                             try {
-                              const res = await fetch('/api/hamqth/configure', {
-                                method: 'POST',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({
-                                  username: hamqthUsername.trim(),
-                                  password: hamqthPassword.trim(),
-                                }),
-                              });
-                              const data = await res.json();
-                              if (data.success) {
-                                setHamqthMessage({ type: 'success', text: 'Connected to HamQTH successfully!' });
-                                setHamqthPassword('');
-                                const st = await fetch('/api/hamqth/status').then((r) => r.json());
-                                setHamqthStatus(st);
+                              if (!isLocalInstall) {
+                                // Shared/hosted instance: verify against HamQTH, then keep the
+                                // credentials in this browser only (see utils/callbookAuth.js)
+                                const res = await fetch('/api/callsign/verify-credentials', {
+                                  method: 'POST',
+                                  headers: { 'Content-Type': 'application/json' },
+                                  body: JSON.stringify({
+                                    provider: 'hamqth',
+                                    username: hamqthUsername.trim(),
+                                    password: hamqthPassword,
+                                  }),
+                                });
+                                const data = await res.json();
+                                if (data.success) {
+                                  setCallbookCredentials({
+                                    ...getCallbookCredentials(),
+                                    hamqthUsername: hamqthUsername.trim(),
+                                    hamqthPassword,
+                                  });
+                                  setPersonalHamqth(true);
+                                  setHamqthPassword('');
+                                  setHamqthMessage({
+                                    type: 'success',
+                                    text: 'Verified — stored in this browser only, used only for your lookups.',
+                                  });
+                                } else {
+                                  setHamqthMessage({ type: 'error', text: data.error || 'Login failed' });
+                                }
                               } else {
-                                setHamqthMessage({ type: 'error', text: data.error || 'Login failed' });
+                                const res = await fetch('/api/hamqth/configure', {
+                                  method: 'POST',
+                                  headers: { 'Content-Type': 'application/json' },
+                                  body: JSON.stringify({
+                                    username: hamqthUsername.trim(),
+                                    password: hamqthPassword.trim(),
+                                  }),
+                                });
+                                const data = await res.json();
+                                if (data.success) {
+                                  setHamqthMessage({ type: 'success', text: 'Connected to HamQTH successfully!' });
+                                  setHamqthPassword('');
+                                  const st = await fetch('/api/hamqth/status').then((r) => r.json());
+                                  setHamqthStatus(st);
+                                } else {
+                                  setHamqthMessage({ type: 'error', text: data.error || 'Login failed' });
+                                }
                               }
                             } catch (e) {
                               setHamqthMessage({ type: 'error', text: 'Connection error' });
@@ -3575,9 +3676,21 @@ export const SettingsPanel = ({
                         >
                           {hamqthTesting ? 'Testing...' : 'Save & Test'}
                         </button>
-                        {hamqthStatus?.configured && hamqthStatus.source !== 'env' && (
+                        {((hamqthStatus?.configured && hamqthStatus.source !== 'env') ||
+                          (!isLocalInstall && personalHamqth)) && (
                           <button
                             onClick={async () => {
+                              if (!isLocalInstall) {
+                                const creds = getCallbookCredentials();
+                                delete creds.hamqthUsername;
+                                delete creds.hamqthPassword;
+                                setCallbookCredentials(creds);
+                                setPersonalHamqth(false);
+                                setHamqthUsername('');
+                                setHamqthPassword('');
+                                setHamqthMessage(null);
+                                return;
+                              }
                               await fetch('/api/hamqth/remove', { method: 'POST' });
                               setHamqthUsername('');
                               setHamqthPassword('');

--- a/src/hooks/app/useCallsignLookup.js
+++ b/src/hooks/app/useCallsignLookup.js
@@ -14,6 +14,7 @@
  */
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { apiFetch } from '../../utils/apiFetch.js';
+import { callbookAuthHeaders } from '../../utils/callbookAuth.js';
 import { extractBaseCall } from '../../components/CallsignLink.jsx';
 
 // TTL: 24 hours (matches server-side cache TTL)
@@ -66,6 +67,7 @@ export default function useCallsignLookup(call) {
 
     try {
       const res = await apiFetch(`/api/callsign/${encodeURIComponent(callsign)}`, {
+        headers: callbookAuthHeaders(),
         signal: AbortSignal.timeout(5000),
       });
       if (!res) {

--- a/src/utils/callbookAuth.js
+++ b/src/utils/callbookAuth.js
@@ -1,0 +1,51 @@
+/**
+ * Per-user callbook (QRZ / HamQTH) credentials for the hosted instance.
+ *
+ * Stored ONLY in this browser's localStorage — deliberately kept out of the
+ * settings sync so they are never written to any server config. They are
+ * sent as base64 auth headers on /api/callsign lookups; the server exchanges
+ * them for callbook session keys held in memory and never persists them, and
+ * lookup results are cached per credential so one subscriber's callbook data
+ * is never served to another user.
+ */
+const STORAGE_KEY = 'ohc-callbook-auth';
+
+export function getCallbookCredentials() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY)) || {};
+  } catch {
+    return {};
+  }
+}
+
+export function setCallbookCredentials(creds) {
+  const clean = {};
+  for (const key of ['qrzUsername', 'qrzPassword', 'hamqthUsername', 'hamqthPassword']) {
+    if (creds?.[key]) clean[key] = creds[key];
+  }
+  try {
+    if (Object.keys(clean).length === 0) localStorage.removeItem(STORAGE_KEY);
+    else localStorage.setItem(STORAGE_KEY, JSON.stringify(clean));
+  } catch {
+    // localStorage unavailable (private mode) — credentials just won't persist
+  }
+}
+
+// btoa() chokes on non-ASCII; encode via UTF-8 bytes so any password works
+const b64 = (s) => btoa(String.fromCharCode(...new TextEncoder().encode(s)));
+
+export function callbookAuthHeaders() {
+  const creds = getCallbookCredentials();
+  const headers = {};
+  try {
+    if (creds.qrzUsername && creds.qrzPassword) {
+      headers['X-QRZ-Auth'] = b64(`${creds.qrzUsername}:${creds.qrzPassword}`);
+    }
+    if (creds.hamqthUsername && creds.hamqthPassword) {
+      headers['X-HamQTH-Auth'] = b64(`${creds.hamqthUsername}:${creds.hamqthPassword}`);
+    }
+  } catch {
+    // malformed stored values — fail open with no auth headers
+  }
+  return headers;
+}


### PR DESCRIPTION
Hosted users can now enter their own QRZ or HamQTH login in Settings and get full callbook data (name, QTH, grid) in the callsign popup — using only their own account, which is what the callbook terms require on a multi-user site.

**How it works**
- Credentials live only in the user's browser (localStorage, deliberately outside the synced config) and ride as base64 auth headers on `/api/callsign` lookups.
- The server exchanges them for QRZ/HamQTH session keys in an in-memory LRU map (500-credential cap, never persisted, never logged).
- Lookup results are cached **per credential hash**, so one subscriber's callbook data is never served to another user.
- Lookup order: user QRZ → user HamQTH → instance QRZ → instance HamQTH → DXCC fallback → prefix estimate.
- New `POST /api/callsign/verify-credentials` (write-rate-limited) validates a login before the browser stores it; the Settings QRZ/HamQTH sections now work on shared instances with a "Your login (this browser)" badge and Remove button. Self-host server-side config unchanged.

**Verified:** exercised locally end-to-end (DXCC fallback unchanged, real HamQTH auth-failure round-trip, malformed/garbage headers fall through safely); 190 utils tests pass; **tested on staging by Chris — names show up.**

Cherry-pick of `0845d71c` from Staging. Chris requested the port to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)