### PR TITLE
fix(presence): stop heartbeat 429s from freezing every API call

### DIFF
--- a/src/hooks/app/usePresence.js
+++ b/src/hooks/app/usePresence.js
@@ -5,9 +5,15 @@
  * Runs globally for all configured users (callsign != N0CALL).
  */
 import { useEffect, useRef } from 'react';
-import { apiFetch } from '../../utils/apiFetch';
 
 const HEARTBEAT_INTERVAL = 2 * 60 * 1000; // 2 minutes
+// Server locks out repeat presence POSTs from one IP for 1 minute — don't
+// even send a heartbeat earlier than that (tab wake-ups and remounts fire
+// the effect again well before the interval elapses).
+const MIN_HEARTBEAT_SPACING = 61 * 1000;
+
+// Module-level so every mount of the hook in this tab shares the throttle
+let lastHeartbeatAt = 0;
 
 export default function usePresence({ callsign, locator, sharePresence = true }) {
   const locationRef = useRef(null);
@@ -40,8 +46,15 @@ export default function usePresence({ callsign, locator, sharePresence = true })
 
     const sendHeartbeat = async () => {
       if (!locationRef.current) return;
+      if (Date.now() - lastHeartbeatAt < MIN_HEARTBEAT_SPACING) return;
+      lastHeartbeatAt = Date.now();
       try {
-        await apiFetch('/api/presence', {
+        // Plain fetch, NOT apiFetch: the server 429s heartbeats that arrive
+        // inside its per-IP lockout (second tab, shared IP, early wake-up),
+        // and that expected, endpoint-specific throttle must not arm
+        // apiFetch's global 30s backoff — it was freezing every panel in
+        // the app each heartbeat cycle.
+        await fetch('/api/presence', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({


### PR DESCRIPTION
Fixes the "news feed isn't scrolling" report from an Edge user on the hosted site.

**Root cause chain:** the presence endpoint locks out repeat POSTs from one IP for 1 minute (by design). The heartbeat hook fires immediately on every effect re-run — tab wake, remount, second tab, shared IP — so early heartbeats routinely 429. The heartbeat went through `apiFetch`, whose 429 handler arms a **global 30-second backoff for all API calls**, freezing every panel in the app each heartbeat cycle. Edge's aggressive tab sleeping makes the wake-up heartbeat near-constant, which is why it presented there first.

**Fix (client-only):**
- Presence heartbeats use plain `fetch` — an expected, endpoint-specific throttle must not back off unrelated API calls.
- The hook self-throttles to the server's 60s lockout spacing (module-level timestamp), so early heartbeats never leave the browser.

Verified: frontend builds clean; the diff is confined to `usePresence.js`.

Cherry-pick of `44b036d4` from Staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)