### PR TITLE
fix(satellites): explicit edge-cache TTL on non-empty TLE payloads

### DIFF
--- a/server/routes/satellites.js
+++ b/server/routes/satellites.js
@@ -1221,11 +1221,16 @@ module.exports = function (app, ctx) {
 
   // satellite data endpoint
   app.get('/api/satellites/data', async (req, res) => {
-    // Don't let Fastly/CDN pin an empty payload — when all sources fail we want
+    // Don't let the CDN pin an empty payload — when all sources fail we want
     // the next request after backoff to hit the origin, not the edge cache.
+    // Good payloads get an explicit short edge TTL: the Cloudflare cache rule
+    // honors origin Cache-Control and bypasses when it's absent, so without
+    // this header the endpoint wouldn't be edge-cached at all.
     const sendSatelliteData = (payload) => {
       if (!payload || Object.keys(payload).length === 0) {
         res.set('Cache-Control', 'no-store');
+      } else {
+        res.set('Cache-Control', 'public, max-age=60, s-maxage=300');
       }
 
       const newestTimestamp = Object.values(ommCache)


### PR DESCRIPTION
Follow-up to today's satellite outage on the hosted site: Cloudflare's old cache rule overrode origin headers and pinned an **empty** `/api/satellites/data` payload (captured during the 19:21 restart window) for ~25 minutes, even though the origin correctly sent `no-store` on it. The origin had recovered (38/40 birds resolved) but the edge kept replaying the empty snapshot.

The Cloudflare rule is now "use cache-control header if present, bypass if not" — so this PR gives good payloads an explicit `Cache-Control: public, max-age=60, s-maxage=300`, keeping the endpoint's 5-minute edge caching under the new rule. Empty payloads stay `no-store` and can never be pinned again; all other API routes bypass the edge unless deliberately opted in.

Cherry-pick of `676fc7f9` from Staging. Chris requested the port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)