### PR TITLE
fix: cluster env hardening — ohc-cluster PORT collision + schemeless OHC_CLUSTER_URL

### DIFF
--- a/ohc-cluster/README.md
+++ b/ohc-cluster/README.md
@@ -40,21 +40,23 @@ send that email.
 
 1. New service from this directory (`ohc-cluster/`).
 2. Set `CALLSIGN` (RBN login) and `NODE_CALL` (what telnet users see).
-3. HTTP is exposed normally via `PORT`.
+3. HTTP listens on 3002 by default (set `HTTP_PORT` to change it). Note:
+   once a TCP proxy is attached, Railway sets `PORT` to the proxy's target
+   port; the server detects that and keeps the HTTP API on 3002.
 4. Telnet needs a **TCP Proxy**: Settings → Networking → TCP Proxy →
    internal port 7300. Railway assigns the public `host:port` — publish that.
 
 ## Environment
 
-| Var              | Default | Purpose                             |
-| ---------------- | ------- | ----------------------------------- |
-| `PORT`           | 3002    | HTTP API port                       |
-| `TELNET_PORT`    | 7300    | telnet cluster port                 |
-| `CALLSIGN`       | K0CJH   | RBN login callsign (must be valid)  |
-| `NODE_CALL`      | K0CJH-2 | node callsign shown to telnet users |
-| `RBN_ENABLED`    | 1       | set `0` to disable RBN ingest       |
-| `HAMQTH_ENABLED` | 1       | set `0` to disable HamQTH polling   |
-| `LOG_LEVEL`      | info    | `debug` / `info` / `warn`           |
+| Var              | Default | Purpose                                                             |
+| ---------------- | ------- | ------------------------------------------------------------------- |
+| `HTTP_PORT`      | 3002    | HTTP API port (falls back to `PORT` unless that is the telnet port) |
+| `TELNET_PORT`    | 7300    | telnet cluster port                                                 |
+| `CALLSIGN`       | K0CJH   | RBN login callsign (must be valid)                                  |
+| `NODE_CALL`      | K0CJH-2 | node callsign shown to telnet users                                 |
+| `RBN_ENABLED`    | 1       | set `0` to disable RBN ingest                                       |
+| `HAMQTH_ENABLED` | 1       | set `0` to disable HamQTH polling                                   |
+| `LOG_LEVEL`      | info    | `debug` / `info` / `warn`                                           |
 
 ## Tests
 

--- a/ohc-cluster/server.js
+++ b/ohc-cluster/server.js
@@ -9,7 +9,9 @@
  * Serve:   classic telnet cluster on :7300, HTTP API on :3002.
  *
  * Environment:
- *   PORT          HTTP port             (default 3002)
+ *   HTTP_PORT     HTTP port             (default 3002; falls back to PORT
+ *                 unless PORT is the telnet port — Railway sets PORT to the
+ *                 TCP proxy target)
  *   TELNET_PORT   telnet cluster port   (default 7300)
  *   CALLSIGN      callsign used to log in to RBN          (default K0CJH)
  *   NODE_CALL     node callsign shown to telnet users     (default K0CJH-2)
@@ -26,8 +28,20 @@ const { buildHttpApi } = require('./lib/httpApi.js');
 const { isValidCallsign } = require('./lib/callsign.js');
 const pkg = require('./package.json');
 
-const HTTP_PORT = parseInt(process.env.PORT, 10) || 3002;
 const TELNET_PORT = parseInt(process.env.TELNET_PORT, 10) || 7300;
+// Railway sets PORT to the TCP proxy's application port — i.e. the telnet
+// port — so a PORT that matches TELNET_PORT is not meant for the HTTP API.
+let HTTP_PORT = parseInt(process.env.HTTP_PORT ?? process.env.PORT, 10) || 3002;
+if (HTTP_PORT === TELNET_PORT) {
+  console.warn(
+    `PORT ${HTTP_PORT} is the telnet cluster port; HTTP API falling back to 3002. Set HTTP_PORT to pick another.`,
+  );
+  HTTP_PORT = 3002;
+  if (HTTP_PORT === TELNET_PORT) {
+    console.error('FATAL: HTTP_PORT and TELNET_PORT are both 3002; set them to different ports.');
+    process.exit(1);
+  }
+}
 const CALLSIGN = (process.env.CALLSIGN || 'K0CJH').trim().toUpperCase();
 const NODE_CALL = (process.env.NODE_CALL || 'K0CJH-2').trim().toUpperCase();
 

--- a/server/routes/dxcluster.js
+++ b/server/routes/dxcluster.js
@@ -82,7 +82,16 @@ module.exports = function (app, ctx) {
 
   // OpenHamClock's own cluster node (ohc-cluster/ sibling service).
   // Unset = not deployed yet; the source is hidden and auto mode skips it.
-  const OHC_CLUSTER_URL = (process.env.OHC_CLUSTER_URL || '').replace(/\/$/, '');
+  // A schemeless value (e.g. "ohc-cluster.railway.internal:3002") would make
+  // every fetch throw "Only absolute URLs are supported" — normalize it.
+  const OHC_CLUSTER_URL = (() => {
+    const raw = (process.env.OHC_CLUSTER_URL || '').trim().replace(/\/$/, '');
+    if (raw && !/^https?:\/\//i.test(raw)) {
+      console.warn(`[DX Cluster] OHC_CLUSTER_URL has no scheme — assuming http://${raw}`);
+      return `http://${raw}`;
+    }
+    return raw;
+  })();
 
   // Hosted-instance lockdown. Set OHC_HOSTED=1 ONLY on our Railway deployments:
   // the hosted site serves many users from one egress IP, so user-directed
@@ -90,6 +99,11 @@ module.exports = function (app, ctx) {
   // everything comes from our own cluster node. Self-hosted installs never set
   // this and keep the full source list (with their own callsign enforced).
   const IS_HOSTED = process.env.OHC_HOSTED === '1' || process.env.OHC_HOSTED === 'true';
+  if (IS_HOSTED && !OHC_CLUSTER_URL) {
+    console.error(
+      '[DX Cluster] OHC_HOSTED is set but OHC_CLUSTER_URL is not — the hosted source list offers only the OHC node, and every fetch to it will fail. Set OHC_CLUSTER_URL.',
+    );
+  }
 
   // Cache for DX Spider telnet spots (to avoid excessive connections)
   let dxSpiderCache = { spots: [], timestamp: 0 };


### PR DESCRIPTION
Ports the last two Staging fixes from today's incident chain to main. Both address failure modes that were worked around with Railway env corrections — these make the code survive the misconfigurations outright.

**1. ohc-cluster: don't bind the HTTP API to Railway's TCP-proxy PORT** (`af9a10a2`)
Railway sets `PORT` to the TCP proxy's application port (the telnet port) once a proxy is attached, and the server read `PORT` as the HTTP port — telnet bound 7300 first and the container crash-looped on `EADDRINUSE` (this morning's prod outage). The HTTP API now prefers `HTTP_PORT`, and when `PORT` collides with `TELNET_PORT` it falls back to 3002 with a warning. Prod currently works because `PORT=3002` is set; with this fix the service also survives that variable being lost.

**2. dxcluster: normalize schemeless OHC_CLUSTER_URL** (`5b5cf751`)
A scheme-less `OHC_CLUSTER_URL` (e.g. `ohc-cluster.railway.internal:3002`) made every fetch to the node throw "Only absolute URLs are supported" — the hosted site silently wasn't getting spots from its own node (this afternoon's deploy-log finding). The value now gets `http://` prepended with a warning when the scheme is missing, and `OHC_HOSTED` without `OHC_CLUSTER_URL` logs a loud startup error instead of failing quietly.

Both verified on Staging (running there since this afternoon); the ohc-cluster fix was additionally exercised locally under the exact Railway condition (`PORT=7300` → telnet holds 7300, `/health` answers on 3002, 20-test suite passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)