### PR TITLE
feat(monitoring): watchtower coverage for fletcher and the OHC Cluster node

### DIFF
--- a/server/health.js
+++ b/server/health.js
@@ -20,6 +20,7 @@ const SATELLITES_CACHE_DURATION_MS = 24 * 60 * 60 * 1000; // mirrors OMM_CACHE_D
 
 const subsystems = {
   fletcher: { status: 'unknown', lastChecked: null, detail: null },
+  'ohc-cluster': { status: 'unknown', lastChecked: null, detail: null },
   rbn: { status: 'unknown', lastChecked: null, detail: null },
   satellites: { status: 'unknown', lastChecked: null, detail: null },
   propagation: { status: 'unknown', lastChecked: null, detail: null },
@@ -53,6 +54,22 @@ async function checkFletcher(ctx) {
     return { status: 'unknown', detail: 'FLETCHER_URL/TLE_FETCHER_URL unset (direct upstream mode)' };
   }
   const result = await probeHttp(`${base}/health`, 'fletcher');
+  if (result.ok) return { status: 'ok', detail: `${result.status} from ${base}/health` };
+  return {
+    status: 'down',
+    detail: result.error ? `probe failed: ${result.error}` : `HTTP ${result.status}`,
+  };
+}
+
+async function checkOhcCluster() {
+  // Same normalization as the dxcluster route: prepend http:// when the
+  // scheme is missing so a schemeless Railway env var still probes.
+  let base = (process.env.OHC_CLUSTER_URL || '').trim().replace(/\/+$/, '');
+  if (base && !/^https?:\/\//i.test(base)) base = `http://${base}`;
+  if (!base) {
+    return { status: 'unknown', detail: 'OHC_CLUSTER_URL unset (node not deployed)' };
+  }
+  const result = await probeHttp(`${base}/health`, 'ohc-cluster');
   if (result.ok) return { status: 'ok', detail: `${result.status} from ${base}/health` };
   return {
     status: 'down',
@@ -101,13 +118,15 @@ async function checkPropagation(ctx) {
 
 async function refreshAll(ctx) {
   const now = Date.now();
-  const [fletcher, rbn, satellites, propagation] = await Promise.all([
+  const [fletcher, ohcCluster, rbn, satellites, propagation] = await Promise.all([
     checkFletcher(ctx),
+    checkOhcCluster(),
     Promise.resolve(checkRbn(ctx)),
     Promise.resolve(checkSatellites(ctx)),
     checkPropagation(ctx),
   ]);
   subsystems.fletcher = { ...fletcher, lastChecked: now };
+  subsystems['ohc-cluster'] = { ...ohcCluster, lastChecked: now };
   subsystems.rbn = { ...rbn, lastChecked: now };
   subsystems.satellites = { ...satellites, lastChecked: now };
   subsystems.propagation = { ...propagation, lastChecked: now };

--- a/watchtower/src/index.js
+++ b/watchtower/src/index.js
@@ -7,8 +7,8 @@
  * goes down is useless. CF runs the prober outside Railway's blast radius.
  *
  * Probes (every 1 min):
- *   - openhamclock.com /api/health  (also reads subsystems: fletcher, rbn,
- *                                    satellites, propagation)
+ *   - openhamclock.com /api/health  (also reads subsystems: fletcher,
+ *                                    ohc-cluster, rbn, satellites, propagation)
  *   - proppy-production.up.railway.app /api/version
  *   - spider-production.up.railway.app /health
  *
@@ -117,7 +117,7 @@ function parseOpenHamClock(body) {
   });
 
   const subs = data.subsystems || {};
-  for (const key of ['fletcher', 'rbn', 'satellites', 'propagation']) {
+  for (const key of ['fletcher', 'ohc-cluster', 'rbn', 'satellites', 'propagation']) {
     const s = subs[key];
     if (!s) continue;
     out.push({

--- a/watchtower/src/index.js
+++ b/watchtower/src/index.js
@@ -62,6 +62,21 @@ const SERVICES = [
     parse: parseSimple200,
     railwayEnv: 'production',
   },
+  // Direct probes for fletcher + the OHC Cluster node: the /api/health
+  // subsystem checks above cover the private-network path the app uses,
+  // but these keep alerting even when the main app itself is down.
+  {
+    name: 'fletcher',
+    url: 'https://fletcher-production.up.railway.app/health',
+    parse: parseSimple200,
+    railwayEnv: 'production',
+  },
+  {
+    name: 'ohc-cluster',
+    url: 'https://ohc-cluster-production.openhamclock.com/health',
+    parse: parseSimple200,
+    railwayEnv: 'production',
+  },
 ];
 
 const STATUS_COLORS = {

--- a/watchtower/src/index.js
+++ b/watchtower/src/index.js
@@ -73,7 +73,9 @@ const SERVICES = [
   },
   {
     name: 'ohc-cluster',
-    url: 'https://ohc-cluster-production.openhamclock.com/health',
+    // NOTE: the domain's target port must be 3002 (the HTTP API) — telnet
+    // (7300) is exposed separately via the Railway TCP proxy.
+    url: 'https://ohc-cluster-production.up.railway.app/health',
     parse: parseSimple200,
     railwayEnv: 'production',
   },


### PR DESCRIPTION
Adds the two Railway sidecar services to outage monitoring, in two layers:

1. **Subsystem layer** — `/api/health` gains an `ohc-cluster` subsystem (probes `OHC_CLUSTER_URL/health` over the private network, schemeless env values normalized, same pattern as the existing fletcher check), and watchtower's subsystem parser reads it. Covers the private-network path the app actually uses.
2. **Direct-probe layer** — fletcher (`fletcher-production.up.railway.app/health`, verified live) and ohc-cluster (`ohc-cluster-production.up.railway.app/health`) added as first-class watchtower services, so they keep alerting even when the main app itself is down.

**Post-merge actions (dashboard/CLI, not in this PR):**
- Set the ohc-cluster domain's target port to **3002** (currently 7300 → the telnet listener 502s HTTPS probes)
- `wrangler deploy` from `watchtower/` — the Worker doesn't auto-deploy from git

⚠️ Merge with **"Create a merge commit"** (not squash) to keep the Staging/main ancestry reconciled per #1116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)