### PR TITLE
fix(monitoring): watchtower probes production; /api/health echoes all subsystems

### DIFF
--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -788,13 +788,11 @@ module.exports = function (app, ctx) {
         // whether fletcher/rbn/satellites/propagation are healthy through one probe.
         // Snapshot is refreshed every 30s by server/health.js; reads here are cache hits.
         subsystemStatus: subsystems?.aggregate ?? 'unknown',
+        // Echo every subsystem health.js tracks — hardcoding the keys here
+        // hid new subsystems (ohc-cluster) while they still drove the
+        // aggregate, producing "down" with all visible subsystems ok.
         subsystems: subsystems
-          ? {
-              fletcher: subsystems.fletcher,
-              rbn: subsystems.rbn,
-              satellites: subsystems.satellites,
-              propagation: subsystems.propagation,
-            }
+          ? Object.fromEntries(Object.entries(subsystems).filter(([key]) => key !== 'aggregate'))
           : null,
 
         // SECURITY: Only expose file paths and detailed internals to authenticated requests

--- a/watchtower/src/index.js
+++ b/watchtower/src/index.js
@@ -42,13 +42,11 @@ const RAILWAY_ENV_IDS = {
 const SERVICES = [
   {
     name: 'openhamclock',
-    // Probe Staging for now: it has Phase A (subsystems block) and the
-    // rate-limit skip on /api/health. Prod gets both with the next release,
-    // at which point this flips to https://openhamclock.up.railway.app or
-    // https://openhamclock.com once CF Bot Fight stops 429ing the worker.
-    url: 'https://openhamclock-staging.up.railway.app/api/health',
+    // Probe PRODUCTION via the Railway-direct URL — openhamclock.com sits
+    // behind CF Bot Fight, which 429s worker-to-worker fetches.
+    url: 'https://openhamclock.up.railway.app/api/health',
     parse: parseOpenHamClock, // returns { aggregate, subsystems: {fletcher, rbn, ...} }
-    railwayEnv: 'staging',
+    railwayEnv: 'production',
   },
   {
     name: 'proppy',


### PR DESCRIPTION
Completes the watchtower rollout on main:

1. **Watchtower probes production** — flips the openhamclock service from the temporary staging URL to the Railway-direct prod URL (`openhamclock.up.railway.app`, verified 200; the openhamclock.com hostname 429s worker fetches via CF Bot Fight).
2. **/api/health echoes every subsystem** — the response hardcoded four subsystem keys, so the new ohc-cluster check drove the aggregate status while being invisible (staging showed aggregate "down" with all listed subsystems ok). Now spreads whatever health.js tracks.

After merge: `git pull && cd watchtower && npx wrangler deploy` to ship the worker.

⚠️ Merge with **"Create a merge commit"** to keep branch ancestry reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)