### PR TITLE
fix(cluster): balance spot modes so SSB and CW survive the FT8 flood

### DIFF
--- a/ohc-cluster/lib/httpApi.js
+++ b/ohc-cluster/lib/httpApi.js
@@ -58,7 +58,7 @@ function buildHttpApi({ store, feeds, telnetServer, hamqth, log, startTime, node
   });
 
   app.get('/api/dxcluster/spots', (req, res) => {
-    const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 50, 1), 200);
+    const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 50, 1), 500);
     const spots = store.query({
       limit,
       band: req.query.band || null,

--- a/ohc-cluster/lib/store.js
+++ b/ohc-cluster/lib/store.js
@@ -20,6 +20,8 @@ const DEFAULTS = {
   maxSpots: 2000, // hard cap across all sources
   humanDedupWindowMs: 2 * 60 * 1000, // same spotter+call+freq within 2 min = dupe
   skimmerRebroadcastMs: 10 * 60 * 1000, // re-announce a busy station at most every 10 min
+  humanReserveShare: 0.25, // slice of the default query window held for human spots
+  ft8Ft4CapShare: 0.5, // max slice of the default query window FT8/FT4 may take
 };
 
 class SpotStore {
@@ -148,17 +150,59 @@ class SpotStore {
     if (this.skimmerIndex.get(key) === spot) this.skimmerIndex.delete(key);
   }
 
-  /** Most recent spots, optionally filtered. */
+  /**
+   * Most recent spots, optionally filtered.
+   *
+   * The default (no mode/humanOnly) window is mode-balanced: FT8/FT4 churn
+   * creates new aggregates so fast that pure recency fills the whole window
+   * with digital spots and users conclude nothing else is on the air. Human
+   * spots — the only source of SSB, since RBN skimmers can't decode phone —
+   * get a reserved slice, FT8/FT4 gets a capped one, and slots either group
+   * doesn't use flow back to the general pool.
+   */
   query({ limit = 50, source = null, band = null, mode = null, humanOnly = false } = {}) {
-    const out = [];
+    const matches = [];
     for (const s of this.spots) {
       if (source && s.source !== source) continue;
       if (band && s.band !== band) continue;
       if (mode && s.mode !== mode) continue;
       if (humanOnly && s.skimmerCount > 0) continue;
-      out.push(s);
-      if (out.length >= limit) break;
+      matches.push(s);
     }
+    // Skimmer refreshes update timestamps in place without reordering the
+    // array, so rank by activity rather than insertion.
+    matches.sort((a, b) => b.timestamp - a.timestamp);
+
+    // A caller asking for a specific mode slice gets exactly that slice.
+    if (mode || humanOnly) return matches.slice(0, limit);
+
+    const humans = [];
+    const ft8ft4 = [];
+    const other = [];
+    for (const s of matches) {
+      if (!s.skimmerCount) humans.push(s);
+      else if (s.mode === 'FT8' || s.mode === 'FT4') ft8ft4.push(s);
+      else other.push(s);
+    }
+
+    const humanReserve = Math.ceil(limit * this.opts.humanReserveShare);
+    const out = humans.slice(0, humanReserve);
+    const ft8Cap = Math.min(Math.ceil(limit * this.opts.ft8Ft4CapShare), limit - out.length);
+    out.push(...ft8ft4.slice(0, ft8Cap));
+    out.push(...other.slice(0, limit - out.length));
+
+    // If any group ran short, backfill with the freshest leftovers — a quiet
+    // night should still fill the window even if it's all FT8.
+    if (out.length < limit && out.length < matches.length) {
+      const chosen = new Set(out);
+      for (const s of matches) {
+        if (chosen.has(s)) continue;
+        out.push(s);
+        if (out.length >= limit) break;
+      }
+    }
+
+    out.sort((a, b) => b.timestamp - a.timestamp);
     return out;
   }
 

--- a/ohc-cluster/test/store.test.js
+++ b/ohc-cluster/test/store.test.js
@@ -95,6 +95,71 @@ test('store caps total spots and evicts oldest', () => {
   assert.equal(store.query({ limit: 100 }).length, 5);
 });
 
+test('default query reserves a slice for human spots under FT8 flood', () => {
+  const store = new SpotStore();
+  const ts = Date.now();
+  // Humans arrive first, then a flood of newer FT8 aggregates
+  for (let i = 0; i < 5; i++) {
+    store.add(humanSpot({ call: `HU${i}MAN`, spotter: `K${i}HS`, freqKhz: 14200 + i, timestamp: ts - 60000 }));
+  }
+  for (let i = 0; i < 60; i++) {
+    store.add(skimmerSpot({ call: `F${i}T8`, freqKhz: 14074, mode: 'FT8', timestamp: ts }));
+  }
+
+  const spots = store.query({ limit: 20 });
+  assert.equal(spots.length, 20);
+  const humans = spots.filter((s) => s.skimmerCount === 0);
+  assert.equal(humans.length, 5); // all humans fit inside the ceil(20 * 0.25) reserve
+});
+
+test('default query caps FT8/FT4 share when other modes are active', () => {
+  const store = new SpotStore();
+  const ts = Date.now();
+  for (let i = 0; i < 40; i++) {
+    store.add(skimmerSpot({ call: `F${i}T8`, freqKhz: 14074, mode: 'FT8', timestamp: ts }));
+    store.add(skimmerSpot({ call: `C${i}W`, freqKhz: 14025, mode: 'CW', timestamp: ts - 1 }));
+  }
+
+  const spots = store.query({ limit: 20 });
+  assert.equal(spots.length, 20);
+  const ft8 = spots.filter((s) => s.mode === 'FT8' || s.mode === 'FT4');
+  assert.ok(ft8.length <= 10, `FT8/FT4 took ${ft8.length} of 20`); // ceil(20 * 0.5)
+  assert.ok(spots.filter((s) => s.mode === 'CW').length >= 10);
+});
+
+test('default query backfills with FT8 when nothing else is on the air', () => {
+  const store = new SpotStore();
+  for (let i = 0; i < 30; i++) {
+    store.add(skimmerSpot({ call: `F${i}T8`, freqKhz: 14074, mode: 'FT8' }));
+  }
+  assert.equal(store.query({ limit: 20 }).length, 20);
+});
+
+test('explicit mode query is an exact slice, not balanced', () => {
+  const store = new SpotStore();
+  for (let i = 0; i < 15; i++) {
+    store.add(skimmerSpot({ call: `F${i}T8`, freqKhz: 14074, mode: 'FT8' }));
+  }
+  store.add(skimmerSpot({ call: 'C1W', freqKhz: 14025, mode: 'CW' }));
+  const spots = store.query({ limit: 10, mode: 'FT8' });
+  assert.equal(spots.length, 10);
+  assert.ok(spots.every((s) => s.mode === 'FT8'));
+});
+
+test('a refreshed skimmer aggregate ranks by activity, not insertion order', () => {
+  const store = new SpotStore();
+  const ts = Date.now();
+  store.add(skimmerSpot({ call: 'OL1DCW', freqKhz: 14025, mode: 'CW', timestamp: ts - 60000 }));
+  for (let i = 0; i < 50; i++) {
+    store.add(skimmerSpot({ call: `F${i}T8`, freqKhz: 14074, mode: 'FT8', timestamp: ts - 30000 }));
+  }
+  // The CW station is still being heard — refresh updates it in place
+  store.add(skimmerSpot({ call: 'OL1DCW', spotter: 'W3OA-#', freqKhz: 14025, mode: 'CW', timestamp: ts }));
+
+  const spots = store.query({ limit: 10 });
+  assert.equal(spots[0].call, 'OL1DCW'); // freshest activity leads despite oldest insertion
+});
+
 test('rejects spots with missing or invalid fields', () => {
   const store = new SpotStore();
   assert.equal(store.add({ spotter: '', call: 'W1AW', freqKhz: 14000 }), null);

--- a/server/routes/dxcluster.js
+++ b/server/routes/dxcluster.js
@@ -901,7 +901,7 @@ module.exports = function (app, ctx) {
       const timeout = setTimeout(() => controller.abort(), 10000);
 
       try {
-        const response = await fetch(`${OHC_CLUSTER_URL}/api/dxcluster/spots?limit=50`, {
+        const response = await fetch(`${OHC_CLUSTER_URL}/api/dxcluster/spots?limit=150`, {
           headers: { 'User-Agent': `OpenHamClock/${APP_VERSION}` },
           signal: controller.signal,
         });
@@ -1791,7 +1791,7 @@ module.exports = function (app, ctx) {
         const ohcController = new AbortController();
         const ohcTimeout = setTimeout(() => ohcController.abort(), 10000);
         try {
-          const ohcResponse = await fetch(`${OHC_CLUSTER_URL}/api/dxcluster/spots?limit=100`, {
+          const ohcResponse = await fetch(`${OHC_CLUSTER_URL}/api/dxcluster/spots?limit=150`, {
             headers: { 'User-Agent': `OpenHamClock/${APP_VERSION}` },
             signal: ohcController.signal,
           });

--- a/src/components/DXClusterPanel.jsx
+++ b/src/components/DXClusterPanel.jsx
@@ -516,7 +516,7 @@ export const DXClusterPanel = ({
             {showSpotter && <span role="columnheader">Spotter</span>}
             <span role="columnheader">Age</span>
           </div>
-          {spots.slice(0, 25).map((spot, i) => {
+          {spots.slice(0, 50).map((spot, i) => {
             // Frequency can be in MHz (string like "14.070") or kHz (number like 14070)
             let freqDisplay = '?';
             let freqMHz = 0;


### PR DESCRIPTION
## Problem

Users reported the DX cluster panel showing only FT8/FT4 spots (and, on closer inspection, a little CW but never SSB).

Root cause, confirmed against the live production node:

- `SpotStore.query()` served spots in **insertion order**. FT8 churn creates new aggregates so fast that the 50-spot window the app fetched was ~90% FT8/FT4. Skimmer refreshes update timestamps in place without reordering, so an actively-heard CW station drifted out of the window minutes after first being spotted.
- **SSB only exists as human spots** (RBN skimmers can't decode phone). 66 human spots — many on phone frequencies — were sitting in the store, but zero survived into the top-50 window.

Live top-50 before: **42 FT8 / 3 FT4 / 5 CW / 0 human, 0 SSB**.

## Fix

`SpotStore.query()` now:
- ranks by refreshed timestamp (activity, not insertion order),
- reserves 25% of the default window for human spots,
- caps FT8/FT4 at 50%, with unused slots from either group flowing back to the general pool (an all-FT8 quiet night still fills the window),
- leaves explicit `?mode=` / `?humanOnly=` queries untouched.

Also widens the display chain: cluster API max limit 200 → 500, app fetch 50 → 150 (spots + map-paths routes), DX panel renders 50 rows instead of 25 (list scrolls).

## Verification

- 25/25 ohc-cluster unit tests pass, including 5 new tests covering the human reserve, FT8/FT4 cap, backfill, exact-slice queries, and activity ranking.
- Ran the patched node locally against the **real** RBN/HamQTH feeds: top-50 became **24 FT8 / 1 FT4 / 12 CW / 13 human**, including phone-band spots (PY6RT 14200, LU6CBI 7150, …) that the client labels SSB, output correctly newest-first.

Same change is on Staging as 4c178d6b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)