### PR TITLE
fix(cluster): balance the panel display window so SSB actually shows

### DIFF
--- a/src/components/DXClusterPanel.jsx
+++ b/src/components/DXClusterPanel.jsx
@@ -6,6 +6,7 @@ import { useState, useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getBandColor } from '../utils/callsign.js';
 import { matchesDXSpotPath } from '../utils/dxClusterSpotMatcher';
+import { balanceSpotWindow } from '../utils/dxClusterFilters';
 import { IconSearch, IconMap, IconGlobe } from './Icons.jsx';
 import CallsignLink from './CallsignLink.jsx';
 import { useCallsignPopup } from './CallsignPopupManager.jsx';
@@ -212,8 +213,11 @@ export const DXClusterPanel = ({
   };
 
   const spots = useMemo(() => {
-    if (sortField === 'time') return rawSpots;
-    const copy = [...rawSpots];
+    // Pick the display window before sorting so mode balance survives: a raw
+    // "newest 50" slice is all FT8/FT4 skimmer churn and SSB never shows.
+    const windowed = balanceSpotWindow(rawSpots, 50);
+    if (sortField === 'time') return windowed;
+    const copy = [...windowed];
     if (sortField === 'freq') {
       copy.sort((a, b) => freqToMHz(a) - freqToMHz(b));
     } else if (sortField === 'call') {
@@ -516,7 +520,7 @@ export const DXClusterPanel = ({
             {showSpotter && <span role="columnheader">Spotter</span>}
             <span role="columnheader">Age</span>
           </div>
-          {spots.slice(0, 50).map((spot, i) => {
+          {spots.map((spot, i) => {
             // Frequency can be in MHz (string like "14.070") or kHz (number like 14070)
             let freqDisplay = '?';
             let freqMHz = 0;

--- a/src/utils/dxClusterFilters.js
+++ b/src/utils/dxClusterFilters.js
@@ -320,6 +320,52 @@ export const applyDXFilters = (item, filters) => {
 };
 
 /**
+ * Pick a mode-balanced display window from a spot list.
+ *
+ * The cluster feed is dominated by RBN skimmer spots, and FT8/FT4 churn keeps
+ * the newest entries almost exclusively digital — a plain "newest N" slice
+ * shows no SSB at all, because SSB only exists as human spots (skimmers can't
+ * decode phone) and those age past the window within minutes. Mirrors the
+ * server-side balancing in ohc-cluster/lib/store.js: reserve a slice of the
+ * window for human spots, cap FT8/FT4, give unused slots back to the pool.
+ * Returns spots in their original (newest-first) feed order.
+ */
+export const balanceSpotWindow = (spots, limit, { humanReserveShare = 0.25, ft8Ft4CapShare = 0.5 } = {}) => {
+  if (!Array.isArray(spots) || spots.length <= limit) return spots || [];
+
+  // Skimmer spots carry source 'RBN' from our node; other feeds mark them
+  // with the classic skimmer callsign suffix (-#).
+  const isSkimmer = (s) => s.source === 'RBN' || /-#$/.test(s.spotter || '');
+  const humans = [];
+  const ft8ft4 = [];
+  const other = [];
+  spots.forEach((spot, i) => {
+    const entry = [spot, i];
+    if (!isSkimmer(spot)) {
+      humans.push(entry);
+    } else {
+      const mode = spot.mode || detectMode(spot.comment, spot.freq);
+      (mode === 'FT8' || mode === 'FT4' ? ft8ft4 : other).push(entry);
+    }
+  });
+
+  const humanReserve = Math.ceil(limit * humanReserveShare);
+  const out = humans.slice(0, humanReserve);
+  out.push(...ft8ft4.slice(0, Math.min(Math.ceil(limit * ft8Ft4CapShare), limit - out.length)));
+  out.push(...other.slice(0, limit - out.length));
+
+  // Backfill with the remaining freshest spots if any group ran short
+  if (out.length < limit) {
+    const chosen = new Set(out.map(([, i]) => i));
+    for (let i = 0; i < spots.length && out.length < limit; i++) {
+      if (!chosen.has(i)) out.push([spots[i], i]);
+    }
+  }
+
+  return out.sort((a, b) => a[1] - b[1]).map(([spot]) => spot);
+};
+
+/**
  * Filter an array of DX spots/paths
  * Wrapper around applyDXFilters for filtering arrays
  */

--- a/src/utils/dxClusterFilters.test.js
+++ b/src/utils/dxClusterFilters.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { applyDXFilters, filterDXPaths } from '../utils/dxClusterFilters.js';
+import { applyDXFilters, filterDXPaths, balanceSpotWindow } from '../utils/dxClusterFilters.js';
 
 describe('dxClusterFilters', () => {
   let mockSpot;
@@ -742,6 +742,82 @@ describe('dxClusterFilters', () => {
         excludeDXCallList: ['4U1UN', '4X6TU'],
       };
       expect(applyDXFilters(beaconSpot, filters)).toBe(false);
+    });
+  });
+
+  describe('balanceSpotWindow', () => {
+    const ft8Spot = (i) => ({
+      call: `F${i}T8`,
+      spotter: 'KM3T-#',
+      freq: '14.074',
+      comment: 'FT8 -12 dB CQ',
+      mode: 'FT8',
+      source: 'RBN',
+    });
+    const cwSpot = (i) => ({
+      call: `C${i}W`,
+      spotter: 'W3OA-#',
+      freq: '14.025',
+      comment: 'CW 20 dB 22 WPM CQ',
+      mode: 'CW',
+      source: 'RBN',
+    });
+    const humanSpot = (i) => ({
+      call: `HU${i}MAN`,
+      spotter: 'K0CJH',
+      freq: '14.200',
+      comment: '59 tnx',
+      source: 'HamQTH',
+    });
+
+    it('returns the list untouched when it fits the window', () => {
+      const spots = [ft8Spot(0), humanSpot(0)];
+      expect(balanceSpotWindow(spots, 50)).toEqual(spots);
+    });
+
+    it('keeps human spots buried deep behind skimmer churn', () => {
+      // 100 fresh FT8 spots ahead of 10 aging human spots — a plain
+      // newest-50 slice would show zero humans
+      const spots = [
+        ...Array.from({ length: 100 }, (_, i) => ft8Spot(i)),
+        ...Array.from({ length: 10 }, (_, i) => humanSpot(i)),
+      ];
+      const windowed = balanceSpotWindow(spots, 50);
+      expect(windowed).toHaveLength(50);
+      expect(windowed.filter((s) => s.source === 'HamQTH')).toHaveLength(10);
+    });
+
+    it('caps FT8/FT4 so other skimmer modes survive', () => {
+      const spots = [];
+      for (let i = 0; i < 60; i++) spots.push(ft8Spot(i));
+      for (let i = 0; i < 60; i++) spots.push(cwSpot(i));
+      const windowed = balanceSpotWindow(spots, 40);
+      expect(windowed).toHaveLength(40);
+      expect(windowed.filter((s) => s.mode === 'FT8').length).toBeLessThanOrEqual(20);
+      expect(windowed.filter((s) => s.mode === 'CW').length).toBeGreaterThanOrEqual(20);
+    });
+
+    it('backfills the window when only FT8 is on the air', () => {
+      const spots = Array.from({ length: 80 }, (_, i) => ft8Spot(i));
+      expect(balanceSpotWindow(spots, 50)).toHaveLength(50);
+    });
+
+    it('preserves feed order in the output', () => {
+      const spots = [...Array.from({ length: 60 }, (_, i) => ft8Spot(i)), humanSpot(0)];
+      const windowed = balanceSpotWindow(spots, 50);
+      const idx = (call) => spots.findIndex((s) => s.call === call);
+      for (let i = 1; i < windowed.length; i++) {
+        expect(idx(windowed[i].call)).toBeGreaterThan(idx(windowed[i - 1].call));
+      }
+    });
+
+    it('recognizes skimmers by the -# suffix when spots carry no source field', () => {
+      const spots = [
+        ...Array.from({ length: 60 }, (_, i) => ({ ...ft8Spot(i), source: undefined })),
+        { call: 'PY6RT', spotter: 'K0CJH', freq: '14.200', comment: '59', source: undefined },
+      ];
+      const windowed = balanceSpotWindow(spots, 50);
+      expect(windowed.some((s) => s.call === 'PY6RT')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Problem

Follow-up to #1119. Users still saw no SSB after the server-side balancing shipped. The cluster feed is fine — verified live: 19 phone-band spots in the 150-spot payload, several tagged "USB"/"LSB". The regression is in the display path:

- The server balances across the full 150-spot fetch, but `DXClusterPanel` rendered only the first 50 rows.
- RBN skimmer aggregates always carry the freshest timestamps (constantly refreshed), so in the feed's newest-first order **every human spot ranked 112+** — the visible 50-row window contained zero human spots, hence zero SSB.

## Fix

New `balanceSpotWindow()` in `dxClusterFilters.js` mirrors the store's balancing client-side: reserves 25% of the display window for human spots, caps FT8/FT4 at 50%, backfills unused slots, and preserves newest-first feed order. The panel now picks the balanced 50-row window *before* applying the user's sort, instead of slicing the newest 50.

Human/skimmer detection works for every source: `source === 'RBN'` for our node's spots, the classic `-#` skimmer suffix for other feeds.

## Verification

- 6 new unit tests (buried-humans reserve, FT8/FT4 cap, backfill, feed-order preservation, `-#` detection); full suite 1030 passing, production build clean.
- Simulated against the live production feed: the old window showed 32 FT8 / 9 FT4 / 9 CW / 0 human; the balanced window includes all 13 human spots incl. the live SSB spots (7Z1DH 14315, CU3HN 14267, LU2LCM 7160).

Same change is on Staging as 40adb085.

🤖 Generated with [Claude Code](https://claude.com/claude-code)