### PR TITLE
fix(cluster): balance the paths pipeline — SSB was cut server-side

### DIFF
--- a/server/routes/dxcluster.js
+++ b/server/routes/dxcluster.js
@@ -1136,9 +1136,40 @@ module.exports = function (app, ctx) {
   // handful of spots it exists to surface.
   const DXPEDITION_RETENTION = 60 * 60 * 1000;
   const isPathLive = (p, now) => now - p.timestamp < (p.isDXpedition ? DXPEDITION_RETENTION : DXPATHS_RETENTION);
+  // Mode-balanced cap. A plain newest-N slice is almost pure FT8/FT4 skimmer
+  // churn (freshest timestamps always), which starves the window of SSB
+  // entirely — SSB only exists as human spots, and RBN can't decode phone.
+  // RBN comments always lead with the mode ("FT8 -13 dB", "CW 26 dB 22 WPM"),
+  // so a spot without a mode marker is human traffic and gets the reserve.
+  const balancePathsByMode = (paths, limit) => {
+    if (paths.length <= limit) return paths;
+    const voice = [];
+    const ft8ft4 = [];
+    const other = [];
+    for (const p of paths) {
+      const c = String(p.comment || '').toUpperCase();
+      if (/\bFT[84]\b/.test(c)) ft8ft4.push(p);
+      else if (/\b(CW|RTTY|PSK)/.test(c)) other.push(p);
+      else voice.push(p); // voice keywords or no mode marker — human spots
+    }
+    const out = voice.slice(0, Math.ceil(limit * 0.25));
+    out.push(...ft8ft4.slice(0, Math.min(Math.ceil(limit * 0.5), limit - out.length)));
+    out.push(...other.slice(0, limit - out.length));
+    if (out.length < limit) {
+      const chosen = new Set(out);
+      for (const p of paths) {
+        if (out.length >= limit) break;
+        if (!chosen.has(p)) out.push(p);
+      }
+    }
+    return out;
+  };
   const capWithDXpeditions = (paths, limit) => {
     const dxpeditions = paths.filter((p) => p.isDXpedition);
-    const regular = paths.filter((p) => !p.isDXpedition).slice(0, limit);
+    const regular = balancePathsByMode(
+      paths.filter((p) => !p.isDXpedition),
+      limit,
+    );
     return [...dxpeditions, ...regular].sort((a, b) => b.timestamp - a.timestamp);
   };
   const DXPATHS_MAX_KEYS = 100; // Hard cap on cache keys

--- a/src/utils/dxClusterFilters.js
+++ b/src/utils/dxClusterFilters.js
@@ -327,30 +327,36 @@ export const applyDXFilters = (item, filters) => {
  * shows no SSB at all, because SSB only exists as human spots (skimmers can't
  * decode phone) and those age past the window within minutes. Mirrors the
  * server-side balancing in ohc-cluster/lib/store.js: reserve a slice of the
- * window for human spots, cap FT8/FT4, give unused slots back to the pool.
- * Returns spots in their original (newest-first) feed order.
+ * window for voice-mode spots, cap FT8/FT4, give unused slots back to the
+ * pool. Returns spots in their original (newest-first) feed order.
+ *
+ * Classification goes through detectMode (comment keywords, then band-plan
+ * frequency inference) rather than source/spotter markers: the paths endpoint
+ * strips the -# skimmer suffix and drops the mode/source fields, so comment
+ * and frequency are the only signals that survive every feed shape.
  */
-export const balanceSpotWindow = (spots, limit, { humanReserveShare = 0.25, ft8Ft4CapShare = 0.5 } = {}) => {
+export const balanceSpotWindow = (spots, limit, { voiceReserveShare = 0.25, ft8Ft4CapShare = 0.5 } = {}) => {
   if (!Array.isArray(spots) || spots.length <= limit) return spots || [];
 
-  // Skimmer spots carry source 'RBN' from our node; other feeds mark them
-  // with the classic skimmer callsign suffix (-#).
-  const isSkimmer = (s) => s.source === 'RBN' || /-#$/.test(s.spotter || '');
-  const humans = [];
+  const voice = [];
   const ft8ft4 = [];
   const other = [];
   spots.forEach((spot, i) => {
     const entry = [spot, i];
-    if (!isSkimmer(spot)) {
-      humans.push(entry);
+    const mode = spot.mode || detectMode(spot.comment, spot.freq);
+    if (mode === 'FT8' || mode === 'FT4') {
+      ft8ft4.push(entry);
+    } else if (mode === 'SSB' || mode === 'AM' || mode === 'FM' || !mode) {
+      // Voice modes and mode-unknown spots — the human-spotted traffic that
+      // skimmer churn otherwise pushes out of the window
+      voice.push(entry);
     } else {
-      const mode = spot.mode || detectMode(spot.comment, spot.freq);
-      (mode === 'FT8' || mode === 'FT4' ? ft8ft4 : other).push(entry);
+      other.push(entry);
     }
   });
 
-  const humanReserve = Math.ceil(limit * humanReserveShare);
-  const out = humans.slice(0, humanReserve);
+  const voiceReserve = Math.ceil(limit * voiceReserveShare);
+  const out = voice.slice(0, voiceReserve);
   out.push(...ft8ft4.slice(0, Math.min(Math.ceil(limit * ft8Ft4CapShare), limit - out.length)));
   out.push(...other.slice(0, limit - out.length));
 

--- a/src/utils/dxClusterFilters.test.js
+++ b/src/utils/dxClusterFilters.test.js
@@ -746,55 +746,56 @@ describe('dxClusterFilters', () => {
   });
 
   describe('balanceSpotWindow', () => {
+    // Spots in the shape the panel actually receives via useDXClusterData:
+    // the paths endpoint drops mode/source and strips the -# skimmer suffix,
+    // so comment + frequency are the only mode signals available.
     const ft8Spot = (i) => ({
       call: `F${i}T8`,
-      spotter: 'KM3T-#',
+      spotter: 'KM3T',
       freq: '14.074',
       comment: 'FT8 -12 dB CQ',
-      mode: 'FT8',
-      source: 'RBN',
+      source: 'DXCluster',
     });
     const cwSpot = (i) => ({
       call: `C${i}W`,
-      spotter: 'W3OA-#',
+      spotter: 'W3OA',
       freq: '14.025',
       comment: 'CW 20 dB 22 WPM CQ',
-      mode: 'CW',
-      source: 'RBN',
+      source: 'DXCluster',
     });
-    const humanSpot = (i) => ({
-      call: `HU${i}MAN`,
+    const ssbSpot = (i) => ({
+      call: `S${i}SB`,
       spotter: 'K0CJH',
-      freq: '14.200',
+      freq: '14.2',
       comment: '59 tnx',
-      source: 'HamQTH',
+      source: 'DXCluster',
     });
 
     it('returns the list untouched when it fits the window', () => {
-      const spots = [ft8Spot(0), humanSpot(0)];
+      const spots = [ft8Spot(0), ssbSpot(0)];
       expect(balanceSpotWindow(spots, 50)).toEqual(spots);
     });
 
-    it('keeps human spots buried deep behind skimmer churn', () => {
-      // 100 fresh FT8 spots ahead of 10 aging human spots — a plain
-      // newest-50 slice would show zero humans
+    it('keeps SSB spots buried deep behind skimmer churn', () => {
+      // 100 fresh FT8 spots ahead of 10 aging SSB spots — a plain
+      // newest-50 slice would show zero SSB
       const spots = [
         ...Array.from({ length: 100 }, (_, i) => ft8Spot(i)),
-        ...Array.from({ length: 10 }, (_, i) => humanSpot(i)),
+        ...Array.from({ length: 10 }, (_, i) => ssbSpot(i)),
       ];
       const windowed = balanceSpotWindow(spots, 50);
       expect(windowed).toHaveLength(50);
-      expect(windowed.filter((s) => s.source === 'HamQTH')).toHaveLength(10);
+      expect(windowed.filter((s) => s.spotter === 'K0CJH')).toHaveLength(10);
     });
 
-    it('caps FT8/FT4 so other skimmer modes survive', () => {
+    it('caps FT8/FT4 so other modes survive', () => {
       const spots = [];
       for (let i = 0; i < 60; i++) spots.push(ft8Spot(i));
       for (let i = 0; i < 60; i++) spots.push(cwSpot(i));
       const windowed = balanceSpotWindow(spots, 40);
       expect(windowed).toHaveLength(40);
-      expect(windowed.filter((s) => s.mode === 'FT8').length).toBeLessThanOrEqual(20);
-      expect(windowed.filter((s) => s.mode === 'CW').length).toBeGreaterThanOrEqual(20);
+      expect(windowed.filter((s) => s.comment.startsWith('FT8')).length).toBeLessThanOrEqual(20);
+      expect(windowed.filter((s) => s.comment.startsWith('CW')).length).toBeGreaterThanOrEqual(20);
     });
 
     it('backfills the window when only FT8 is on the air', () => {
@@ -803,7 +804,7 @@ describe('dxClusterFilters', () => {
     });
 
     it('preserves feed order in the output', () => {
-      const spots = [...Array.from({ length: 60 }, (_, i) => ft8Spot(i)), humanSpot(0)];
+      const spots = [...Array.from({ length: 60 }, (_, i) => ft8Spot(i)), ssbSpot(0)];
       const windowed = balanceSpotWindow(spots, 50);
       const idx = (call) => spots.findIndex((s) => s.call === call);
       for (let i = 1; i < windowed.length; i++) {
@@ -811,13 +812,24 @@ describe('dxClusterFilters', () => {
       }
     });
 
-    it('recognizes skimmers by the -# suffix when spots carry no source field', () => {
+    it('prefers an explicit mode field over comment/frequency inference', () => {
+      // OHC spots-endpoint shape carries mode; a "SSB" mode on an odd
+      // frequency must still land in the voice reserve
       const spots = [
-        ...Array.from({ length: 60 }, (_, i) => ({ ...ft8Spot(i), source: undefined })),
-        { call: 'PY6RT', spotter: 'K0CJH', freq: '14.200', comment: '59', source: undefined },
+        ...Array.from({ length: 60 }, (_, i) => ft8Spot(i)),
+        { call: 'PY6RT', spotter: 'K0CJH', freq: '14.347', comment: '', mode: 'SSB' },
       ];
       const windowed = balanceSpotWindow(spots, 50);
       expect(windowed.some((s) => s.call === 'PY6RT')).toBe(true);
+    });
+
+    it('treats mode-unknown spots as voice so human spots are never starved', () => {
+      const spots = [
+        ...Array.from({ length: 60 }, (_, i) => ft8Spot(i)),
+        { call: 'ZL1XYZ', spotter: 'K0CJH', freq: '14.100', comment: 'loud', source: 'DXCluster' },
+      ];
+      const windowed = balanceSpotWindow(spots, 50);
+      expect(windowed.some((s) => s.call === 'ZL1XYZ')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Problem

Third piece of the SSB puzzle (after #1119, #1120). Users still saw zero SSB because the DX cluster panel is fed by `/api/dxcluster/paths`, not `/api/dxcluster/spots`:

- The paths route accumulates spots newest-first, caps at 100, and returns the newest 50. RBN skimmer spots always carry the freshest timestamps, so human spots — the only SSB source — were cut **server-side**. Verified live: the paths payload contained exactly one phone-band row, a CW beacon.
- The paths shape also drops `mode`/`source` and strips the `-#` skimmer suffix, so #1120's client-side classification had nothing to key on and was a silent no-op.

## Fix

- `capWithDXpeditions()` now mode-balances before slicing. RBN comments always lead with the mode ("FT8 -13 dB", "CW 26 dB 22 WPM"), so a spot without a mode marker is human traffic: humans/voice get a 25% reserve, FT8/FT4 capped at 50%, leftovers backfilled. DXpedition exemption unchanged.
- `balanceSpotWindow()` (client) reclassifies via `detectMode` — comment keywords, then band-plan frequency inference — the only signals that survive every feed shape.

## Verification

- Ran the patched server locally against the production cluster node: `/api/dxcluster/paths?source=ohc` went from **1 phone-band row** to **25 FT8/FT4 + 13 human/voice + 12 CW**, including live SSB spots (ZF2OO 14.208, IK0PHY 14.214).
- Unit tests updated to exercise the real paths shape (no mode/source, stripped spotter): 1031 passing, build clean.

Same change is on Staging as d72bd28e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)