### PR TITLE
feat(cluster): hold an hour of spot history through the whole chain

### DIFF
--- a/ohc-cluster/lib/store.js
+++ b/ohc-cluster/lib/store.js
@@ -16,8 +16,12 @@
 const { bandForKhz, toHHMMz } = require('./format.js');
 
 const DEFAULTS = {
-  retentionMs: 30 * 60 * 1000, // drop spots older than 30 min
-  maxSpots: 2000, // hard cap across all sources
+  // A full hour of history so mode-filtered queries (?mode=SSB) have real
+  // depth — SSB-only traffic is sparse and a 30-min window left users with a
+  // handful of results. New-aggregate rate runs ~4700/hour (measured), so the
+  // cap needs headroom above that or eviction silently undercuts retention.
+  retentionMs: 60 * 60 * 1000,
+  maxSpots: 8000, // hard cap across all sources
   humanDedupWindowMs: 2 * 60 * 1000, // same spotter+call+freq within 2 min = dupe
   skimmerRebroadcastMs: 10 * 60 * 1000, // re-announce a busy station at most every 10 min
   humanReserveShare: 0.25, // slice of the default query window held for human spots

--- a/server/routes/dxcluster.js
+++ b/server/routes/dxcluster.js
@@ -1129,12 +1129,12 @@ module.exports = function (app, ctx) {
   // Cache for DX spot paths to avoid excessive lookups (per source/profile)
   const dxSpotPathsCacheByKey = new Map();
   const DXPATHS_CACHE_TTL = 25000; // 25 seconds cache (just under 30s poll interval to maximize cache hits)
-  const DXPATHS_RETENTION = 30 * 60 * 1000; // 30 minute spot retention
+  const DXPATHS_RETENTION = 60 * 60 * 1000; // 60 min — deep enough that mode filters (SSB-only) have real history
   // DXpedition-tagged paths get longer retention and are exempt from display
-  // caps: under RBN skimmer volume (OHC Cluster source) the newest-100 window
-  // spans only a few minutes, which starved the dxpeditionsOnly filter of the
+  // caps: under RBN skimmer volume (OHC Cluster source) a newest-N window
+  // spans only minutes, which starved the dxpeditionsOnly filter of the
   // handful of spots it exists to surface.
-  const DXPEDITION_RETENTION = 60 * 60 * 1000;
+  const DXPEDITION_RETENTION = 2 * 60 * 60 * 1000;
   const isPathLive = (p, now) => now - p.timestamp < (p.isDXpedition ? DXPEDITION_RETENTION : DXPATHS_RETENTION);
   // Mode-balanced cap. A plain newest-N slice is almost pure FT8/FT4 skimmer
   // churn (freshest timestamps always), which starves the window of SSB
@@ -1958,7 +1958,7 @@ module.exports = function (app, ctx) {
       if (newSpots.length === 0) {
         // Return existing paths if fetch failed
         const validPaths = pathsCache.allPaths.filter((p) => isPathLive(p, now));
-        return res.json(capWithDXpeditions(validPaths, 50));
+        return res.json(capWithDXpeditions(validPaths, 150));
       }
 
       // Get unique callsigns to look up (sanitize and strip modifiers)
@@ -2216,10 +2216,11 @@ module.exports = function (app, ctx) {
         }
       }
 
-      // Sort by timestamp (newest first) and limit
+      // Sort by timestamp (newest first) and cap. 600 holds a full hour of
+      // balanced history — the accumulator is what mode filters draw from.
       const sortedPaths = capWithDXpeditions(
         mergedPaths.sort((a, b) => b.timestamp - a.timestamp),
-        100,
+        600,
       );
 
       logDebug(
@@ -2251,12 +2252,12 @@ module.exports = function (app, ctx) {
 
       // Update cache
       dxSpotPathsCacheByKey.set(cacheKey, {
-        paths: capWithDXpeditions(sortedPaths, 50), // Return 50 for display
+        paths: capWithDXpeditions(sortedPaths, 150), // Return 150 for display/filtering
         allPaths: sortedPaths, // Keep all for accumulation
         timestamp: now,
       });
 
-      res.json(capWithDXpeditions(sortedPaths, 50));
+      res.json(capWithDXpeditions(sortedPaths, 150));
     } catch (error) {
       logErrorOnce('DX Paths', error.message);
       // Return cached data on error

--- a/src/hooks/useDXClusterData.js
+++ b/src/hooks/useDXClusterData.js
@@ -5,7 +5,7 @@
  */
 import { useState, useEffect, useCallback, useRef } from 'react';
 
-import { applyDXFilters } from '../utils/dxClusterFilters';
+import { applyDXFilters, balanceSpotWindow } from '../utils/dxClusterFilters';
 import { useVisibilityRefresh } from './useVisibilityRefresh';
 import { apiFetch } from '../utils/apiFetch';
 
@@ -93,13 +93,18 @@ export const useDXClusterData = (filters = {}, config = {}) => {
               (item) => now - (item.timestamp || now) < effectiveRetentionMs,
             );
 
-            // Sort by timestamp (newest first) and limit. DXpedition-tagged
-            // spots are rare and exempt from the cap — under RBN skimmer
-            // volume 200 spots span minutes, which would evict them long
-            // before their retention expires.
+            // Sort by timestamp (newest first) and cap. The accumulator is
+            // what mode filters draw from, so it holds an hour of history
+            // (600 spots) and evicts mode-balanced — a plain newest-N cap
+            // would let FT8/FT4 skimmer churn flush out the sparse SSB
+            // history within minutes. DXpedition-tagged spots are rare and
+            // exempt from the cap entirely.
             const sorted = validItems.sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
             const dxpeditions = sorted.filter((item) => item.isDXpedition);
-            const regular = sorted.filter((item) => !item.isDXpedition).slice(0, 200);
+            const regular = balanceSpotWindow(
+              sorted.filter((item) => !item.isDXpedition),
+              config.lowMemoryMode ? 200 : 600,
+            );
             return [...dxpeditions, ...regular].sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
           });
 


### PR DESCRIPTION
## Problem

Mode filters (SSB-only etc.) were starved even after the balancing fixes (#1119–#1121): every layer kept only a shallow newest-N window — cluster store 30 min (and actually eviction-bound at the 2000 cap), paths accumulator 100 spots / 30 min, response 50 rows, client accumulator 200 newest. Filtering by SSB left users with a handful of rows.

## Change

An hour of history at every layer, all behind the mode-balanced caps so skimmer churn can't flush the sparse SSB history:

- **ohc-cluster store**: retention 30 → 60 min, cap 2000 → 8000 (measured new-aggregate rate is ~4700/hour — the old cap silently undercut even 30-min retention)
- **paths route**: retention 30 → 60 min (DXpeditions 2 h), accumulator 100 → 600, response 50 → 150
- **client accumulator**: 200 → 600 (200 in low-memory mode), evicting via `balanceSpotWindow` instead of a plain newest-N slice

## Verification

Ran the patched server locally against the production cluster: paths response is 150 balanced rows (85 FT8/FT4, 39 CW/RTTY, 26 human/voice incl. 8 live SSB). History deepens as accumulators age post-deploy. Full suite: 1031 passing, cluster tests 25/25, build clean.

Needs **both** Railway services redeployed (ohc-cluster + main app). Same change is on Staging as 457f9efa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)