### PR TITLE
feat(cluster): ingest POTA, SOTA, DX Summit and dxspider-proxy human spots

### DIFF
--- a/ohc-cluster/README.md
+++ b/ohc-cluster/README.md
@@ -8,15 +8,23 @@ No DXSpider/AR-Cluster nodes are scraped. That's the point.
 
 ## Spot sources
 
-| Source    | What                  | How                                                       |
-| --------- | --------------------- | --------------------------------------------------------- |
-| RBN       | CW/RTTY skimmer spots | telnet.reversebeacon.net:7000 (open feed, built for this) |
-| RBN       | FT8/FT4 skimmer spots | telnet.reversebeacon.net:7001                             |
-| HamQTH    | Human cluster spots   | public CSV feed, polled once per minute                   |
-| OHC users | Human spots           | telnet `dx` command or `POST /api/dxcluster/spot`         |
+| Source         | What                  | How                                                       |
+| -------------- | --------------------- | --------------------------------------------------------- |
+| RBN            | CW/RTTY skimmer spots | telnet.reversebeacon.net:7000 (open feed, built for this) |
+| RBN            | FT8/FT4 skimmer spots | telnet.reversebeacon.net:7001                             |
+| HamQTH         | Human cluster spots   | public CSV feed, polled once per minute                   |
+| POTA           | Activator spots       | api.pota.app JSON, 1/min (RBN reposts skipped)            |
+| SOTA           | Summit spots          | api2.sota.org.uk JSON, 1/min                              |
+| DX Summit      | Human cluster spots   | dxsummit.fi JSON API, 1/min                               |
+| dxspider-proxy | Human cluster spots   | our own DXSpider client node's feed, 1/min                |
+| OHC users      | Human spots           | telnet `dx` command or `POST /api/dxcluster/spot`         |
 
 RBN volume is collapsed by call+band+mode into living aggregates (skimmer
-count, best SNR) so 40 skimmers hearing the same CQ produce one spot.
+count, best SNR) so 40 skimmers hearing the same CQ produce one spot. The
+human-spot pollers exist mostly for phone coverage: RBN can't decode SSB, so
+without them the only phone supply was HamQTH's shared 50-row window.
+Repeated rows are dropped per source (spot ids), and the same real spot
+arriving via two sources is deduped by spotter+call+freq window.
 
 ## Interfaces
 
@@ -48,15 +56,17 @@ send that email.
 
 ## Environment
 
-| Var              | Default | Purpose                                                             |
-| ---------------- | ------- | ------------------------------------------------------------------- |
-| `HTTP_PORT`      | 3002    | HTTP API port (falls back to `PORT` unless that is the telnet port) |
-| `TELNET_PORT`    | 7300    | telnet cluster port                                                 |
-| `CALLSIGN`       | K0CJH   | RBN login callsign (must be valid)                                  |
-| `NODE_CALL`      | K0CJH-2 | node callsign shown to telnet users                                 |
-| `RBN_ENABLED`    | 1       | set `0` to disable RBN ingest                                       |
-| `HAMQTH_ENABLED` | 1       | set `0` to disable HamQTH polling                                   |
-| `LOG_LEVEL`      | info    | `debug` / `info` / `warn`                                           |
+| Var                                                                       | Default          | Purpose                                                             |
+| ------------------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------- |
+| `HTTP_PORT`                                                               | 3002             | HTTP API port (falls back to `PORT` unless that is the telnet port) |
+| `TELNET_PORT`                                                             | 7300             | telnet cluster port                                                 |
+| `CALLSIGN`                                                                | K0CJH            | RBN login callsign (must be valid)                                  |
+| `NODE_CALL`                                                               | K0CJH-2          | node callsign shown to telnet users                                 |
+| `RBN_ENABLED`                                                             | 1                | set `0` to disable RBN ingest                                       |
+| `HAMQTH_ENABLED`                                                          | 1                | set `0` to disable HamQTH polling                                   |
+| `POTA_ENABLED` / `SOTA_ENABLED` / `DXSUMMIT_ENABLED` / `DXSPIDER_ENABLED` | 1                | set `0` to disable that human-spot poller                           |
+| `DXSPIDER_PROXY_URL`                                                      | production proxy | base URL of our dxspider-proxy feed                                 |
+| `LOG_LEVEL`                                                               | info             | `debug` / `info` / `warn`                                           |
 
 ## Tests
 

--- a/ohc-cluster/lib/httpApi.js
+++ b/ohc-cluster/lib/httpApi.js
@@ -17,7 +17,7 @@ const SUBMIT_WINDOW_MS = 60 * 1000;
 const SUBMIT_MAX_PER_WINDOW = 10; // per IP — an OHC instance may proxy a few users
 const submitTimesByIp = new Map();
 
-function buildHttpApi({ store, feeds, telnetServer, hamqth, log, startTime, nodeCall }) {
+function buildHttpApi({ store, feeds, telnetServer, hamqth, pollers = [], log, startTime, nodeCall }) {
   const app = express();
   app.use(cors());
   app.use(express.json({ limit: '8kb' }));
@@ -44,6 +44,7 @@ function buildHttpApi({ store, feeds, telnetServer, hamqth, log, startTime, node
       spots: stats.activeSpots,
       feeds: feeds.map((f) => f.status()),
       hamqth: hamqth ? hamqth.status() : null,
+      pollers: pollers.map((p) => p.status()),
       telnet: telnetServer ? telnetServer.status() : null,
     });
   });
@@ -53,6 +54,7 @@ function buildHttpApi({ store, feeds, telnetServer, hamqth, log, startTime, node
       store: store.stats(),
       feeds: feeds.map((f) => f.status()),
       hamqth: hamqth ? hamqth.status() : null,
+      pollers: pollers.map((p) => p.status()),
       telnet: telnetServer ? telnetServer.status() : null,
     });
   });

--- a/ohc-cluster/lib/pollers.js
+++ b/ohc-cluster/lib/pollers.js
@@ -1,0 +1,237 @@
+/**
+ * HTTP JSON spot pollers — human-spot sources beyond HamQTH.
+ *
+ * RBN can't decode phone, so SSB exists only where humans type spots. One
+ * 50-row HamQTH poll per minute was our whole phone supply; these pollers
+ * widen it:
+ *   POTA      api.pota.app          activator spots, explicit mode, kHz
+ *   SOTA      api2.sota.org.uk      summit spots, explicit mode, MHz
+ *   DXSummit  dxsummit.fi           classic cluster spots, no mode field
+ *   DXSpider  our own dxspider-proxy node feed
+ *
+ * Each source gets a seen-key dedupe (spot ids where the API provides them,
+ * composite keys otherwise) because re-polling returns mostly the same rows —
+ * and the proxy feed carries no date at all, so store-level timestamp dedupe
+ * can't catch its repeats. Cross-source duplicates of the same real spot are
+ * handled by the store's spotter+call+freq window.
+ */
+
+const POLL_INTERVAL_MS = 60 * 1000;
+const FETCH_TIMEOUT_MS = 10 * 1000;
+const SEEN_TTL_MS = 2 * 60 * 60 * 1000; // outlives store retention
+
+// "2026-07-09T23:12:58" — these APIs emit UTC without the Z
+const parseUtcNoZ = (s) => {
+  const ts = Date.parse(
+    String(s || '')
+      .trim()
+      .replace(/Z?$/, 'Z'),
+  );
+  return Number.isFinite(ts) ? ts : Date.now();
+};
+
+const clean = (s) =>
+  String(s || '')
+    .trim()
+    .toUpperCase();
+
+/** api.pota.app/spot/activator */
+function parsePotaSpots(json) {
+  const out = [];
+  for (const row of Array.isArray(json) ? json : []) {
+    const spotter = clean(row.spotter);
+    // RBN reposts (spotter "XX0XX-#") — we ingest RBN directly; skip
+    if (!spotter || spotter.endsWith('-#') || row.invalid) continue;
+    const freqKhz = parseFloat(row.frequency); // already kHz
+    if (!Number.isFinite(freqKhz) || freqKhz <= 0) continue;
+    const comment = ['POTA', row.reference, String(row.comments || '').trim()].filter(Boolean).join(' ').slice(0, 72);
+    out.push({
+      key: `pota|${row.spotId}`,
+      spot: {
+        spotter,
+        call: clean(row.activator),
+        freqKhz,
+        mode: clean(row.mode) || null,
+        comment,
+        dxGrid: row.grid6 || row.grid4 || null,
+        timestamp: parseUtcNoZ(row.spotTime),
+        source: 'POTA',
+        isSkimmer: false,
+      },
+    });
+  }
+  return out;
+}
+
+/** api2.sota.org.uk/api/spots/<n>/all */
+function parseSotaSpots(json) {
+  const out = [];
+  for (const row of Array.isArray(json) ? json : []) {
+    const call = clean(row.activatorCallsign || row.callsign);
+    if (!call) continue;
+    const mhz = parseFloat(row.frequency);
+    if (!Number.isFinite(mhz) || mhz <= 0) continue;
+    const freqKhz = mhz > 1000 ? mhz : mhz * 1000; // API emits MHz
+    const summit = [row.associationCode, row.summitCode].filter(Boolean).join('/');
+    const comment = ['SOTA', summit, String(row.comments || '').trim()].filter(Boolean).join(' ').slice(0, 72);
+    out.push({
+      key: `sota|${row.id}`,
+      spot: {
+        spotter: clean(row.callsign) || call,
+        call,
+        freqKhz,
+        mode: clean(row.mode) || null,
+        comment,
+        timestamp: parseUtcNoZ(row.timeStamp),
+        source: 'SOTA',
+        isSkimmer: false,
+      },
+    });
+  }
+  return out;
+}
+
+/** dxsummit.fi/api/v1/spots — no mode field; consumers infer from freq/comment */
+function parseDxSummitSpots(json) {
+  const out = [];
+  for (const row of Array.isArray(json) ? json : []) {
+    const spotter = clean(row.de_call);
+    const call = clean(row.dx_call);
+    const freqKhz = parseFloat(row.frequency);
+    if (!spotter || !call || !Number.isFinite(freqKhz) || freqKhz <= 0) continue;
+    out.push({
+      key: `dxsummit|${row.id}`,
+      spot: {
+        spotter,
+        call,
+        freqKhz,
+        mode: null,
+        comment: String(row.info || '')
+          .trim()
+          .slice(0, 72),
+        timestamp: parseUtcNoZ(row.time),
+        source: 'DXSummit',
+        isSkimmer: false,
+      },
+    });
+  }
+  return out;
+}
+
+/** our dxspider-proxy /api/dxcluster/spots — freq in MHz, no date (HH:MMz only) */
+function parseDxSpiderSpots(json) {
+  const out = [];
+  for (const row of Array.isArray(json) ? json : []) {
+    const spotter = clean(row.spotter);
+    const call = clean(row.call);
+    const mhz = parseFloat(row.freq);
+    if (!spotter || !call || !Number.isFinite(mhz) || mhz <= 0) continue;
+    const freqKhz = mhz > 1000 ? mhz : mhz * 1000;
+    out.push({
+      // No date in the feed — the composite key is the only repeat guard
+      key: `spider|${spotter}|${call}|${freqKhz}|${row.time || ''}`,
+      spot: {
+        spotter,
+        call,
+        freqKhz,
+        mode: clean(row.mode) || null,
+        comment: String(row.comment || '')
+          .trim()
+          .slice(0, 72),
+        timestamp: Date.now(), // feed is near-live; HH:MMz adds nothing safe
+        source: 'DXSpider',
+        isSkimmer: false,
+      },
+    });
+  }
+  return out;
+}
+
+class JsonPoller {
+  constructor({ name, url, parse, store, log, appVersion, intervalMs = POLL_INTERVAL_MS }) {
+    this.name = name;
+    this.url = url;
+    this.parse = parse;
+    this.store = store;
+    this.log = log;
+    this.userAgent = `OpenHamClock-Cluster/${appVersion || '0.1.0'}`;
+    this.intervalMs = intervalMs;
+
+    this.timer = null;
+    this.seen = new Map(); // key -> first-seen ts
+    this.lastPollAt = 0;
+    this.lastSuccessAt = 0;
+    this.pollCount = 0;
+    this.errorCount = 0;
+    this.spotCount = 0; // spots actually stored (past seen-set and store dedupe)
+  }
+
+  start() {
+    this._poll();
+    this.timer = setInterval(() => this._poll(), this.intervalMs);
+  }
+
+  stop() {
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  status() {
+    return {
+      name: this.name,
+      lastPollAgeMs: this.lastPollAt ? Date.now() - this.lastPollAt : null,
+      lastSuccessAgeMs: this.lastSuccessAt ? Date.now() - this.lastSuccessAt : null,
+      pollCount: this.pollCount,
+      errorCount: this.errorCount,
+      spotCount: this.spotCount,
+    };
+  }
+
+  /** Feed parsed rows through the seen-set into the store. Exposed for tests. */
+  ingest(rows) {
+    const now = Date.now();
+    let stored = 0;
+    for (const { key, spot } of rows) {
+      if (this.seen.has(key)) continue;
+      this.seen.set(key, now);
+      if (this.store.add(spot)) {
+        stored++;
+        this.spotCount++;
+      }
+    }
+    // Sweep expired keys so the set can't grow forever
+    if (this.seen.size > 5000) {
+      const cutoff = now - SEEN_TTL_MS;
+      for (const [key, ts] of this.seen) {
+        if (ts < cutoff) this.seen.delete(key);
+      }
+    }
+    return stored;
+  }
+
+  async _poll() {
+    this.lastPollAt = Date.now();
+    this.pollCount++;
+    try {
+      const response = await fetch(this.url, {
+        headers: { 'User-Agent': this.userAgent, Accept: 'application/json' },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const stored = this.ingest(this.parse(await response.json()));
+      if (stored > 0) this.log('SPOT', `[${this.name}] +${stored} spots`);
+      this.lastSuccessAt = Date.now();
+    } catch (err) {
+      this.errorCount++;
+      this.log('ERROR', `[${this.name}] poll failed: ${err.message}`);
+    }
+  }
+}
+
+module.exports = {
+  JsonPoller,
+  parsePotaSpots,
+  parseSotaSpots,
+  parseDxSummitSpots,
+  parseDxSpiderSpots,
+};

--- a/ohc-cluster/server.js
+++ b/ohc-cluster/server.js
@@ -4,8 +4,9 @@
  * Born 2026-06-10 after the NC7J sysop suggested we "build our own cluster".
  * OK. Done.
  *
- * Ingest:  RBN skimmer feeds (CW/RTTY + FT8/FT4), HamQTH human spots,
- *          user submissions (telnet `dx` command + HTTP POST).
+ * Ingest:  RBN skimmer feeds (CW/RTTY + FT8/FT4), human spots from HamQTH,
+ *          POTA, SOTA, DX Summit and our dxspider-proxy node, plus user
+ *          submissions (telnet `dx` command + HTTP POST).
  * Serve:   classic telnet cluster on :7300, HTTP API on :3002.
  *
  * Environment:
@@ -17,12 +18,22 @@
  *   NODE_CALL     node callsign shown to telnet users     (default K0CJH-2)
  *   RBN_ENABLED   set to '0' to disable RBN ingest
  *   HAMQTH_ENABLED set to '0' to disable HamQTH ingest
+ *   POTA_ENABLED / SOTA_ENABLED / DXSUMMIT_ENABLED / DXSPIDER_ENABLED
+ *                 set to '0' to disable the matching human-spot poller
+ *   DXSPIDER_PROXY_URL  our proxy's base URL (defaults to production)
  *   LOG_LEVEL     debug | info | warn   (default info)
  */
 
 const { SpotStore } = require('./lib/store.js');
 const { RbnFeed } = require('./lib/rbn.js');
 const { HamqthPoller } = require('./lib/hamqth.js');
+const {
+  JsonPoller,
+  parsePotaSpots,
+  parseSotaSpots,
+  parseDxSummitSpots,
+  parseDxSpiderSpots,
+} = require('./lib/pollers.js');
 const { TelnetClusterServer } = require('./lib/telnetServer.js');
 const { buildHttpApi } = require('./lib/httpApi.js');
 const { isValidCallsign } = require('./lib/callsign.js');
@@ -97,6 +108,41 @@ if (process.env.HAMQTH_ENABLED !== '0') {
   hamqth.start();
 }
 
+// Additional human-spot pollers — the SSB supply (RBN can't decode phone)
+const DXSPIDER_PROXY_URL = (process.env.DXSPIDER_PROXY_URL || 'https://spider-production-1ec7.up.railway.app')
+  .trim()
+  .replace(/\/+$/, '');
+const pollerDefs = [
+  { flag: 'POTA_ENABLED', name: 'pota', url: 'https://api.pota.app/spot/activator', parse: parsePotaSpots },
+  { flag: 'SOTA_ENABLED', name: 'sota', url: 'https://api2.sota.org.uk/api/spots/60/all', parse: parseSotaSpots },
+  {
+    flag: 'DXSUMMIT_ENABLED',
+    name: 'dxsummit',
+    url: 'http://www.dxsummit.fi/api/v1/spots?limit=50',
+    parse: parseDxSummitSpots,
+  },
+  {
+    flag: 'DXSPIDER_ENABLED',
+    name: 'dxspider',
+    url: `${DXSPIDER_PROXY_URL}/api/dxcluster/spots?limit=50`,
+    parse: parseDxSpiderSpots,
+  },
+];
+const pollers = [];
+for (const def of pollerDefs) {
+  if (process.env[def.flag] === '0') continue;
+  const poller = new JsonPoller({
+    name: def.name,
+    url: def.url,
+    parse: def.parse,
+    store,
+    log,
+    appVersion: pkg.version,
+  });
+  poller.start();
+  pollers.push(poller);
+}
+
 // ── Serve ─────────────────────────────────────────────────────────────
 const telnetServer = new TelnetClusterServer({
   port: TELNET_PORT,
@@ -107,7 +153,7 @@ const telnetServer = new TelnetClusterServer({
 });
 telnetServer.start();
 
-const app = buildHttpApi({ store, feeds, telnetServer, hamqth, log, startTime, nodeCall: NODE_CALL });
+const app = buildHttpApi({ store, feeds, telnetServer, hamqth, pollers, log, startTime, nodeCall: NODE_CALL });
 app.listen(HTTP_PORT, () => {
   log('START', `OHC-Cluster v${pkg.version} — HTTP :${HTTP_PORT}, telnet :${TELNET_PORT}, node call ${NODE_CALL}`);
 });
@@ -117,6 +163,7 @@ const shutdown = () => {
   log('START', 'Shutting down');
   for (const feed of feeds) feed.stop();
   hamqth?.stop();
+  for (const poller of pollers) poller.stop();
   telnetServer.stop();
   process.exit(0);
 };

--- a/ohc-cluster/test/pollers.test.js
+++ b/ohc-cluster/test/pollers.test.js
@@ -1,0 +1,135 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  JsonPoller,
+  parsePotaSpots,
+  parseSotaSpots,
+  parseDxSummitSpots,
+  parseDxSpiderSpots,
+} = require('../lib/pollers.js');
+const { SpotStore } = require('../lib/store.js');
+
+// Fixtures mirror real API responses captured 2026-07-09
+const POTA_ROW = {
+  spotId: 53252827,
+  activator: 'KD8IE',
+  frequency: '14278.0',
+  mode: 'SSB',
+  reference: 'US-1942',
+  spotTime: '2026-07-09T23:12:58',
+  spotter: 'KE8AFJ',
+  comments: '5/8 VA',
+  invalid: null,
+  grid6: 'EN91em',
+};
+
+const SOTA_ROW = {
+  id: 345544,
+  timeStamp: '2026-07-09T23:13:29',
+  comments: 'Matariki',
+  callsign: 'ZL1BYZ',
+  associationCode: 'ZL1',
+  summitCode: 'AK-027',
+  activatorCallsign: 'ZL1BYZ',
+  frequency: '28.062',
+  mode: 'CW',
+};
+
+const DXSUMMIT_ROW = {
+  info: 'FT8 GG66sj -> GG54',
+  de_call: 'PY2DN',
+  frequency: 144174.0,
+  time: '2026-07-09T23:14:42',
+  dx_call: 'PY5CC',
+  id: 67424269,
+};
+
+const SPIDER_ROW = {
+  spotter: 'PU2LQX',
+  freq: '21.074',
+  call: 'KA1MXL',
+  comment: 'FT8, TNX QSO, 73s',
+  time: '23:14z',
+  mode: 'FT8',
+};
+
+test('parsePotaSpots: maps kHz, mode, grid, and skips RBN reposts', () => {
+  const rows = parsePotaSpots([
+    POTA_ROW,
+    { ...POTA_ROW, spotId: 1, spotter: 'DR4W-#' }, // RBN repost — skip
+    { ...POTA_ROW, spotId: 2, invalid: true }, // withdrawn — skip
+  ]);
+  assert.equal(rows.length, 1);
+  const { key, spot } = rows[0];
+  assert.equal(key, 'pota|53252827');
+  assert.equal(spot.call, 'KD8IE');
+  assert.equal(spot.freqKhz, 14278);
+  assert.equal(spot.mode, 'SSB');
+  assert.equal(spot.dxGrid, 'EN91em');
+  assert.equal(spot.comment, 'POTA US-1942 5/8 VA');
+  assert.equal(spot.timestamp, Date.parse('2026-07-09T23:12:58Z'));
+  assert.equal(spot.isSkimmer, false);
+});
+
+test('parseSotaSpots: converts MHz to kHz and builds the summit reference', () => {
+  const rows = parseSotaSpots([SOTA_ROW]);
+  assert.equal(rows.length, 1);
+  const { key, spot } = rows[0];
+  assert.equal(key, 'sota|345544');
+  assert.equal(spot.freqKhz, 28062);
+  assert.equal(spot.mode, 'CW');
+  assert.equal(spot.comment, 'SOTA ZL1/AK-027 Matariki');
+  assert.equal(spot.source, 'SOTA');
+});
+
+test('parseDxSummitSpots: maps fields, leaves mode null for inference', () => {
+  const rows = parseDxSummitSpots([DXSUMMIT_ROW, { ...DXSUMMIT_ROW, id: 2, dx_call: '' }]);
+  assert.equal(rows.length, 1);
+  const { spot } = rows[0];
+  assert.equal(spot.spotter, 'PY2DN');
+  assert.equal(spot.call, 'PY5CC');
+  assert.equal(spot.freqKhz, 144174);
+  assert.equal(spot.mode, null);
+  assert.equal(spot.comment, 'FT8 GG66sj -> GG54');
+});
+
+test('parseDxSpiderSpots: MHz to kHz, composite key covers the missing date', () => {
+  const rows = parseDxSpiderSpots([SPIDER_ROW]);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].key, 'spider|PU2LQX|KA1MXL|21074|23:14z');
+  assert.equal(rows[0].spot.freqKhz, 21074);
+  assert.equal(rows[0].spot.mode, 'FT8');
+});
+
+test('JsonPoller.ingest: seen-set drops repeats across polls', () => {
+  const store = new SpotStore();
+  const poller = new JsonPoller({
+    name: 'test',
+    url: 'http://unused',
+    parse: (x) => x,
+    store,
+    log: () => {},
+  });
+
+  const rows = parsePotaSpots([POTA_ROW]);
+  assert.equal(poller.ingest(rows), 1);
+  assert.equal(poller.ingest(rows), 0); // same poll payload again — all seen
+  assert.equal(store.stats().activeSpots, 1);
+});
+
+test('JsonPoller.ingest: distinct spots from the same source all land', () => {
+  const store = new SpotStore();
+  const poller = new JsonPoller({
+    name: 'test',
+    url: 'http://unused',
+    parse: (x) => x,
+    store,
+    log: () => {},
+  });
+  const rows = parsePotaSpots([
+    POTA_ROW,
+    { ...POTA_ROW, spotId: 99, activator: 'W1AW', frequency: '7200.0', spotter: 'K1ABC' },
+  ]);
+  assert.equal(poller.ingest(rows), 2);
+});


### PR DESCRIPTION
## Problem

SSB supply was a single 50-row HamQTH poll shared across all modes. RBN can't decode phone, so human spots are the only phone source — and one thin feed meant an SSB filter had a handful of rows even with an hour of retention (#1123).

## Change

Four new 1-per-minute JSON pollers in ohc-cluster, all verified live before writing a line of parser:

- **POTA** (api.pota.app/spot/activator) — explicit mode, kHz, grid6. RBN reposts (spotter `XX0XX-#`, 22 of 63 rows!) and withdrawn spots are skipped since we ingest RBN directly.
- **SOTA** (api2.sota.org.uk) — explicit mode, MHz converted to kHz, summit reference in the comment.
- **DX Summit** (dxsummit.fi/api/v1/spots) — classic cluster human spots; no mode field, left null for client band-plan inference.
- **dxspider-proxy** — our own DXSpider client node's feed; zero new external dependencies.

Shared `JsonPoller` with a per-source seen-key dedupe (spot ids where the API has them; a composite key for the proxy feed, which carries no date so timestamp-window dedupe can't catch its repeats). Cross-source duplicates of the same real spot fall to the store's existing spotter+call+freq window. Each poller has an env kill-switch (`POTA_ENABLED=0` etc.) and reports in `/health` and `/api/stats` under `pollers`.

## Verification

- 31/31 cluster unit tests (6 new: per-parser fixtures from captured live responses, seen-set repeat handling).
- Ran the node locally against all four real APIs: one poll cycle stored ~150 new human spots with zero errors, and `?mode=SSB` returned **37 rows** (POTA 21, SOTA 15, spider 1) — up from ~4 before.

Only the **ohc-cluster** Railway service needs redeploying. Same change is on Staging as b7049e73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)