### PR TITLE
fix(cluster): enrich locations for the whole paths batch, not the first 100

### DIFF
--- a/server/routes/dxcluster.js
+++ b/server/routes/dxcluster.js
@@ -1987,8 +1987,13 @@ module.exports = function (app, ctx) {
       });
 
       // Look up prefix-based locations for all callsigns (includes grid squares!)
+      // estimateLocationFromPrefix is a local CTY-table lookup — cheap enough
+      // to run for every call in the batch. A 100-call cap here silently left
+      // spots past it uncharted once fetches grew past 50 spots (the map
+      // filters out paths with no spotter coordinates). The remote HamQTH
+      // batch below has its own 10-per-cycle cap.
       const prefixLocations = {};
-      const callsToLookup = [...allCalls].slice(0, 100);
+      const callsToLookup = [...allCalls].slice(0, 1000);
 
       for (const call of callsToLookup) {
         const loc = estimateLocationFromPrefix(call);


### PR DESCRIPTION
## Problem

Filtering the DX cluster panel by SSB drew almost nothing on the map (report from Chris). Live measurement: of 20 SSB rows passing the filter, only **3** had spotter coordinates, so the map (which requires both endpoints located) dropped the rest.

Root cause: the paths route's prefix-location pass runs on `[...allCalls].slice(0, 100)`. That was fine at 50-spot fetches, but #1123 raised fetches to 150 spots ≈ 300 unique callsigns — two thirds of spotters silently got no location. Human/SSB spots sit late in the feed and lost that race every time.

## Fix

`estimateLocationFromPrefix` is a local CTY-table lookup — cheap enough to run for the full batch, now guarded at 1000 calls. The remote HamQTH lookup batch keeps its own 10-per-cycle cap, unchanged.

## Verification

Ran the patched server locally against the production cluster: SSB-filtered paths went from **3-of-20 drawable to 18-of-18**, all with coordinates (mostly `prefix-grid`). Full suite: 1031 passing.

Same change is on Staging as 7d6c5e24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)