### PR TITLE
fix(cluster): collapse re-spots of the same station into one row

### DIFF
--- a/server/routes/dxcluster.js
+++ b/server/routes/dxcluster.js
@@ -6,7 +6,7 @@
 const dgram = require('dgram');
 const net = require('net');
 const { maidenheadToLatLon } = require('../utils/grid.js');
-const { areDXPathsDuplicate } = require('../utils/dxClusterPathIdentity');
+const { areDXPathsDuplicate, collapseDuplicateDXPaths } = require('../utils/dxClusterPathIdentity');
 const { isPrivateIP, validateCustomHost } = require('../utils/ssrf');
 
 module.exports = function (app, ctx) {
@@ -2221,10 +2221,13 @@ module.exports = function (app, ctx) {
         }
       }
 
-      // Sort by timestamp (newest first) and cap. 600 holds a full hour of
-      // balanced history — the accumulator is what mode filters draw from.
+      // Sort by timestamp (newest first), collapse re-spots of the same
+      // station (same call within ~2 kHz keeps only the newest row — every
+      // extra spotter of an activator was another visible duplicate), then
+      // cap. 600 holds a full hour of balanced history — the accumulator is
+      // what mode filters draw from.
       const sortedPaths = capWithDXpeditions(
-        mergedPaths.sort((a, b) => b.timestamp - a.timestamp),
+        collapseDuplicateDXPaths(mergedPaths.sort((a, b) => b.timestamp - a.timestamp)),
         600,
       );
 

--- a/server/utils/dxClusterPathIdentity.js
+++ b/server/utils/dxClusterPathIdentity.js
@@ -27,7 +27,38 @@ function areDXPathsDuplicate(existing = {}, candidate = {}, now = Date.now(), de
   return now - (existing.timestamp || 0) < dedupWindowMs;
 }
 
+/**
+ * Collapse re-spots of the same station into one row: same DX call within
+ * ~2 kHz keeps only the first (newest, given newest-first input) occurrence.
+ * The spotter-keyed duplicate check above can't catch these — every extra
+ * spotter of a POTA activator produced another visible row. A larger QSY
+ * stays a separate row; the station moving is real information.
+ */
+function collapseDuplicateDXPaths(paths) {
+  const kept = [];
+  const freqsByCall = new Map();
+  for (const p of paths) {
+    const call = normalizeCall(p.dxCall || p.call);
+    const f = parseFloat(p.freq);
+    const khz = Number.isFinite(f) ? (f > 1000 ? f : f * 1000) : NaN;
+    if (!call || !Number.isFinite(khz)) {
+      kept.push(p);
+      continue;
+    }
+    const freqs = freqsByCall.get(call);
+    if (freqs) {
+      if (freqs.some((k) => Math.abs(k - khz) < 2)) continue;
+      freqs.push(khz);
+    } else {
+      freqsByCall.set(call, [khz]);
+    }
+    kept.push(p);
+  }
+  return kept;
+}
+
 module.exports = {
   buildDXPathIdentityKey,
   areDXPathsDuplicate,
+  collapseDuplicateDXPaths,
 };

--- a/src/hooks/useDXClusterData.js
+++ b/src/hooks/useDXClusterData.js
@@ -5,7 +5,7 @@
  */
 import { useState, useEffect, useCallback, useRef } from 'react';
 
-import { applyDXFilters, balanceSpotWindow } from '../utils/dxClusterFilters';
+import { applyDXFilters, balanceSpotWindow, collapseDuplicateSpots } from '../utils/dxClusterFilters';
 import { useVisibilityRefresh } from './useVisibilityRefresh';
 import { apiFetch } from '../utils/apiFetch';
 
@@ -93,13 +93,15 @@ export const useDXClusterData = (filters = {}, config = {}) => {
               (item) => now - (item.timestamp || now) < effectiveRetentionMs,
             );
 
-            // Sort by timestamp (newest first) and cap. The accumulator is
-            // what mode filters draw from, so it holds an hour of history
-            // (600 spots) and evicts mode-balanced — a plain newest-N cap
-            // would let FT8/FT4 skimmer churn flush out the sparse SSB
-            // history within minutes. DXpedition-tagged spots are rare and
-            // exempt from the cap entirely.
-            const sorted = validItems.sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
+            // Sort by timestamp (newest first), collapse re-spots of the
+            // same station (accumulator keys include the spotter, so each
+            // extra spotter would otherwise show as a duplicate row), and
+            // cap. The accumulator is what mode filters draw from, so it
+            // holds an hour of history (600 spots) and evicts mode-balanced
+            // — a plain newest-N cap would let FT8/FT4 skimmer churn flush
+            // out the sparse SSB history within minutes. DXpedition-tagged
+            // spots are rare and exempt from the cap entirely.
+            const sorted = collapseDuplicateSpots(validItems.sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0)));
             const dxpeditions = sorted.filter((item) => item.isDXpedition);
             const regular = balanceSpotWindow(
               sorted.filter((item) => !item.isDXpedition),

--- a/src/utils/dxClusterFilters.js
+++ b/src/utils/dxClusterFilters.js
@@ -372,6 +372,40 @@ export const balanceSpotWindow = (spots, limit, { voiceReserveShare = 0.25, ft8F
 };
 
 /**
+ * Collapse re-spots of the same station into one row: same call within
+ * ~2 kHz keeps only the first (newest, given newest-first input) occurrence.
+ * Accumulator dedupe keys on spotter, so every extra spotter of a POTA
+ * activator otherwise produces another visible row. A larger QSY stays a
+ * separate row — the station moving is real information. Mirrors the
+ * server-side collapseDuplicateDXPaths in utils/dxClusterPathIdentity.js.
+ */
+export const collapseDuplicateSpots = (spots) => {
+  if (!Array.isArray(spots)) return spots || [];
+  const kept = [];
+  const freqsByCall = new Map();
+  for (const s of spots) {
+    const call = String(s.dxCall || s.call || '')
+      .trim()
+      .toUpperCase();
+    const f = parseFloat(s.freq);
+    const khz = Number.isFinite(f) ? (f > 1000 ? f : f * 1000) : NaN;
+    if (!call || !Number.isFinite(khz)) {
+      kept.push(s);
+      continue;
+    }
+    const freqs = freqsByCall.get(call);
+    if (freqs) {
+      if (freqs.some((k) => Math.abs(k - khz) < 2)) continue;
+      freqs.push(khz);
+    } else {
+      freqsByCall.set(call, [khz]);
+    }
+    kept.push(s);
+  }
+  return kept;
+};
+
+/**
  * Filter an array of DX spots/paths
  * Wrapper around applyDXFilters for filtering arrays
  */

--- a/src/utils/dxClusterFilters.test.js
+++ b/src/utils/dxClusterFilters.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { applyDXFilters, filterDXPaths, balanceSpotWindow } from '../utils/dxClusterFilters.js';
+import { applyDXFilters, filterDXPaths, balanceSpotWindow, collapseDuplicateSpots } from '../utils/dxClusterFilters.js';
 
 describe('dxClusterFilters', () => {
   let mockSpot;
@@ -830,6 +830,57 @@ describe('dxClusterFilters', () => {
       ];
       const windowed = balanceSpotWindow(spots, 50);
       expect(windowed.some((s) => s.call === 'ZL1XYZ')).toBe(true);
+    });
+  });
+
+  describe('collapseDuplicateSpots', () => {
+    const spot = (over = {}) => ({
+      dxCall: 'NX9T',
+      spotter: 'K0CJH',
+      freq: '7.225',
+      comment: 'POTA US-1502',
+      timestamp: 1000,
+      ...over,
+    });
+
+    it('collapses re-spots of the same station by different spotters, keeping the newest', () => {
+      // newest-first input, as the accumulator provides
+      const spots = [
+        spot({ spotter: 'W1AW', comment: 'POTA US-1502 59 OH', timestamp: 3000 }),
+        spot({ spotter: 'K2ABC', timestamp: 2000 }),
+        spot({ timestamp: 1000 }),
+      ];
+      const out = collapseDuplicateSpots(spots);
+      expect(out).toHaveLength(1);
+      expect(out[0].spotter).toBe('W1AW');
+    });
+
+    it('collapses slightly-off frequencies (within 2 kHz) of the same call', () => {
+      const spots = [spot({ freq: '14.208' }), spot({ freq: '14.2085', spotter: 'W2XYZ' })];
+      expect(collapseDuplicateSpots(spots)).toHaveLength(1);
+    });
+
+    it('keeps a real QSY as a separate row', () => {
+      const spots = [spot({ freq: '14.208' }), spot({ freq: '14.288', spotter: 'W2XYZ' })];
+      expect(collapseDuplicateSpots(spots)).toHaveLength(2);
+    });
+
+    it('keeps different stations on the same frequency', () => {
+      const spots = [spot(), spot({ dxCall: 'K2LT', spotter: 'W2XYZ' })];
+      expect(collapseDuplicateSpots(spots)).toHaveLength(2);
+    });
+
+    it('handles the legacy call field and kHz frequencies', () => {
+      const spots = [
+        { call: 'ZF2OO', spotter: 'A1AA', freq: 14208, comment: '' },
+        { call: 'ZF2OO', spotter: 'B2BB', freq: 14208.5, comment: '' },
+      ];
+      expect(collapseDuplicateSpots(spots)).toHaveLength(1);
+    });
+
+    it('passes through rows it cannot key', () => {
+      const spots = [spot({ dxCall: '', call: '' }), spot({ freq: 'garbage', dxCall: 'W9XYZ' })];
+      expect(collapseDuplicateSpots(spots)).toHaveLength(2);
     });
   });
 });


### PR DESCRIPTION
## Problem

A station spotted by several people showed one row per spotter, in both the panel and the map. The dedupe identity (`dxCall|freq|spotter`) includes the spotter, so every extra spot of a POTA activator was another visible duplicate. Live measurement: production paths carried 17 duplicated call+freq combos, one station appearing **7 times**. This became visible once human spots actually survived into the window (#1119–#1125) — it was always there, just starved of data.

## Fix

Same call within ~2 kHz collapses to the newest report; a larger QSY stays a separate row (the station moving is real information). Applied at both layers:

- **Server** (`collapseDuplicateDXPaths` in `utils/dxClusterPathIdentity.js`): runs on the paths accumulator before the balanced cap, so duplicates stop wasting balanced-window slots.
- **Client** (`collapseDuplicateSpots` in `dxClusterFilters.js`): runs on the accumulator, so duplicates the browser already fetched disappear too.

## Verification

- 6 new unit tests (multi-spotter collapse keeps newest, 2 kHz window, QSY preserved, distinct stations preserved, legacy `call` field + kHz frequencies, unkeyable rows pass through); full suite 1037 passing, build clean.
- Ran the patched server against the production cluster: paths response went from 17 duplicated call+freq combos to **zero** (139 unique rows).

Same change is on Staging as 4bfce4ae.

🤖 Generated with [Claude Code](https://claude.com/claude-code)