### PR TITLE
feat(cluster): busted-call filter at the store choke point

### DIFF
--- a/ohc-cluster/lib/callsign.js
+++ b/ohc-cluster/lib/callsign.js
@@ -40,6 +40,27 @@ function isValidCallsign(raw) {
   return parts.every((p) => /^[A-Z0-9]{1,8}$/i.test(p));
 }
 
+// Busted-call filter for SPOTTED calls (skimmer decode errors, human typos,
+// junk like a literal "CQ" in an aggregated feed). Deliberately wider than the
+// login validation above: special-event calls have long suffixes (YR50NADIA),
+// year-marker bodies (DL2026T), and 1x1 shapes (K0C) that CORE_RE rejects.
+// Calibrated against 561 live production calls: the only rejects were genuine
+// busts (NATZR — dropped digit, TM113TDFBK — CW "BK" prosign decoded into the
+// call, a literal "CQ").
+const DX_CORE_RE = /^[A-Z0-9]{1,5}\d[A-Z]{1,5}$/i;
+
+function isPlausibleDxCall(raw) {
+  if (typeof raw !== 'string') return false;
+  const call = raw.trim().toUpperCase();
+  if (call.length < 3 || call.length > 14) return false;
+  if (call.includes('-')) return false; // SSIDs belong to nodes, not DX calls
+  if (!/\d/.test(call) || !/[A-Z]/.test(call)) return false;
+  const parts = call.split('/');
+  if (parts.length > 3) return false;
+  if (!parts.every((p) => /^[A-Z0-9]{1,9}$/.test(p))) return false;
+  return parts.some((p) => DX_CORE_RE.test(p));
+}
+
 // Strip SSID and portable decorations down to the base call (for rate keys)
 function baseCallsign(raw) {
   const call = String(raw || '')
@@ -59,4 +80,4 @@ function sanitizeLine(raw) {
     .trim();
 }
 
-module.exports = { isValidCallsign, baseCallsign, sanitizeLine };
+module.exports = { isValidCallsign, isPlausibleDxCall, baseCallsign, sanitizeLine };

--- a/ohc-cluster/lib/store.js
+++ b/ohc-cluster/lib/store.js
@@ -14,6 +14,7 @@
  */
 
 const { bandForKhz, toHHMMz } = require('./format.js');
+const { isPlausibleDxCall } = require('./callsign.js');
 
 const DEFAULTS = {
   // A full hour of history so mode-filtered queries (?mode=SSB) have real
@@ -34,7 +35,7 @@ class SpotStore {
     this.spots = []; // newest first
     this.skimmerIndex = new Map(); // call|band|mode -> spot ref
     this.listeners = new Set();
-    this.counters = { received: 0, stored: 0, collapsed: 0, dropped: 0 };
+    this.counters = { received: 0, stored: 0, collapsed: 0, dropped: 0, busted: 0 };
   }
 
   onSpot(fn) {
@@ -61,6 +62,13 @@ class SpotStore {
     const freqKhz = parseFloat(raw.freqKhz);
     if (!raw.spotter || !raw.call || !Number.isFinite(freqKhz) || freqKhz <= 0) {
       this.counters.dropped++;
+      return null;
+    }
+
+    // Busted-call filter: skimmer decode errors and human typos produce calls
+    // no licensing authority would issue. One choke point covers every feed.
+    if (!isPlausibleDxCall(raw.call)) {
+      this.counters.busted++;
       return null;
     }
 

--- a/ohc-cluster/test/parsers.test.js
+++ b/ohc-cluster/test/parsers.test.js
@@ -3,7 +3,7 @@ const assert = require('node:assert');
 
 const { parseRbnLine } = require('../lib/rbn.js');
 const { parseHamqthCsv, parseHamqthTimestamp } = require('../lib/hamqth.js');
-const { isValidCallsign, baseCallsign, sanitizeLine } = require('../lib/callsign.js');
+const { isValidCallsign, isPlausibleDxCall, baseCallsign, sanitizeLine } = require('../lib/callsign.js');
 const { bandForKhz, formatSpotLine } = require('../lib/format.js');
 
 test('parseRbnLine: CW spot with WPM', () => {
@@ -52,6 +52,44 @@ test('parseHamqthCsv: parses caret-separated rows', () => {
 test('parseHamqthTimestamp: HHMM YYYY-MM-DD to UTC epoch', () => {
   const ts = parseHamqthTimestamp('2149 2025-05-27');
   assert.equal(new Date(ts).toISOString(), '2025-05-27T21:49:00.000Z');
+});
+
+test('isPlausibleDxCall: accepts real spotted-call shapes, incl. special events', () => {
+  for (const call of [
+    'W1AW',
+    'K0C', // 1x1 special event
+    'YR50NADIA', // long special-event suffix
+    'GB100RSGB',
+    'DL2026T', // year-marker body
+    'TM113TDF',
+    'PJ2/W9WI',
+    'N2BTD/VE3',
+    'JK1XOQ/1',
+    'VP2EA/QRP',
+    '9A1A',
+    '3DA0RU',
+  ]) {
+    assert.ok(isPlausibleDxCall(call), `${call} should be plausible`);
+  }
+});
+
+test('isPlausibleDxCall: rejects busted calls and junk', () => {
+  for (const call of [
+    'NATZR', // dropped digit (live bust)
+    'TM113TDFBK', // CW BK prosign decoded into the call (live bust)
+    'CQ', // literal junk from an aggregated feed (live)
+    'QRZ',
+    'TEST',
+    '12345',
+    'W1AW-5', // SSIDs belong to nodes
+    'A/B/C/D',
+    'DX',
+    'FT8',
+    '',
+    null,
+  ]) {
+    assert.ok(!isPlausibleDxCall(call), `${call} should be rejected`);
+  }
 });
 
 test('isValidCallsign: accepts real shapes', () => {

--- a/ohc-cluster/test/store.test.js
+++ b/ohc-cluster/test/store.test.js
@@ -103,7 +103,7 @@ test('default query reserves a slice for human spots under FT8 flood', () => {
     store.add(humanSpot({ call: `HU${i}MAN`, spotter: `K${i}HS`, freqKhz: 14200 + i, timestamp: ts - 60000 }));
   }
   for (let i = 0; i < 60; i++) {
-    store.add(skimmerSpot({ call: `F${i}T8`, freqKhz: 14074, mode: 'FT8', timestamp: ts }));
+    store.add(skimmerSpot({ call: `K${i}FT`, freqKhz: 14074, mode: 'FT8', timestamp: ts }));
   }
 
   const spots = store.query({ limit: 20 });
@@ -116,7 +116,7 @@ test('default query caps FT8/FT4 share when other modes are active', () => {
   const store = new SpotStore();
   const ts = Date.now();
   for (let i = 0; i < 40; i++) {
-    store.add(skimmerSpot({ call: `F${i}T8`, freqKhz: 14074, mode: 'FT8', timestamp: ts }));
+    store.add(skimmerSpot({ call: `K${i}FT`, freqKhz: 14074, mode: 'FT8', timestamp: ts }));
     store.add(skimmerSpot({ call: `C${i}W`, freqKhz: 14025, mode: 'CW', timestamp: ts - 1 }));
   }
 
@@ -130,7 +130,7 @@ test('default query caps FT8/FT4 share when other modes are active', () => {
 test('default query backfills with FT8 when nothing else is on the air', () => {
   const store = new SpotStore();
   for (let i = 0; i < 30; i++) {
-    store.add(skimmerSpot({ call: `F${i}T8`, freqKhz: 14074, mode: 'FT8' }));
+    store.add(skimmerSpot({ call: `K${i}FT`, freqKhz: 14074, mode: 'FT8' }));
   }
   assert.equal(store.query({ limit: 20 }).length, 20);
 });
@@ -138,7 +138,7 @@ test('default query backfills with FT8 when nothing else is on the air', () => {
 test('explicit mode query is an exact slice, not balanced', () => {
   const store = new SpotStore();
   for (let i = 0; i < 15; i++) {
-    store.add(skimmerSpot({ call: `F${i}T8`, freqKhz: 14074, mode: 'FT8' }));
+    store.add(skimmerSpot({ call: `K${i}FT`, freqKhz: 14074, mode: 'FT8' }));
   }
   store.add(skimmerSpot({ call: 'C1W', freqKhz: 14025, mode: 'CW' }));
   const spots = store.query({ limit: 10, mode: 'FT8' });
@@ -151,7 +151,7 @@ test('a refreshed skimmer aggregate ranks by activity, not insertion order', () 
   const ts = Date.now();
   store.add(skimmerSpot({ call: 'OL1DCW', freqKhz: 14025, mode: 'CW', timestamp: ts - 60000 }));
   for (let i = 0; i < 50; i++) {
-    store.add(skimmerSpot({ call: `F${i}T8`, freqKhz: 14074, mode: 'FT8', timestamp: ts - 30000 }));
+    store.add(skimmerSpot({ call: `K${i}FT`, freqKhz: 14074, mode: 'FT8', timestamp: ts - 30000 }));
   }
   // The CW station is still being heard — refresh updates it in place
   store.add(skimmerSpot({ call: 'OL1DCW', spotter: 'W3OA-#', freqKhz: 14025, mode: 'CW', timestamp: ts }));
@@ -165,4 +165,15 @@ test('rejects spots with missing or invalid fields', () => {
   assert.equal(store.add({ spotter: '', call: 'W1AW', freqKhz: 14000 }), null);
   assert.equal(store.add({ spotter: 'K0CJH', call: 'W1AW', freqKhz: -5 }), null);
   assert.equal(store.add({ spotter: 'K0CJH', call: '', freqKhz: 14000 }), null);
+});
+
+test('busted-call filter drops implausible spotted calls and counts them', () => {
+  const store = new SpotStore();
+  assert.equal(store.add(humanSpot({ call: 'NATZR' })), null); // dropped digit
+  assert.equal(store.add(skimmerSpot({ call: 'TM113TDFBK' })), null); // CW BK bust
+  assert.equal(store.add(humanSpot({ call: 'CQ', spotter: 'W1AW' })), null);
+  assert.ok(store.add(humanSpot({ call: 'YR50NADIA', spotter: 'K2ABC' }))); // special event survives
+  const stats = store.stats();
+  assert.equal(stats.busted, 3);
+  assert.equal(stats.activeSpots, 1);
 });


### PR DESCRIPTION
## What

Drops spotted calls no licensing authority would issue — skimmer decode errors, human typos, and junk like a literal `CQ` arriving as a DX call from aggregated feeds. The one idea worth borrowing from DXHeat's validation layer, implemented on our own data.

## How

New `isPlausibleDxCall()` in `ohc-cluster/lib/callsign.js`, deliberately **wider** than the telnet-login validator so real oddballs survive: special-event calls (`YR50NADIA`, `GB100RSGB`), year-marker bodies (`DL2026T`), 1×1 calls (`K0C`), and portable decorations (`PJ2/W9WI`, `JK1XOQ/1`). Enforced once in `SpotStore.add()` so every feed — RBN, all six pollers, telnet/HTTP submissions — passes through the same gate. Rejects are counted separately (`busted` in `/api/stats`) so we can watch the rate.

## Calibration & verification

- Ran the heuristic against **561 unique live production calls** before enforcing: the only rejects were genuine busts — `NATZR` (dropped digit), `TM113TDFBK` (CW "BK" prosign decoded into the real Tour-de-France call TM113TDF), and a literal `CQ` from DX Summit. Zero false positives.
- 37/37 cluster tests (3 new: plausible-shape acceptance incl. special events, bust rejection with the live examples, store counter behavior).
- 90-second live soak with all feeds: 1,872 spots received, 1 bust caught (~0.05% — RBN pre-validates its own CW, so a low rate is expected).

Only the **ohc-cluster** Railway service needs redeploying. Same change is on Staging as 5daede3a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)