### PR TITLE
fix(p533): don't kill the engine on plain-HTTP hosts

### DIFF
--- a/src/services/p533/dataLoader.js
+++ b/src/services/p533/dataLoader.js
@@ -160,6 +160,24 @@ async function gunzip(bytes) {
   return new Uint8Array(ab);
 }
 
+// crypto.subtle only exists in secure contexts (HTTPS or localhost). A
+// self-hosted instance reached over plain HTTP (http://192.168.x.x:3001)
+// doesn't have it — skip the integrity check there instead of killing the
+// whole engine (issue #1129: the failure surfaced as "WASM engine
+// unavailable" even though the wasm bundle was fine). gzip's own CRC still
+// catches corruption, and the bytes come from our own same-origin proxy.
+let warnedNoSubtle = false;
+function canVerifyIntegrity() {
+  if (globalThis.crypto?.subtle) return true;
+  if (!warnedNoSubtle) {
+    warnedNoSubtle = true;
+    console.warn(
+      '[p533] crypto.subtle unavailable (page not served over HTTPS/localhost) — skipping data integrity checks',
+    );
+  }
+  return false;
+}
+
 async function fetchAndDecompress(asset) {
   const url = urlFor(asset);
   const res = await fetch(url);
@@ -167,7 +185,7 @@ async function fetchAndDecompress(asset) {
     throw new Error(`p533 fetch ${asset} failed: ${res.status} ${res.statusText}`);
   }
   const gz = new Uint8Array(await res.arrayBuffer());
-  const expected = await expectedSha256For(asset);
+  const expected = canVerifyIntegrity() ? await expectedSha256For(asset) : null;
   if (expected) {
     const actual = await sha256Hex(gz);
     if (actual !== expected) {
@@ -254,4 +272,9 @@ export const __internal = {
   padMonth,
   gunzip,
   sha256Hex,
+  canVerifyIntegrity,
+  fetchAndDecompress,
+  resetIntegrityWarning: () => {
+    warnedNoSubtle = false;
+  },
 };

--- a/src/services/p533/dataLoader.test.js
+++ b/src/services/p533/dataLoader.test.js
@@ -88,6 +88,35 @@ describe('sha256Hex', () => {
   });
 });
 
+describe('insecure context (no crypto.subtle)', () => {
+  // Plain-HTTP self-hosted instances have no crypto.subtle (issue #1129) —
+  // the integrity check must step aside instead of killing the engine.
+  it('skips the integrity check and still delivers data', async () => {
+    __internal.resetIntegrityWarning();
+    vi.stubGlobal('crypto', {}); // secure-context API absent
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(__internal.canVerifyIntegrity()).toBe(false);
+
+    const payload = new TextEncoder().encode('fake-decile-payload');
+    stubFetch(async (url) => {
+      if (url.includes('P1239-3-Decile-Factors.txt.gz')) return new Response(gz(payload));
+      // Manifest with a WRONG hash — it must not even be consulted
+      if (url.includes('manifest.json'))
+        return new Response(makeManifest([{ name: 'P1239-3-Decile-Factors.txt.gz', sha256: 'f'.repeat(64) }]));
+      return null;
+    });
+
+    const out = await __internal.fetchAndDecompress('P1239-3-Decile-Factors.txt.gz');
+    expect(Array.from(out)).toEqual(Array.from(payload));
+    expect(warn).toHaveBeenCalledTimes(1); // warned once, not per asset
+
+    await __internal.fetchAndDecompress('P1239-3-Decile-Factors.txt.gz');
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+});
+
 describe('getMonthFiles', () => {
   it('fetches both ionos + COEFF for the requested month', async () => {
     const ionos = new TextEncoder().encode('fake-ionos-payload');


### PR DESCRIPTION
Fixes #1129.

## Diagnosis

The reporter's screenshot shows the real error: `WASM engine unavailable … (can't access property "digest", crypto.subtle is undefined)`. **`crypto.subtle` only exists in secure contexts** (HTTPS or localhost). A self-hosted instance reached over plain HTTP on a LAN address doesn't have it, so `sha256Hex()` threw during the P.533 **data-file** integrity check — killing the whole engine and surfacing as a WASM problem. The wasm bundle itself was installed and serving correctly (as the reporter verified), and the official instance works because it's HTTPS.

## Fix

Skip the integrity check when `crypto.subtle` is absent, with a one-time console warning. This is safe: gzip's own CRC still catches corruption, and the bytes come from our own same-origin `/api/p533-data/` proxy.

## Verification

- New test: with `crypto.subtle` absent, `fetchAndDecompress` still delivers data, the manifest hash (deliberately wrong in the fixture) is never consulted, and the warning fires exactly once across assets.
- Full suite 1038 passing, build clean.

Same change is on Staging as 087aea60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)