### PR TITLE
fix: remove container_name to prevent deployment conflicts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
         required: false
     build: .
     image: ghcr.io/accius/openhamclock:latest
-    container_name: openhamclock
     ports:
       - '3000:3000' # HTTP
       - '2237:2237/udp' # WSJT-X UDP — point WSJT-X to 127.0.0.1:2237


### PR DESCRIPTION
Removing the hardcoded `container_name` lets docker compose generate a unique name (e.g. `openhamclock-openhamclock-1`), which prevents orphaned containers from blocking new deployments. This fixes an issue where an interrupted `docker compose down` leaves an orphaned container occupying the `openhamclock` name, breaking subsequent `docker compose up` commands with a name conflict error.

Original work by @9M2PJU in #1140 — this is a clean rebase of that single-line fix onto `Staging` (the original PR branched from `main`, which has since diverged). Authorship is preserved on the commit. Closes #1140.
