### PR TITLE
scripts: Rename setup-linux.sh to setup-unix.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,7 +973,7 @@ Works on Linux, macOS, and Windows. Requires Node.js 18+ (22 LTS recommended) an
 **One-line install (Linux / macOS):**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/accius/openhamclock/main/scripts/setup-linux.sh | bash
+curl -fsSL https://raw.githubusercontent.com/accius/openhamclock/main/scripts/setup-unix.sh | bash
 ```
 
 This clones the repo, installs dependencies, builds the frontend, creates a `.env` config file, and generates a `run.sh` launcher. After install, edit `~/openhamclock/.env` to set your `CALLSIGN` and `LOCATOR`, then start with `~/openhamclock/run.sh`.
@@ -981,7 +981,7 @@ This clones the repo, installs dependencies, builds the frontend, creates a `.en
 **Auto-start on boot (Linux with systemd — Ubuntu, Debian, Fedora, etc.):**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/accius/openhamclock/main/scripts/setup-linux.sh | bash -s -- --service
+curl -fsSL https://raw.githubusercontent.com/accius/openhamclock/main/scripts/setup-unix.sh | bash -s -- --service
 ```
 
 This does everything above plus creates a `systemd` service that starts OpenHamClock automatically on boot. Manage it with:
@@ -1307,7 +1307,7 @@ openhamclock/
 ├── electron/                 # Electron desktop app wrapper (experimental)
 ├── scripts/                  # Setup and update scripts
 │   ├── setup-pi.sh               # Raspberry Pi one-line installer
-│   ├── setup-linux.sh            # Linux / macOS installer (--service for systemd)
+│   ├── setup-unix.sh             # Linux / macOS / FreeBSD installer (--service for systemd)
 │   ├── setup-windows.ps1         # Windows PowerShell installer
 │   ├── update.ps1                # Windows update script (backup → pull → rebuild → restore)
 │   └── update.sh                 # Linux/Pi update script (backup → pull → rebuild → restore)

--- a/scripts/setup-pi.sh
+++ b/scripts/setup-pi.sh
@@ -46,7 +46,7 @@
 #   • Headless-only Pi Zero / Pi Zero 2 W in kiosk mode
 #     (--server mode works; --kiosk requires a display)
 #   • Windows / macOS / generic x86-64 Linux
-#     (see scripts/setup-linux.sh for Linux desktop installs)
+#     (see scripts/setup-unix.sh for Linux desktop installs)
 #
 # ═══════════════════════════════════════════════════════════════════
 # PREREQUISITES

--- a/scripts/setup-unix.sh
+++ b/scripts/setup-unix.sh
@@ -42,16 +42,16 @@
 # ═══════════════════════════════════════════════════════════════════
 #
 #   Quick install (pipe to bash):
-#     curl -fsSL https://raw.githubusercontent.com/accius/openhamclock/main/scripts/setup-linux.sh | bash
+#     curl -fsSL https://raw.githubusercontent.com/accius/openhamclock/main/scripts/setup-unix.sh | bash
 #
 #   With systemd service:
-#     curl -fsSL https://raw.githubusercontent.com/accius/openhamclock/main/scripts/setup-linux.sh | bash -s -- --service
+#     curl -fsSL https://raw.githubusercontent.com/accius/openhamclock/main/scripts/setup-unix.sh | bash -s -- --service
 #
 #   Manual:
-#     chmod +x setup-linux.sh
-#     ./setup-linux.sh                # install only
-#     ./setup-linux.sh --service      # install + systemd service
-#     ./setup-linux.sh --help         # show option summary
+#     chmod +x setup-unix.sh
+#     ./setup-unix.sh                # install only
+#     ./setup-unix.sh --service      # install + systemd service
+#     ./setup-unix.sh --help         # show option summary
 #
 #   After installation, edit ~/openhamclock/.env to set your
 #   CALLSIGN and LOCATOR before (re)starting.
@@ -78,7 +78,7 @@ while [[ "$#" -gt 0 ]]; do
     case $1 in
         --service) INSTALL_SERVICE=true ;;
         --help)
-            echo "Usage: ./setup-linux.sh [OPTIONS]"
+            echo "Usage: ./setup-unix.sh [OPTIONS]"
             echo ""
             echo "Options:"
             echo "  --service   Create a systemd service for auto-start on boot (Linux only)"
@@ -351,7 +351,7 @@ print_summary() {
         if [ "$IS_LINUX" = true ] && [ "$HAS_SYSTEMD" = true ]; then
             echo ""
             echo -e "  ${YELLOW}Tip:${NC} Re-run with --service to auto-start on boot:"
-            echo "    ./scripts/setup-linux.sh --service"
+            echo "    ./scripts/setup-unix.sh --service"
         fi
     fi
 


### PR DESCRIPTION
Since the setup script now supports Linux, macOS, and FreeBSD, `setup-unix.sh` is a much more accurate name for it. This renames the file and updates all references to it in the README and other scripts.