### PR TITLE
refactor(satellites): render both telemetry windows from one derivation

### DIFF
--- a/src/plugins/layers/useSatelliteLayer.js
+++ b/src/plugins/layers/useSatelliteLayer.js
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { addMinimizeToggle } from './addMinimizeToggle.js';
 import { replicatePoint, replicatePath } from '../../utils/geo.js';
+import { deriveSatelliteTelemetry } from '../../utils/satelliteTelemetry.js';
 import { openSatellitePredict as openSatellitePredictShared } from '../../utils/satellitePredict.js';
 
 export const metadata = {
@@ -52,14 +53,6 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
   };
 
   // Helper to format seconds from now into a string representation e.g. "00:12:34"
-  const formatSecsFromNow = (secsFromNow) => {
-    return secsFromNow > 3600
-      ? `${String(Math.floor(secsFromNow / 3600)).padStart(2, '0')}:${String(Math.floor((secsFromNow % 3600) / 60)).padStart(2, '0')}:${String(secsFromNow % 60).padStart(2, '0')}`
-      : secsFromNow > 60
-        ? `00:${String(Math.floor(secsFromNow / 60)).padStart(2, '0')}:${String(secsFromNow % 60).padStart(2, '0')}`
-        : `00:00:${String(secsFromNow).padStart(2, '0')}`;
-  };
-
   const fetchSatellites = async () => {
     try {
       const response = await fetch('/api/satellites/data');
@@ -263,17 +256,11 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
     win.style.overflowY = 'auto';
 
     // --- SAFE HELPERS ---------------------------------------------------------
-    const safeNum = (v, digits = null) => {
-      if (!Number.isFinite(v)) return '';
-      return digits === null ? v : v.toFixed(digits);
-    };
-
     const safeStr = (v) =>
       String(v ?? '')
         .replace(/&/g, '&amp;')
         .replace(/"/g, '&quot;');
 
-    const safeArr = (v) => (Array.isArray(v) ? v : []);
     // --------------------------------------------------------------------------
 
     win.innerHTML =
@@ -285,41 +272,12 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
         .map((satRaw) => {
           const sat = satRaw ?? {}; // ensure sat is always an object
 
-          const isVisible = sat.isVisible === true;
-          const isAboveHorizon = Number.isFinite(sat.elevation) && sat.elevation >= 0;
-
-          const isMetric = allUnits.dist === 'metric';
-          const distanceUnitsStr = isMetric ? 'km' : 'miles';
-          const speedUnitsStr = isMetric ? 'km/h' : 'mph';
-          const rangeRateUnitsStr = isMetric ? 'km/s' : 'miles/s';
-          const km_to_miles_factor = 0.621371;
-
-          const speedKmH = Number.isFinite(sat.speedKmH) ? sat.speedKmH : null;
-          const speed = speedKmH !== null ? Math.round(speedKmH * (isMetric ? 1 : km_to_miles_factor)) : null;
-          const speedStr = speed !== null ? `${speed.toLocaleString()} ${speedUnitsStr}` : 'N/A';
-
-          const alt = Number.isFinite(sat.alt) ? sat.alt : null;
-          const altitude = alt !== null ? Math.round(alt * (isMetric ? 1 : km_to_miles_factor)) : null;
-          const altitudeStr = altitude !== null ? `${altitude.toLocaleString()} ${distanceUnitsStr}` : 'N/A';
-
-          const nextPassStartTimes = safeArr(sat.nextPassStartTimes);
-          const nextPassEndTimes = safeArr(sat.nextPassEndTimes);
-
-          let nextPassSecsFromNow = null;
-          let nextPassEndingSecsFromNow = null;
-          nextPassStartTimes.forEach((startTime, i) => {
-            const endTime = nextPassEndTimes[i];
-            const secsFromNow = Number.isFinite(new Date(startTime).getTime())
-              ? Math.floor((new Date(startTime) - new Date()) / 1000)
-              : null;
-            const secsEndingFromNow = Number.isFinite(new Date(endTime).getTime())
-              ? Math.floor((new Date(endTime) - new Date()) / 1000)
-              : null;
-            if (secsEndingFromNow > 0 && nextPassSecsFromNow === null) {
-              nextPassSecsFromNow = secsFromNow;
-              nextPassEndingSecsFromNow = secsEndingFromNow;
-            }
-          });
+          // Figures come from the shared derivation, the same one the 3D
+          // telemetry panel uses, so the two windows cannot disagree about
+          // altitude, speed, pass timing or visibility. Only the markup below
+          // is specific to this Leaflet window.
+          const d = deriveSatelliteTelemetry(sat, allUnits);
+          const isVisible = d.isVisible;
 
           return `
       <div class="sat-card" style="border-bottom: 1px solid var(--border-color); margin-bottom: 10px; padding-bottom: 8px;">
@@ -339,25 +297,25 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
         <!-- section 1: satellite position and motion -->
         <tr style="background-color: var(--bg-tertiary); color: var(--text-secondary);">
           <td style="padding: 0 2px;">${t('station.settings.satellites.latitude')}:</td>
-          <td align="right" style="padding: 0 2px;">${safeNum(sat.lat, 2)}°</td>
+          <td align="right" style="padding: 0 2px;">${d.lat}°</td>
         </tr>
         <tr style="background-color: var(--bg-tertiary); color: var(--text-secondary);">
           <td style="padding: 0 2px;">${t('station.settings.satellites.longitude')}:</td>
-          <td align="right" style="padding: 0 2px;">${safeNum(sat.lon, 2)}°</td>
+          <td align="right" style="padding: 0 2px;">${d.lon}°</td>
         </tr>
         <tr style="background-color: var(--bg-tertiary); color: var(--text-secondary);">
           <td style="padding: 0 2px;">${t('station.settings.satellites.altitude')}:</td>
-          <td align="right" style="padding: 0 2px;">${altitudeStr}</td>
+          <td align="right" style="padding: 0 2px;">${d.altitude}</td>
         </tr>
         <tr style="background-color: var(--bg-tertiary); color: var(--text-secondary);">
           <td style="padding: 0 2px;">${t('station.settings.satellites.speed')}:</td>
-          <td align="right" style="padding: 0 2px;">${speedStr}</td>
+          <td align="right" style="padding: 0 2px;">${d.speed}</td>
         </tr>
 
         <!-- section 2: relative location and visibility -->
         <tr style="background-color: ${isVisible ? 'var(--accent-green)' : 'var(--bg-primary)'}; color: ${isVisible ? '#000' : 'var(--text-secondary)'};">
           <td style="padding: 0 2px;">${t('station.settings.satellites.azimuth_elevation')}:</td>
-          <td align="right" style="padding: 0 2px;">${safeNum(sat.azimuth)}° / ${safeNum(sat.elevation)}°</td>
+          <td align="right" style="padding: 0 2px;">${d.azEl}</td>
         </tr>
 
         ${
@@ -365,15 +323,15 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
             ? `
           <tr style="background-color: var(--accent-green); color:#000;">
             <td style="padding: 0 2px;">${t('station.settings.satellites.range')}:</td>
-            <td align="right" style="padding: 0 2px;">${safeNum(sat.range * (isMetric ? 1 : km_to_miles_factor), 0)} ${distanceUnitsStr}</td>
+            <td align="right" style="padding: 0 2px;">${d.range}</td>
           </tr>
           <tr style="background-color: var(--accent-green); color:#000;">
             <td style="padding: 0 2px;">${t('station.settings.satellites.rangeRate')}:</td>
-            <td align="right" style="padding: 0 2px;">${safeNum(sat.rangeRate * (isMetric ? 1 : km_to_miles_factor), 2)} ${rangeRateUnitsStr}</td>
+            <td align="right" style="padding: 0 2px;">${d.rangeRate}</td>
           </tr>
           <tr style="background-color: var(--accent-green); color:#000;">
             <td style="padding: 0 2px;">${t('station.settings.satellites.dopplerFactor')}:</td>
-            <td align="right" style="padding: 0 2px;">${safeNum(sat.dopplerFactor, 7)}</td>
+            <td align="right" style="padding: 0 2px;">${d.dopplerFactor}</td>
           </tr>
         `
             : ``
@@ -382,33 +340,27 @@ export const useLayer = ({ map, enabled, satellites, setSatellites, opacity, con
         <tr style="background-color: ${isVisible ? 'var(--accent-green)' : 'var(--bg-primary)'}; color: ${isVisible ? '#000' : 'var(--text-secondary)'};">
           <td style="padding: 0 2px;">${t('station.settings.satellites.status')}:</td>
           <td align="right" style="padding: 0 2px;">
-            ${
-              isVisible
-                ? t('station.settings.satellites.visible')
-                : isAboveHorizon
-                  ? t('station.settings.satellites.belowMinElev')
-                  : t('station.settings.satellites.belowHorizon')
-            }
+            ${t(`station.settings.satellites.${d.status}`)}
           </td>
         </tr>
 
         ${
-          !isVisible && nextPassSecsFromNow !== null
+          !isVisible && d.nextPass
             ? `
             <tr style="background-color: var(--bg-primary); color: var(--text-secondary);">
               <td style="padding: 0 2px;">${t('station.settings.satellites.nextPass')}:</td>
-              <td align="right" style="padding: 0 2px;">${formatSecsFromNow(nextPassSecsFromNow)}</td>
+              <td align="right" style="padding: 0 2px;">${d.nextPass}</td>
             </tr>
             `
             : ``
         }
 
         ${
-          isVisible && nextPassEndingSecsFromNow !== null
+          isVisible && d.endingIn
             ? `
             <tr style="background-color: var(--accent-green); color:#000;">
               <td style="padding: 0 2px;">Ending:</td>
-              <td align="right" style="padding: 0 2px;">${formatSecsFromNow(nextPassEndingSecsFromNow)}</td>
+              <td align="right" style="padding: 0 2px;">${d.endingIn}</td>
             </tr>
             `
             : ``

--- a/src/utils/satelliteTelemetry.test.js
+++ b/src/utils/satelliteTelemetry.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { deriveSatelliteTelemetry, nextPassTiming, formatSecsFromNow } from './satelliteTelemetry.js';
+
+// Both satellite windows — the Leaflet one and the 3D panel — render from this
+// module. These tests pin the formatting so the two cannot drift apart again:
+// a change here that is not intended for both windows will fail loudly.
+
+const METRIC = { dist: 'metric' };
+const IMPERIAL = { dist: 'imperial' };
+
+// altitude and speed go through toLocaleString, whose thousands separator
+// follows the runtime locale — a Dutch machine renders 15.933 where a US one
+// renders 15,933. Build the expectation the same way so these assertions pin
+// the conversion and the unit without pinning the separator.
+const localised = (n, unit) => `${n.toLocaleString()} ${unit}`;
+
+const NOW = new Date('2026-08-19T12:00:00Z');
+const inSecs = (s) => new Date(NOW.getTime() + s * 1000).toISOString();
+
+const baseSat = {
+  name: 'AO-7',
+  lat: -76.3456,
+  lon: 113.9412,
+  alt: 1479.6,
+  speedKmH: 25642.4,
+  azimuth: 158,
+  elevation: -70,
+  range: 8123.45,
+  rangeRate: -3.2149,
+  dopplerFactor: 0.99998712,
+  isVisible: false,
+  mode: 'Linear',
+  downlink: '29.400 - 29.500 MHz',
+};
+
+describe('formatSecsFromNow', () => {
+  it('pads to hh:mm:ss across each magnitude', () => {
+    expect(formatSecsFromNow(5)).toBe('00:00:05');
+    expect(formatSecsFromNow(61)).toBe('00:01:01');
+    expect(formatSecsFromNow(3601)).toBe('01:00:01');
+    expect(formatSecsFromNow(45296)).toBe('12:34:56');
+  });
+
+  it('returns empty for non-finite input rather than NaN text', () => {
+    expect(formatSecsFromNow(null)).toBe('');
+    expect(formatSecsFromNow(undefined)).toBe('');
+    expect(formatSecsFromNow(Number.NaN)).toBe('');
+  });
+});
+
+describe('nextPassTiming', () => {
+  it('picks the first pass that has not finished yet, not merely the first listed', () => {
+    const sat = {
+      // A pass already over, then the one that matters.
+      nextPassStartTimes: [inSecs(-3600), inSecs(600)],
+      nextPassEndTimes: [inSecs(-3000), inSecs(1200)],
+    };
+    expect(nextPassTiming(sat, NOW)).toEqual({ startsIn: 600, endsIn: 1200 });
+  });
+
+  it('reports a pass in progress with a negative start', () => {
+    const sat = { nextPassStartTimes: [inSecs(-120)], nextPassEndTimes: [inSecs(300)] };
+    const { startsIn, endsIn } = nextPassTiming(sat, NOW);
+    expect(startsIn).toBe(-120);
+    expect(endsIn).toBe(300);
+  });
+
+  it('returns nulls when there is nothing scheduled', () => {
+    expect(nextPassTiming({}, NOW)).toEqual({ startsIn: null, endsIn: null });
+    expect(nextPassTiming({ nextPassStartTimes: 'nonsense' }, NOW)).toEqual({ startsIn: null, endsIn: null });
+  });
+});
+
+describe('deriveSatelliteTelemetry', () => {
+  it('formats metric values with their units', () => {
+    const d = deriveSatelliteTelemetry(baseSat, METRIC, NOW);
+    expect(d.altitude).toBe(localised(1480, 'km'));
+    expect(d.speed).toBe(localised(25642, 'km/h'));
+    expect(d.range).toBe('8123 km');
+    expect(d.rangeRate).toBe('-3.21 km/s');
+    expect(d.lat).toBe('-76.35');
+    expect(d.lon).toBe('113.94');
+    expect(d.azEl).toBe('158° / -70°');
+    expect(d.dopplerFactor).toBe('0.9999871');
+  });
+
+  it('converts to imperial rather than relabelling', () => {
+    const d = deriveSatelliteTelemetry(baseSat, IMPERIAL, NOW);
+    expect(d.altitude).toBe(localised(919, 'miles'));
+    expect(d.speed).toBe(localised(15933, 'mph'));
+    expect(d.range).toBe('5048 miles');
+    expect(d.rangeRate).toBe('-2.00 miles/s');
+    // Coordinates and angles are not distances and must not be scaled.
+    expect(d.lat).toBe('-76.35');
+    expect(d.azEl).toBe('158° / -70°');
+  });
+
+  it('separates below-horizon from above-horizon-but-below-minimum', () => {
+    expect(deriveSatelliteTelemetry({ ...baseSat, isVisible: true }, METRIC, NOW).status).toBe('visible');
+    expect(deriveSatelliteTelemetry({ ...baseSat, isVisible: false, elevation: 2 }, METRIC, NOW).status).toBe(
+      'belowMinElev',
+    );
+    expect(deriveSatelliteTelemetry({ ...baseSat, isVisible: false, elevation: -30 }, METRIC, NOW).status).toBe(
+      'belowHorizon',
+    );
+  });
+
+  it('renders missing numbers as N/A or empty, never NaN', () => {
+    const d = deriveSatelliteTelemetry({ name: 'unknown' }, METRIC, NOW);
+    expect(d.altitude).toBe('N/A');
+    expect(d.speed).toBe('N/A');
+    expect(d.range).toBe('');
+    expect(d.azEl).toBe('');
+    expect(d.dopplerFactor).toBe('');
+    expect(d.nextPass).toBe('');
+    expect(JSON.stringify(d)).not.toMatch(/NaN/);
+  });
+
+  it('survives a null satellite instead of throwing', () => {
+    expect(() => deriveSatelliteTelemetry(null, METRIC, NOW)).not.toThrow();
+    expect(deriveSatelliteTelemetry(null, METRIC, NOW).name).toBe('');
+  });
+
+  it('treats an absent unit preference as imperial, matching the app default', () => {
+    expect(deriveSatelliteTelemetry(baseSat, undefined, NOW).altitude).toBe(localised(919, 'miles'));
+  });
+
+  it('surfaces pass countdowns already formatted', () => {
+    const sat = { ...baseSat, nextPassStartTimes: [inSecs(600)], nextPassEndTimes: [inSecs(1200)] };
+    const d = deriveSatelliteTelemetry(sat, METRIC, NOW);
+    expect(d.nextPass).toBe('00:10:00');
+    expect(d.endingIn).toBe('00:20:00');
+  });
+
+  it('passes orbit elements through for the Predict modal', () => {
+    const omm = { OBJECT_NAME: 'AO-7' };
+    expect(deriveSatelliteTelemetry({ ...baseSat, omm }, METRIC, NOW).omm).toBe(omm);
+    expect(deriveSatelliteTelemetry(baseSat, METRIC, NOW).omm).toBeNull();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

The last of the seven follow-ups @accius raised when merging #1151: *"satelliteTelemetry.js has no 2D callers yet so the two windows can still disagree."*

`satelliteTelemetry.js` was extracted during #1151 but only the new 3D panel called it — the Leaflet window still computed its own figures. The two agreed only because I had mirrored the maths by hand, and nothing enforced that. Change the imperial conversion or the next-pass rule in one place and the same satellite would report a different altitude in Flat than in 3D. Exactly the `ACTIVITY_COLORS` hazard you called out, which is presumably why you spotted it.

**The Leaflet window now calls `deriveSatelliteTelemetry` for its numbers.** Its HTML generation is untouched. The defect was divergent *figures*, not divergent markup, so this closes it without going near the window's drag and minimise handling. Net 48 lines lighter: `safeNum`, `safeArr` and the local `formatSecsFromNow` are dead and gone. `safeStr` stays — it still escapes interpolated values.

**Also adds unit tests for the shared module, which had none.** That is the part that actually stops the drift recurring; the refactor alone only makes drift preventable. 13 tests covering the unit conversions, the pass-selection rule (first pass not yet finished, not merely first listed), the three visibility states, and missing-data behaviour.

### On step two

The obvious next move is rendering the shared React component inside the Leaflet container so the presentation is single-sourced too. **I have deliberately not done that, and my recommendation is not to.** It means standing up a React root inside a 900-line plugin while preserving its drag and minimise behaviour, and the payoff is deduplicating markup rather than fixing a defect. Two windows drawing the same verified numbers is a normal state for a codebase. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. `npm ci`, then `node server.js` and `npm run dev`.
2. Select two satellites in **Flat** and open the telemetry window. Every row — latitude, longitude, altitude, speed, Az/El, status, next pass, mode, downlink, uplink, tone — should read exactly as it did before this change.
3. Switch to **3D** with the same satellites selected. Both windows should agree on labels, units and formatting; only the genuinely time-varying values (position, countdowns) differ, and only by the seconds elapsed between looking at them.
4. Change **Settings → Units** between metric and imperial and confirm both windows convert together.
5. `npx vitest run src/utils/satelliteTelemetry.test.js`.

## Checklist

- [x] App loads without console errors
- [x] Tested in **Dark**, **Light**, and **Retro** themes
- [x] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps — *n/a, untouched*
- [ ] If adding an API route: includes caching and error handling — *n/a, none added*
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts — *n/a, no new panel*
- [x] No hardcoded colors — uses CSS variables
- [x] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Notes on verification

Equivalence was established **before** the swap rather than assumed afterwards. I ran the plugin's original formulas against the shared module over the live satellite feed plus synthetic edge cases the feed will not produce (no fields at all, visible, above-horizon-but-below-minimum, below-horizon):

**860 field comparisons across 39 live satellites and 4 synthetic ones, in both unit systems — identical throughout.**

Then confirmed in the browser, reading both windows for the same satellites: same labels, same units, same formatting, differing only where the satellite had actually moved between the two readings.

One note on the tests. `altitude` and `speed` go through `toLocaleString`, so my first draft hardcoded US thousands separators and would have failed for any contributor in a European locale — my own UI renders `15.932` where CI renders `15,933`. The expectations now build through `toLocaleString` as well, so they pin the conversion and the unit without pinning the separator. Verified passing under both `en_US` and `nl_NL`.