### PR TITLE
fix(maps): share the activity palette, fix satellite colour space and…

### DIFF
--- a/src/components/AzimuthalMap.jsx
+++ b/src/components/AzimuthalMap.jsx
@@ -15,6 +15,7 @@ import { MAP_STYLES } from '../utils/config.js';
 import { createTileReprojector } from '../utils/tileReproject.js';
 import { createAzimuthalCRS } from '../utils/azimuthalCRS.js';
 import { matchesDXSpotPath } from '../utils/dxClusterSpotMatcher';
+import { ACTIVITY_COLORS } from '../utils/activityColors.js';
 
 // ── Projection Math ────────────────────────────────────────
 const DEG = Math.PI / 180;
@@ -708,7 +709,7 @@ export default function AzimuthalMap({
         ctx.lineTo(p.x - 5, p.y + 4);
         ctx.lineTo(p.x + 5, p.y + 4);
         ctx.closePath();
-        ctx.fillStyle = '#44cc44';
+        ctx.fillStyle = ACTIVITY_COLORS.pota;
         ctx.fill();
         ctx.strokeStyle = '#000';
         ctx.lineWidth = 0.5;
@@ -729,7 +730,7 @@ export default function AzimuthalMap({
         ctx.lineTo(p.x - 5, p.y - 4);
         ctx.lineTo(p.x + 5, p.y - 4);
         ctx.closePath();
-        ctx.fillStyle = '#a3f3a3';
+        ctx.fillStyle = ACTIVITY_COLORS.wwff;
         ctx.fill();
         ctx.strokeStyle = '#000';
         ctx.lineWidth = 0.5;
@@ -748,7 +749,7 @@ export default function AzimuthalMap({
         ctx.save();
         ctx.translate(p.x, p.y);
         ctx.rotate(Math.PI / 4);
-        ctx.fillStyle = '#ff9632';
+        ctx.fillStyle = ACTIVITY_COLORS.sota;
         ctx.fillRect(-4, -4, 8, 8);
         ctx.strokeStyle = '#000';
         ctx.lineWidth = 0.5;
@@ -765,10 +766,10 @@ export default function AzimuthalMap({
         if (!bandPassesMapFilter(band)) return;
 
         const p = toCanvas(spot.lat, spot.lon);
-        // Blue circle for WWBOTA
+        // WWBOTA circle — shared palette; this was #4488ff, the DE marker's blue
         ctx.beginPath();
         ctx.arc(p.x, p.y, 5, 0, Math.PI * 2);
-        ctx.fillStyle = '#4488ff';
+        ctx.fillStyle = ACTIVITY_COLORS.wwbota;
         ctx.fill();
         ctx.strokeStyle = '#000';
         ctx.lineWidth = 0.5;

--- a/src/components/Globe3D.jsx
+++ b/src/components/Globe3D.jsx
@@ -17,6 +17,7 @@ import { getBandColor, getBandFromFreq } from '../utils/callsign.js';
 import { getSunPosition } from '../utils/geo.js';
 import { MAP_STYLES } from '../utils/config.js';
 import { buildGlobeTexture, chooseGlobeTileZoom } from '../utils/globeTexture.js';
+import { ACTIVITY_COLORS } from '../utils/activityColors.js';
 // Project icon set — exists because bare glyphs/emoji render inconsistently
 // (or as tofu) depending on the platform's font coverage.
 import { IconRefresh } from './Icons.jsx';
@@ -153,19 +154,11 @@ function cssVarColor(name, fallback) {
 }
 
 /**
- * Activity-type marker palette.
- *
- * Deliberately not themed: these identify what a spot *is*, and a POTA marker
- * has to read identically in Flat, Azimuthal and 3D. WorldMap and AzimuthalMap
- * use these same values, so re-theming them here would desynchronise the
- * projections. Band colours are centralised in bandColors.js for the same
- * reason. Station accents (DE/DX) and all UI chrome do follow the theme.
+ * Globe-only marker colours. The activity programmes (POTA/WWFF/SOTA/WWBOTA)
+ * come from the shared palette so the globe cannot drift from the panels and
+ * the other projections again; these are the ones only this view draws.
  */
-const ACTIVITY_COLORS = {
-  pota: '#44cc44',
-  wwff: '#22bb88',
-  sota: '#ddaa33',
-  wwbota: '#cc66dd',
+const GLOBE_COLORS = {
   pskRx: '#ff44aa',
   pskTx: '#aa66ff',
   wsjtx: '#00ddff',
@@ -335,7 +328,11 @@ export default function Globe3D({
   nightDarkness = 60,
   onNightDarknessChange,
 }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  // Basemap label language, resolved the way AzimuthalMap does it. Without
+  // this, {lang} templates fell through to the builder's 'en' default and
+  // non-English operators got English labels only in 3D.
+  const mapLang = i18n.language?.split('-')[0] || 'en';
   const containerRef = useRef(null);
   const gl = useRef({}); // three.js objects, kept off React state
   // Mirrors the nightDarkness prop so a scene rebuild seeds the shader uniform
@@ -486,7 +483,7 @@ export default function Globe3D({
         out.push({
           lat: p.dxLat,
           lon: p.dxLon,
-          color: getBandColor(parseFloat(p.freq)) || ACTIVITY_COLORS.bandFallback,
+          color: getBandColor(parseFloat(p.freq)) || GLOBE_COLORS.bandFallback,
           size: 9,
           kind: 'DX',
           label: p.dxCall || p.callsign || 'DX',
@@ -511,7 +508,7 @@ export default function Globe3D({
         out.push({
           lat,
           lon,
-          color: isRx ? ACTIVITY_COLORS.pskRx : ACTIVITY_COLORS.pskTx,
+          color: isRx ? GLOBE_COLORS.pskRx : GLOBE_COLORS.pskTx,
           size: 7,
           kind: isRx ? 'PSK RX' : 'PSK TX',
           label: (isRx ? s.sender : s.receiver || s.sender) || 'PSK',
@@ -537,7 +534,7 @@ export default function Globe3D({
         out.push({
           lat,
           lon,
-          color: ACTIVITY_COLORS.wsjtx,
+          color: GLOBE_COLORS.wsjtx,
           size: 8,
           kind: 'WSJT-X',
           label: call,
@@ -580,7 +577,7 @@ export default function Globe3D({
         out.push({
           from: [p.spotterLat, p.spotterLon],
           to: [p.dxLat, p.dxLon],
-          color: getBandColor(parseFloat(p.freq)) || ACTIVITY_COLORS.bandFallback,
+          color: getBandColor(parseFloat(p.freq)) || GLOBE_COLORS.bandFallback,
           opacity: 0.62,
         });
       });
@@ -830,6 +827,7 @@ export default function Globe3D({
     buildGlobeTexture({
       tileUrlTemplate: template,
       tileZoom: chooseGlobeTileZoom({ lowMemory: lowMem, pixelRatio: window.devicePixelRatio || 1 }),
+      lang: mapLang,
       // Countries ships transparent overlay tiles; flat mode paints this same
       // blue behind them via the map div's background.
       baseColor: MAP_STYLES[style].countriesOverlay ? '#4a90d9' : undefined,
@@ -862,7 +860,7 @@ export default function Globe3D({
       });
 
     return () => ac.abort();
-  }, [tileStyle, lowMem]);
+  }, [tileStyle, lowMem, mapLang]);
 
   // ── Terminator: track the subsolar point ─────────────────
   // Depends on lowMem because a scene rebuild loses s.sunWorld, which would
@@ -1127,6 +1125,10 @@ export default function Globe3D({
           vec4 t = texture2D(uTex, gl_PointCoord);
           if (t.a < 0.5) discard;
           gl_FragColor = vec4(vColor, t.a);
+        // Same transform the spot-dot shader this was copied from applies:
+        // THREE.Color.set() yields linear values, so without it satellite
+        // dots render in a different colour space from the rest.
+        #include <colorspace_fragment>
         }
       `,
       transparent: true,

--- a/src/utils/activityColors.js
+++ b/src/utils/activityColors.js
@@ -1,0 +1,23 @@
+/**
+ * Activity-programme marker colours.
+ *
+ * POTA, WWFF, SOTA and WWBOTA each have a colour that identifies the programme
+ * wherever it appears — the dedicated panels, the layer picker, and every map
+ * projection. They are not themed: a SOTA spot has to look like a SOTA spot in
+ * Dark, Light and Retro alike, and band colours are centralised in
+ * bandColors.js for the same reason.
+ *
+ * These values are the ones POTAPanel, WWFFPanel, SOTAPanel, WWBOTAPanel,
+ * PotaSotaPanel and the layer picker already agree on. They live here so a map
+ * cannot quietly pick a different shade — which is exactly what had happened:
+ * the 3D globe had invented its own WWFF, SOTA and WWBOTA colours, and the
+ * azimuthal map drew WWBOTA in the same blue as the DE station marker.
+ */
+export const ACTIVITY_COLORS = {
+  pota: '#44cc44',
+  wwff: '#a3f3a3',
+  sota: '#ff9632',
+  wwbota: '#8b7fff',
+};
+
+export default ACTIVITY_COLORS;


### PR DESCRIPTION
… 3D labels

Three of the deferred review items, all user-visible.

**Activity colours.** The globe declared its own POTA/WWFF/SOTA/WWBOTA values with a comment claiming they matched the other projections. Only POTA did. WWFF, SOTA and WWBOTA were shades I had invented, so the same spot appeared in one colour on the globe and another in the panels, the layer picker and the azimuthal map. The four programme colours now come from utils/activityColors.js, taken from the values POTAPanel, WWFFPanel, SOTAPanel, WWBOTAPanel, PotaSotaPanel and the layer picker already agree on. The globe keeps its own constants for PSK, WSJT-X and the band fallback, which no other view draws.

Adopting the shared source also fixes an older inconsistency in the azimuthal map, which drew WWBOTA in #4488ff — the same blue as the DE station marker, so a WWBOTA spot could be mistaken for your own station.

**Satellite dot colour space.** That shader was copied from the spot-dot shader without its `#include <colorspace_fragment>`, so satellite dots were written as linear values into an sRGB target and drifted from the palette. Same fix as the other three shaders already carry.

**Basemap language in 3D.** The globe never passed `{lang}` to the texture builder, so it fell through to the builder's 'en' default and non-English operators got English labels in 3D while Flat and Azimuthal honoured their language. It now resolves the language the same way AzimuthalMap does, and the texture rebuilds when the language changes.

Verified the three invented colours appear nowhere in src or in the built bundle, and that both maps now import the shared palette.

## What does this PR do?

<!-- A brief description of the change. What problem does it solve or what feature does it add? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

<!-- Steps for reviewers to verify the change works correctly -->

1.
2.
3.

## Checklist

- [ ] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<!-- Before/after screenshots or a quick screen recording help reviewers a lot -->
