### PR TITLE
SatelliteInfoPanel.jsx button behavior to match useSatelliteLayer.js

### DIFF
--- a/src/components/SatelliteInfoPanel.jsx
+++ b/src/components/SatelliteInfoPanel.jsx
@@ -84,7 +84,7 @@ export default function SatelliteInfoPanel({ satellites, selected, allUnits, con
         top: `${PANEL_TOP + offset.y}px`,
         right: `${PANEL_RIGHT - offset.x}px`,
         zIndex: 1200,
-        width: '260px',
+        width: minimized ? 'fit-content' : '260px',
         maxHeight: 'calc(100% - 80px)',
         overflowY: 'auto',
         background: 'var(--bg-panel)',
@@ -111,8 +111,10 @@ export default function SatelliteInfoPanel({ satellites, selected, allUnits, con
         }}
       >
         <span>
-          🛰 {active.length}{' '}
-          {active.length !== 1 ? t('station.settings.satellites.name_plural') : t('station.settings.satellites.name')}
+          🛰{' '}
+          {minimized
+            ? ''
+            : `${active.length} ${active.length !== 1 ? t('station.settings.satellites.name_plural') : t('station.settings.satellites.name')}`}
         </span>
         <button
           onClick={() => setMinimized((v) => !v)}


### PR DESCRIPTION
## What does this PR do?

- modifies behavior of SatelliteInfoPanel.jsx satellite button to minimize its size when minimized,
- behavior matches that of useSatelliteLayer.js

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [X] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## Checklist

- [ ] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes
- [ ] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps (we serve 2,000+ concurrent users)
- [ ] If adding an API route: includes caching and error handling
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts
- [ ] No hardcoded colors — uses CSS variables (`var(--accent-cyan)`, etc.)
- [ ] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Screenshots (if visual change)

<!-- Before/after screenshots or a quick screen recording help reviewers a lot -->
not minimized:
<img width="291" height="104" alt="image" src="https://github.com/user-attachments/assets/99515e70-244b-4b38-8b4e-584bb8380825" />

minimized:
<img width="170" height="75" alt="image" src="https://github.com/user-attachments/assets/4055359c-ffc3-4694-8e8f-122b9c294a5b" />
