### PR TITLE
feat(rig-bridge): Yaesu band-select on band change, band-aware SSB

### DIFF
--- a/rig-bridge/plugins/usb/index.js
+++ b/rig-bridge/plugins/usb/index.js
@@ -327,42 +327,64 @@ function createUsbPlugin(radioType) {
         console.log(`[USB/${radioType}] Disconnected`);
       }
 
-      // A band change makes the radio recall that band's stored mode, which would
-      // overwrite a mode command issued before the band finished switching. The
-      // mode is therefore resolved when the deferred write fires: a mode
-      // requested alongside the tune is applied after the band change, and when
-      // none was requested the radio keeps the mode it recalled for that band.
+      // A band change makes the radio recall that band's stored mode and VFO, so
+      // both the mode to apply afterwards and the band to compare against have
+      // to survive the gap between a tune being requested and the radio
+      // reporting it back on the next IF; poll.
       let lastRequestedMode = null;
-      let modeRequestSeq = 0;
+      let lastRequestedModeAt = 0;
       let lastRequestedFreq = 0;
       let lastRequestedFreqAt = 0;
 
-      // Frequency a band-dependent mode (generic SSB) resolves against. A tune
-      // still in flight has not been echoed by the radio yet, so the frequency
-      // just requested wins; after that window state.freq is authoritative and
-      // also reflects the operator turning the VFO by hand.
-      const FREQ_IN_FLIGHT_MS = 1000;
+      // A tune and its mode arrive as two separate commands milliseconds apart,
+      // and nothing guarantees which lands first. Anything inside this window
+      // belongs to the same tune, whichever order it arrived in.
+      const TUNE_WINDOW_MS = 1000;
+
+      /**
+       * Frequency to reason about the radio's current band and sideband.
+       *
+       * state.freq only refreshes on the IF; poll (500 ms by default), so a tune
+       * still in flight has not been echoed back yet. Within the window the
+       * frequency just requested wins; after it, state.freq is authoritative and
+       * also reflects the operator turning the VFO by hand.
+       */
       const modeReferenceFreq = () =>
-        Date.now() - lastRequestedFreqAt < FREQ_IN_FLIGHT_MS ? lastRequestedFreq : state.freq;
+        Date.now() - lastRequestedFreqAt < TUNE_WINDOW_MS ? lastRequestedFreq : state.freq;
 
       function setFreq(hz) {
         console.log(`[USB/${radioType}] SET FREQ: ${(hz / 1e6).toFixed(6)} MHz`);
+        // Both read before this tune is recorded: comparing the target against
+        // itself would make every band change look like an in-band retune, and
+        // the mode has to be the one in effect before BS; recalls another.
+        const referenceFreq = modeReferenceFreq();
+        const modeBefore = state.mode;
         lastRequestedFreq = hz;
         lastRequestedFreqAt = Date.now();
+
         if (radioType === 'icom') {
           proto.setFreq(hz, write, getIcomAddress());
         } else {
-          // Third arg is the radio's live frequency: Yaesu uses it to decide
-          // whether this is a band change. Kenwood ignores both extra args.
-          const seqAtCall = modeRequestSeq;
-          proto.setFreq(hz, write, state.freq, () => (modeRequestSeq !== seqAtCall ? lastRequestedMode : null));
+          // Third arg is the frequency Yaesu compares to decide whether this is a
+          // band change. Kenwood ignores both extra args.
+          proto.setFreq(hz, write, referenceFreq, () => {
+            // A mode requested around this tune wins. Otherwise re-assert the
+            // mode from before the band change: the caller skips the mode command
+            // when the mode is already correct, so letting the band's stored mode
+            // win would drop the operator out of it — clicking a 20m CW spot from
+            // 40m CW would land in USB.
+            if (lastRequestedMode && Date.now() - lastRequestedModeAt < TUNE_WINDOW_MS) {
+              return lastRequestedMode;
+            }
+            return modeBefore;
+          });
         }
       }
 
       function setMode(mode) {
         console.log(`[USB/${radioType}] SET MODE: ${mode}`);
         lastRequestedMode = mode;
-        modeRequestSeq++;
+        lastRequestedModeAt = Date.now();
         if (radioType === 'icom') {
           proto.setMode(mode, write, getIcomAddress());
         } else {

--- a/rig-bridge/plugins/usb/index.js
+++ b/rig-bridge/plugins/usb/index.js
@@ -327,21 +327,46 @@ function createUsbPlugin(radioType) {
         console.log(`[USB/${radioType}] Disconnected`);
       }
 
+      // A band change makes the radio recall that band's stored mode, which would
+      // overwrite a mode command issued before the band finished switching. The
+      // mode is therefore resolved when the deferred write fires: a mode
+      // requested alongside the tune is applied after the band change, and when
+      // none was requested the radio keeps the mode it recalled for that band.
+      let lastRequestedMode = null;
+      let modeRequestSeq = 0;
+      let lastRequestedFreq = 0;
+      let lastRequestedFreqAt = 0;
+
+      // Frequency a band-dependent mode (generic SSB) resolves against. A tune
+      // still in flight has not been echoed by the radio yet, so the frequency
+      // just requested wins; after that window state.freq is authoritative and
+      // also reflects the operator turning the VFO by hand.
+      const FREQ_IN_FLIGHT_MS = 1000;
+      const modeReferenceFreq = () =>
+        Date.now() - lastRequestedFreqAt < FREQ_IN_FLIGHT_MS ? lastRequestedFreq : state.freq;
+
       function setFreq(hz) {
         console.log(`[USB/${radioType}] SET FREQ: ${(hz / 1e6).toFixed(6)} MHz`);
+        lastRequestedFreq = hz;
+        lastRequestedFreqAt = Date.now();
         if (radioType === 'icom') {
           proto.setFreq(hz, write, getIcomAddress());
         } else {
-          proto.setFreq(hz, write);
+          // Third arg is the radio's live frequency: Yaesu uses it to decide
+          // whether this is a band change. Kenwood ignores both extra args.
+          const seqAtCall = modeRequestSeq;
+          proto.setFreq(hz, write, state.freq, () => (modeRequestSeq !== seqAtCall ? lastRequestedMode : null));
         }
       }
 
       function setMode(mode) {
         console.log(`[USB/${radioType}] SET MODE: ${mode}`);
+        lastRequestedMode = mode;
+        modeRequestSeq++;
         if (radioType === 'icom') {
           proto.setMode(mode, write, getIcomAddress());
         } else {
-          proto.setMode(mode, write);
+          proto.setMode(mode, write, modeReferenceFreq());
         }
       }
 

--- a/rig-bridge/plugins/usb/protocol-yaesu.js
+++ b/rig-bridge/plugins/usb/protocol-yaesu.js
@@ -148,27 +148,40 @@ function parse(data, updateState, getState, debug) {
   }
 }
 
-// Maps upper-edge frequency (Hz) to Yaesu BS band-select code.
-// Frequencies above the last entry (70cm) are sent without a band-change first.
+// Ham band edges (Hz) and the Yaesu BS band-select code for each.
+//
+// Ranges, not upper edges: with upper edges alone every out-of-band frequency
+// fell into the next band up, so 15 MHz WWV selected 17m and 12 MHz selected
+// 20m before FA; landed. A frequency outside every band now selects no band at
+// all and is sent as a plain FA;, which is what general-coverage receive wants —
+// the radio keeps whatever band it is on rather than being dragged to a ham band
+// whose stored settings have nothing to do with the frequency being tuned.
+//
+// Edges span the widest regional allocation for each band (for example 7.0–7.3
+// covers both IARU R1 and the US) so no legitimate in-band frequency is refused
+// a band change; a frequency legal in one region and not another still tunes,
+// it simply keeps the current band's settings.
 const BAND_MAP = [
-  { max: 2_000_000, code: '00' }, // 160m
-  { max: 4_000_000, code: '01' }, // 80m
-  { max: 5_500_000, code: '02' }, // 60m
-  { max: 7_300_000, code: '03' }, // 40m
-  { max: 10_200_000, code: '04' }, // 30m
-  { max: 14_350_000, code: '05' }, // 20m
-  { max: 18_200_000, code: '06' }, // 17m
-  { max: 21_450_000, code: '07' }, // 15m
-  { max: 24_990_000, code: '08' }, // 12m
-  { max: 29_700_000, code: '09' }, // 10m
-  { max: 54_000_000, code: '10' }, // 6m
-  { max: 148_000_000, code: '14' }, // 2m
-  { max: 450_000_000, code: '15' }, // 70cm
+  { min: 1_800_000, max: 2_000_000, code: '00' }, // 160m
+  { min: 3_500_000, max: 4_000_000, code: '01' }, // 80m
+  { min: 5_250_000, max: 5_450_000, code: '02' }, // 60m
+  { min: 7_000_000, max: 7_300_000, code: '03' }, // 40m
+  { min: 10_100_000, max: 10_150_000, code: '04' }, // 30m
+  { min: 14_000_000, max: 14_350_000, code: '05' }, // 20m
+  { min: 18_068_000, max: 18_168_000, code: '06' }, // 17m
+  { min: 21_000_000, max: 21_450_000, code: '07' }, // 15m
+  { min: 24_890_000, max: 24_990_000, code: '08' }, // 12m
+  { min: 28_000_000, max: 29_700_000, code: '09' }, // 10m
+  { min: 50_000_000, max: 54_000_000, code: '10' }, // 6m
+  { min: 144_000_000, max: 148_000_000, code: '14' }, // 2m
+  { min: 420_000_000, max: 450_000_000, code: '15' }, // 70cm
 ];
 
+/** BS code for a frequency, or null when it falls outside every ham band. */
 function freqToBandCode(hz) {
-  for (const { max, code } of BAND_MAP) {
-    if (hz <= max) return code;
+  if (!Number.isFinite(hz)) return null;
+  for (const { min, max, code } of BAND_MAP) {
+    if (hz >= min && hz <= max) return code;
   }
   return null;
 }
@@ -191,8 +204,9 @@ function freqToBandCode(hz) {
  * the band finished switching is simply overwritten. getMode is called when the
  * deferred write fires, not now: the caller sets frequency and mode as two
  * near-simultaneous commands, so at fire time it can report the mode that was
- * just requested. When no mode was requested it returns nothing and the radio
- * keeps the mode it recalled for the new band.
+ * just requested — or, when none was, the mode the radio was in before the band
+ * change, which BS; would otherwise silently replace with that band's stored
+ * mode.
  *
  * @param {number} hz          - target frequency
  * @param {Function} serialWrite

--- a/rig-bridge/plugins/usb/protocol-yaesu.js
+++ b/rig-bridge/plugins/usb/protocol-yaesu.js
@@ -31,6 +31,8 @@ Object.entries(MODES).forEach(([k, v]) => {
   MODE_REVERSE[v] = k;
 });
 
+// Generic SSB is deliberately absent: it has no fixed sideband, so setMode()
+// resolves it from the frequency instead.
 const MODE_ALIASES = {
   USB: '2',
   LSB: '1',
@@ -45,7 +47,6 @@ const MODE_ALIASES = {
   FT8: 'C',
   FT4: 'C',
   DIGI: 'C',
-  SSB: '2',
   PSK: 'C',
   JT65: 'C',
 };
@@ -147,14 +148,119 @@ function parse(data, updateState, getState, debug) {
   }
 }
 
-function setFreq(hz, serialWrite) {
-  const padded = String(Math.round(hz)).padStart(9, '0');
-  serialWrite(`FA${padded};`);
+// Maps upper-edge frequency (Hz) to Yaesu BS band-select code.
+// Frequencies above the last entry (70cm) are sent without a band-change first.
+const BAND_MAP = [
+  { max: 2_000_000, code: '00' }, // 160m
+  { max: 4_000_000, code: '01' }, // 80m
+  { max: 5_500_000, code: '02' }, // 60m
+  { max: 7_300_000, code: '03' }, // 40m
+  { max: 10_200_000, code: '04' }, // 30m
+  { max: 14_350_000, code: '05' }, // 20m
+  { max: 18_200_000, code: '06' }, // 17m
+  { max: 21_450_000, code: '07' }, // 15m
+  { max: 24_990_000, code: '08' }, // 12m
+  { max: 29_700_000, code: '09' }, // 10m
+  { max: 54_000_000, code: '10' }, // 6m
+  { max: 148_000_000, code: '14' }, // 2m
+  { max: 450_000_000, code: '15' }, // 70cm
+];
+
+function freqToBandCode(hz) {
+  for (const { max, code } of BAND_MAP) {
+    if (hz <= max) return code;
+  }
+  return null;
 }
 
-function setMode(mode, serialWrite) {
+/**
+ * setFreq()
+ *
+ * BS; switches band, which makes the radio recall that band's stored VFO and
+ * settings — so it is only sent when the target is on a different band than the
+ * radio is on now. Sending it for an in-band retune would bounce the VFO to the
+ * stored frequency and back, with the ATU and band relays following along.
+ *
+ * currentHz is the radio's live frequency from the IF; poll rather than a
+ * remembered "band we last selected". A remembered value goes stale as soon as
+ * the operator turns the band knob, and we would then skip the BS; that the
+ * band change actually needed.
+ *
+ * A mode requested alongside the tune is sent after the band change, because
+ * BS; restores the band's stored settings, mode included — a MD; issued before
+ * the band finished switching is simply overwritten. getMode is called when the
+ * deferred write fires, not now: the caller sets frequency and mode as two
+ * near-simultaneous commands, so at fire time it can report the mode that was
+ * just requested. When no mode was requested it returns nothing and the radio
+ * keeps the mode it recalled for the new band.
+ *
+ * @param {number} hz          - target frequency
+ * @param {Function} serialWrite
+ * @param {number} [currentHz] - radio's present frequency; omit if unknown
+ * @param {Function} [getMode] - called after a band change; returns the mode
+ *                               requested with this tune, or falsy to leave the
+ *                               band's recalled mode alone
+ */
+function setFreq(hz, serialWrite, currentHz, getMode) {
+  const padded = String(Math.round(hz)).padStart(9, '0');
+  const bandCode = freqToBandCode(hz);
+  // Unknown current frequency (not yet polled) counts as a band change: better a
+  // redundant BS; than leaving band settings on the wrong band.
+  const currentBand = Number.isFinite(currentHz) && currentHz > 0 ? freqToBandCode(currentHz) : null;
+
+  if (bandCode !== null && bandCode !== currentBand) {
+    serialWrite(`BS${bandCode};`);
+    setTimeout(() => {
+      // Mode before frequency: switching to CW can shift the displayed
+      // frequency by the CW pitch offset, so FA; goes last and wins.
+      const mode = typeof getMode === 'function' ? getMode() : null;
+      // Resolve the sideband against the target frequency, not the band we came
+      // from — the radio has not reported the new frequency yet.
+      if (mode) setMode(mode, serialWrite, hz);
+      serialWrite(`FA${padded};`);
+    }, 100);
+  } else {
+    serialWrite(`FA${padded};`);
+  }
+}
+
+// 60m is worked USB by convention, unlike every other band below 10 MHz. These
+// bounds span both the IARU R1 band and the US channels, and match the app's
+// getSideband() so the two agree on what a generic 'SSB' means.
+const SIXTY_M_MIN_HZ = 5_300_000;
+const SIXTY_M_MAX_HZ = 5_405_000;
+
+/**
+ * Sideband for a generic 'SSB': LSB below 10 MHz, USB at and above it, with 60m
+ * as the exception. An unknown frequency falls back to USB, which is what this
+ * module did before the rule became frequency-aware.
+ */
+function ssbSidebandDigit(hz) {
+  if (!Number.isFinite(hz) || hz <= 0) return '2';
+  if (hz >= SIXTY_M_MIN_HZ && hz <= SIXTY_M_MAX_HZ) return '2';
+  return hz < 10_000_000 ? '1' : '2';
+}
+
+/**
+ * setMode()
+ *
+ * @param {string} mode
+ * @param {Function} serialWrite
+ * @param {number} [currentHz] - frequency the mode applies to; only needed to
+ *                               resolve the sideband for a generic 'SSB'
+ */
+function setMode(mode, serialWrite, currentHz) {
+  const m = String(mode || '').toUpperCase();
+
+  // Generic SSB carries no sideband of its own — resolve it from the frequency
+  // so a caller sending 'SSB' lands on the same sideband the app would pick.
+  if (m === 'SSB') {
+    serialWrite(`MD0${ssbSidebandDigit(currentHz)};`);
+    return;
+  }
+
   let digit = MODE_REVERSE[mode];
-  if (!digit) digit = MODE_ALIASES[mode.toUpperCase()];
+  if (!digit) digit = MODE_ALIASES[m];
   if (digit) serialWrite(`MD0${digit};`);
 }
 


### PR DESCRIPTION
## What does this PR do?

Yaesu CAT only ever received `FA;` when tuning, which moves the VFO without telling the radio it has changed band. Band-specific settings — gain, ATU memory, antenna selection — stay on whichever band was previously selected, so clicking a spot on a new band leaves the radio set up for the old one.

Rig Bridge now sends the `BS` band-select command first, waits 100 ms for the radio to settle, then sends `FA;`. Frequencies above 450 MHz have no `BS` code and are sent exactly as before.

Originally reported and prototyped in discussion #1032; this goes further than that draft in three ways.

### `BS;` only on an actual band change

`BS;` makes the radio recall the band's stored VFO, so issuing it for an in-band retune would bounce the frequency to the stored value and back, taking the ATU and band relays with it. It is therefore sent only when the target is on a different band than the radio is on now.

The comparison uses the radio's **live frequency from the `IF;` poll**, not a remembered "band we last selected". A remembered value goes stale the moment the operator turns the band knob — the rig would be on 40m, the memo would still say 20m, and the next click on a 40m spot would skip the `BS;` it actually needed. An unknown current frequency counts as a band change, so the first tune after connect always sets the band.

### Mode is applied after the band change, not before

A band change also restores the band's stored **mode**, which silently overwrites a `MD;` issued before the switch completed.

A mode requested alongside the tune is therefore sent after the band change. It is resolved when the deferred write fires rather than when `setFreq` is called: the caller sends frequency and mode as two commands milliseconds apart, so at fire time the mode just requested wins instead of the one that was in effect when the tune started. Capturing it up front would have re-asserted the old mode 100 ms later and undone the mode the caller had just set — breaking the case that already worked.

When no mode was requested, nothing is sent and the radio keeps the mode it recalled for the new band.

`MD;` precedes `FA;` inside that deferred write because switching to CW shifts the displayed frequency by the pitch offset — observed live as a 700 Hz error — so the frequency has to be set last.

### Generic `SSB` now resolves to the correct sideband

**This part is an existing bug, not a consequence of the band-select work.** `MODE_ALIASES` mapped `SSB` unconditionally to `'2'` (USB), so `POST /mode {"mode":"SSB"}` gave USB on 40m and 80m. OpenHamClock itself is unaffected — `mapModeToRig()` resolves the sideband before sending — but any other client using the generic alias got the wrong sideband below 10 MHz.

`SSB` now resolves from the frequency: LSB below 10 MHz, USB at and above, with 60m as the USB exception. The bounds (5.300–5.405 MHz) are the ones `src/utils/bandPlan.js` `getSideband()` already uses, so the bridge and the app cannot disagree about what `SSB` means; that span covers both the IARU R1 band and the US channels. An unknown frequency still falls back to USB, as before. The `SSB` entry was removed from `MODE_ALIASES` rather than left beside the new branch, so there is one source of truth for the sideband.

`protocol-kenwood.js` and `protocol-icom.js` carry the same band-agnostic `SSB: '2'`. Left alone deliberately — happy to fix them in a follow-up, but I can only test against a Yaesu.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

Needs a Yaesu on USB CAT. With Rig Bridge running and connected:

1. **Band change sets the band.** From 20m, click a spot on 40m. The radio should switch band — check that a band-specific setting you have configured differently per band (RF gain, ATU memory, antenna) follows, rather than staying on the 20m setting.
2. **In-band retune stays quiet.** Click another spot on the same band. The frequency should move directly, with no jump to the band's stored frequency and back, and no relay/ATU activity.
3. **Mode survives a band change.** Click a CW spot on a different band. The radio must end in CW, not in whatever mode that band had stored.
4. **Sideband.** `curl -X POST -H 'Content-Type: application/json' -H 'X-RigBridge-Token: <token>' -d '{"mode":"SSB"}' http://localhost:5555/mode` on 40m gives LSB, on 20m gives USB, and on 60m (5.3515) gives USB.
5. **Above 450 MHz.** Tune 1296 MHz if your radio covers it: no `BS;`, plain `FA;` as before.

Run with `--debug` to watch the CAT frames directly.

## Checklist

- [x] App loads without console errors
- [ ] Tested in **Dark**, **Light**, and **Retro** themes — *n/a, no UI change*
- [ ] Responsive at different screen sizes — *n/a, no UI change*
- [ ] If touching `server.js`: caches have TTLs and size caps — *n/a, untouched*
- [ ] If adding an API route: includes caching and error handling — *n/a, none added*
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts — *n/a, no new panel*
- [x] No hardcoded colors — uses CSS variables
- [x] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Verification

CAT output, verified against the module directly:

```
band change + SSB to 40m         BS03; MD01; FA007150000;
band change + SSB to 60m         BS02; MD02; FA005351500;
band change + CW                 BS03; MD03; FA007020000;
band change, no mode requested   BS03; FA007150000;
in-band retune                   FA014246000;
above 450 MHz                    FA1296100000;
```

Sideband boundaries, exact rather than rounded: 5.299999 → LSB, 5.300000 → USB, 5.405000 → USB, 5.405001 → LSB, 9.999999 → LSB, 10.000000 → USB. Explicit `USB`/`LSB`/`CW`/`FT8`/`DATA-USB` are unchanged, and lowercase `ssb` resolves too.

Confirmed on a live radio (FT-series, 38400 baud):

- 40m → 20m with no mode command ended in **CW**, where the band's stored mode was USB — proof the `MD;` landed after the band recall.
- 20m → 40m with a mode command right behind it ended in the **requested** mode, not the pre-change CW — the case a naive implementation breaks.
- Generic `SSB` on 40m produced **LSB** on the radio, where it previously produced USB.

The deferred write is safe across a disconnect: `write()` in `plugins/usb/index.js` returns false when the port is closed, so a late `FA;` is a no-op rather than a throw.

## Screenshots (if visual change)

None — no UI change.
