### PR TITLE
feat(globe): real polar imagery for the 3D globe's satellite basemap

### DIFF
--- a/src/components/Globe3D.jsx
+++ b/src/components/Globe3D.jsx
@@ -879,6 +879,8 @@ export default function Globe3D({
       // Countries ships transparent overlay tiles; flat mode paints this same
       // blue behind them via the map div's background.
       baseColor: MAP_STYLES[style].countriesOverlay ? '#4a90d9' : undefined,
+      // Real imagery for the polar caps, where this basemap has a polar source.
+      polar: MAP_STYLES[style].polar,
       onProgress: (p) => setTextureProgress(p),
       signal: ac.signal,
     })

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -358,6 +358,14 @@ export const MAP_STYLES = {
     name: 'Satellite',
     url: 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
     attribution: '&copy; Esri',
+    // Web Mercator stops at ±85.05°, so the globe's polar caps have no imagery
+    // from the tiles above. These polar-projected services cover the rest, and
+    // ArcGIS reprojects them to plate carrée server-side on request — see
+    // fetchPolarStrip() in utils/globeTexture.js.
+    polar: {
+      north: 'https://services.arcgisonline.com/arcgis/rest/services/Polar/Arctic_Imagery/MapServer',
+      south: 'https://services.arcgisonline.com/arcgis/rest/services/Polar/Antarctic_Imagery/MapServer',
+    },
   },
   MODIS: {
     name: 'Modis Truecolor', // NASA GIBS MODIS Truecolor Imagery

--- a/src/utils/globeTexture.js
+++ b/src/utils/globeTexture.js
@@ -138,13 +138,74 @@ export async function buildGlobeTexture({ tileUrlTemplate, tileZoom = 3, lang, b
 
   for (let y = 0; y < outH; y++) {
     const lat = 90 - ((y + 0.5) / outH) * 180;
-    // Beyond ±85.05° Mercator has no data; clamping stretches the last real
-    // row over the caps, which is the usual compromise for globe textures.
+    // Beyond ±85.05° Mercator has no data, so clamping repeats the last real
+    // row across the cap. resolvePolarCaps() below then fades those repeats out
+    // — on a sphere every column of a row converges to the pole, so a repeated
+    // row of coastline becomes a pinwheel of wedges.
     const srcY = Math.max(0, Math.min(dim - 1, Math.floor(latToMercatorY(lat, dim))));
     ectx.drawImage(merc, 0, srcY, dim, 1, 0, y, outW, 1);
   }
 
+  resolvePolarCaps(ectx, outW, outH);
+
   return { canvas: eq, meanLuma: measureMeanLuma(eq) };
+}
+
+/**
+ * Average colour of one pixel row, as [r, g, b].
+ */
+function averageRow(ctx, width, y) {
+  const { data } = ctx.getImageData(0, y, width, 1);
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  for (let i = 0; i < data.length; i += 4) {
+    r += data[i];
+    g += data[i + 1];
+    b += data[i + 2];
+  }
+  const n = data.length / 4;
+  return [Math.round(r / n), Math.round(g / n), Math.round(b / n)];
+}
+
+/**
+ * Settle the polar caps.
+ *
+ * Web Mercator stops at ±85.0511°, so the rows above and below that are copies
+ * of the last real row. SphereGeometry collapses every column of a row onto the
+ * pole, which turns those copies into a fan of wedges radiating from the point.
+ *
+ * Each cap is faded toward the average colour of its own last real row —
+ * Arctic sea reads blue-grey, Antarctic ice reads white — with the blend
+ * starting at zero on the boundary row so nothing seams at 85°, and reaching
+ * full at the pole so the wedges converge on a single flat colour instead of
+ * on 4096 competing ones. Detail Mercator never carried cannot be recovered;
+ * this makes the caps read as plausible rather than broken.
+ */
+function resolvePolarCaps(ctx, width, height) {
+  const capRows = Math.floor(((90 - MAX_MERCATOR_LAT) / 180) * height);
+  if (capRows < 1) return;
+
+  // Smoothstep keeps the ramp from showing a visible edge where it begins.
+  const ease = (t) => t * t * (3 - 2 * t);
+
+  const caps = [
+    { edge: capRows, dir: -1 }, // north: boundary row, walking up to y=0
+    { edge: height - 1 - capRows, dir: 1 }, // south: walking down to y=height-1
+  ];
+
+  for (const { edge, dir } of caps) {
+    const [r, g, b] = averageRow(ctx, width, edge);
+    for (let i = 1; i <= capRows; i++) {
+      const y = edge + dir * i;
+      if (y < 0 || y >= height) break;
+      ctx.save();
+      ctx.globalAlpha = ease(i / capRows);
+      ctx.fillStyle = `rgb(${r}, ${g}, ${b})`;
+      ctx.fillRect(0, y, width, 1);
+      ctx.restore();
+    }
+  }
 }
 
 /**

--- a/src/utils/globeTexture.js
+++ b/src/utils/globeTexture.js
@@ -76,13 +76,16 @@ function loadTile(url, signal) {
  *
  * @param {object}   opts
  * @param {string}   opts.tileUrlTemplate - Leaflet URL template ({z}/{x}/{y})
+ * @param {object}   [opts.polar]         - { north, south } ArcGIS MapServer URLs for
+ *                                        real polar imagery; omit for sources that
+ *                                        publish Mercator only
  * @param {number}   [opts.tileZoom=3]    - Zoom level; 2^z × 2^z tiles are fetched
  * @param {string}   [opts.lang]          - Language for {lang} templates
  * @param {Function} [opts.onProgress]    - Called with 0..1 as tiles land
  * @param {AbortSignal} [opts.signal]     - Cancels in-flight work
  * @returns {Promise<HTMLCanvasElement>}  - 2:1 equirectangular canvas
  */
-export async function buildGlobeTexture({ tileUrlTemplate, tileZoom = 3, lang, baseColor, onProgress, signal }) {
+export async function buildGlobeTexture({ tileUrlTemplate, tileZoom = 3, lang, baseColor, polar, onProgress, signal }) {
   const numTiles = Math.pow(2, tileZoom);
   const dim = numTiles * 256;
 
@@ -152,7 +155,11 @@ export async function buildGlobeTexture({ tileUrlTemplate, tileZoom = 3, lang, b
     ectx.drawImage(merc, 0, srcY, dim, 1, 0, y, outW, 1);
   }
 
-  resolvePolarCaps(ectx, outW, outH);
+  // Real imagery first where a polar-projected source exists, then the cosmetic
+  // fallback for whatever it does not reach.
+  const capRows = Math.floor(((90 - MAX_MERCATOR_LAT) / 180) * outH);
+  const holeRows = await drawPolarImagery(ectx, outW, outH, capRows, polar, signal);
+  resolvePolarCaps(ectx, outW, outH, holeRows);
 
   return { canvas: eq, meanLuma: measureMeanLuma(eq) };
 }
@@ -175,6 +182,138 @@ function averageRow(ctx, width, y) {
 }
 
 /**
+ * One polar cap as a plate-carrée strip, fetched from a polar-projected service.
+ *
+ * Web Mercator has no data past ±85.05°, but the same imagery exists in polar
+ * projections. Rather than reprojecting here, the ArcGIS export endpoint is
+ * asked for the strip already in EPSG:4326 (imageSR=4326) — the projection this
+ * texture is in — so the result drops straight into the cap rows.
+ *
+ * Returns null rather than throwing: real polar imagery is an improvement on the
+ * fallback, never a requirement for building a texture.
+ */
+async function fetchPolarStrip(serviceUrl, hemisphere, width, rows, signal) {
+  if (!serviceUrl || rows < 1) return null;
+
+  const bbox = hemisphere === 'north' ? `-180,${MAX_MERCATOR_LAT},180,90` : `-180,-90,180,${-MAX_MERCATOR_LAT}`;
+
+  // png32 keeps an alpha channel, which is how the no-data hole over the pole
+  // itself is told apart from genuinely dark ocean.
+  const url =
+    `${serviceUrl}/export?bbox=${bbox}&bboxSR=4326&imageSR=4326` +
+    `&size=${width},${rows}&format=png32&transparent=true&f=image`;
+
+  try {
+    const res = await fetch(url, { signal });
+    if (!res.ok) return null;
+    const blob = await res.blob();
+    const bitmap = await createImageBitmap(blob);
+    return bitmap;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Scale a cap's colours so it meets the Mercator imagery without a step.
+ *
+ * The polar services render the same ocean differently from the basemap — Esri's
+ * Arctic imagery is markedly darker than World Imagery at the same latitude — so
+ * dropping one into the other leaves a visible ring at 85°. Matching the mean of
+ * the cap's first row to the mean of the last real Mercator row removes it.
+ *
+ * A per-channel gain rather than an offset, so the cap keeps its own contrast;
+ * clamped, because a wild ratio would mean the two sources disagree so badly
+ * that forcing them together would look worse than the seam.
+ */
+function matchCapToBoundary(ctx, width, height, edgeRow, capTop, capRows) {
+  if (capRows < 1) return;
+
+  const target = averageRow(ctx, width, edgeRow);
+  const source = averageRow(ctx, width, capTop === 0 ? capRows - 1 : capTop);
+
+  const gain = [0, 1, 2].map((i) => {
+    if (source[i] < 4) return 1; // near-black: a ratio here is meaningless
+    return Math.max(0.5, Math.min(2.5, target[i] / source[i]));
+  });
+  if (gain.every((g) => Math.abs(g - 1) < 0.02)) return;
+
+  const img = ctx.getImageData(0, capTop, width, capRows);
+  const d = img.data;
+  for (let i = 0; i < d.length; i += 4) {
+    d[i] = d[i] * gain[0];
+    d[i + 1] = d[i + 1] * gain[1];
+    d[i + 2] = d[i + 2] * gain[2];
+  }
+  ctx.putImageData(img, 0, capTop);
+}
+
+/**
+ * Paint real polar imagery over the repeated Mercator rows.
+ *
+ * Returns how far poleward real data reaches, as a row index per cap, so the
+ * cosmetic fallback only has to cover what is left — typically the half-degree
+ * hole these services leave over the pole itself.
+ */
+async function drawPolarImagery(ctx, width, height, capRows, polar, signal) {
+  const reach = { north: null, south: null };
+  if (!polar) return reach;
+
+  const [north, south] = await Promise.all([
+    fetchPolarStrip(polar.north, 'north', Math.min(width, 4096), capRows, signal),
+    fetchPolarStrip(polar.south, 'south', Math.min(width, 4096), capRows, signal),
+  ]);
+
+  // Measured on a scratch canvas: drawing straight onto the texture would blend
+  // the strip's transparent hole with what is underneath and lose the alpha that
+  // says where real data stops.
+  const measure = (bitmap, hemisphere) => {
+    if (!bitmap) return null;
+    const scratch = document.createElement('canvas');
+    scratch.width = bitmap.width;
+    scratch.height = bitmap.height;
+    const sctx = scratch.getContext('2d', { willReadFrequently: true });
+    sctx.drawImage(bitmap, 0, 0);
+    const { data } = sctx.getImageData(0, 0, bitmap.width, bitmap.height);
+
+    // Row order runs north to south in both strips, so the pole is the first row
+    // for the northern cap and the last for the southern one.
+    const rowsIn =
+      hemisphere === 'north' ? [...Array(bitmap.height).keys()] : [...Array(bitmap.height).keys()].reverse();
+    let covered = 0;
+    for (const y of rowsIn) {
+      let opaque = 0;
+      for (let x = 0; x < bitmap.width; x++) {
+        if (data[(y * bitmap.width + x) * 4 + 3] >= 128) opaque++;
+      }
+      // A row counts as real once most of it carries data; the services cut a
+      // clean circular hole, so this flips once rather than flickering.
+      if (opaque < bitmap.width * 0.5) covered++;
+      else break;
+    }
+    return covered;
+  };
+
+  if (north) {
+    const hole = measure(north, 'north');
+    ctx.drawImage(north, 0, 0, north.width, north.height, 0, 0, width, capRows);
+    // Boundary row is the first real Mercator row, just below the cap.
+    matchCapToBoundary(ctx, width, height, capRows, 0, capRows);
+    reach.north = hole === null ? null : hole;
+    north.close?.();
+  }
+  if (south) {
+    const hole = measure(south, 'south');
+    ctx.drawImage(south, 0, 0, south.width, south.height, 0, height - capRows, width, capRows);
+    matchCapToBoundary(ctx, width, height, height - 1 - capRows, height - capRows, capRows);
+    reach.south = hole === null ? null : hole;
+    south.close?.();
+  }
+
+  return reach;
+}
+
+/**
  * Horizontal box blur across the rows of one polar cap.
  *
  * The stripes are horizontal variation inside a single repeated row, so only a
@@ -187,14 +326,14 @@ function averageRow(ctx, width, y) {
  * would replace the pinwheel with a seam down the 180th meridian where the
  * texture joins.
  */
-function blurCapRows(ctx, width, height, edge, dir, capRows) {
+function blurCapRows(ctx, width, height, edge, dir, rows) {
   const maxRadius = Math.max(1, Math.round(width * CAP_BLUR_MAX_FRACTION));
 
   // The whole cap is read and written once. Doing it row by row costs one GPU
   // readback per row — 112 of them for a retina texture, which is most of the
   // time this function takes and is felt on slower hardware.
   const blockTop = dir < 0 ? Math.max(0, edge - capRows) : Math.min(height - 1, edge + 1);
-  const blockRows = Math.min(capRows, dir < 0 ? edge : height - 1 - edge);
+  const blockRows = Math.min(rows, dir < 0 ? edge : height - 1 - edge);
   if (blockRows < 1) return;
 
   const img = ctx.getImageData(0, blockTop, width, blockRows);
@@ -206,7 +345,7 @@ function blurCapRows(ctx, width, height, edge, dir, capRows) {
     const row = y - blockTop;
     if (row < 0 || row >= blockRows) continue;
 
-    const radius = Math.round((i / capRows) * maxRadius);
+    const radius = Math.round((i / rows) * maxRadius);
     if (radius < 1) continue;
 
     const base = row * width * 4;
@@ -257,29 +396,37 @@ function blurCapRows(ctx, width, height, edge, dir, capRows) {
  * on 4096 competing ones. Detail Mercator never carried cannot be recovered;
  * this makes the caps read as plausible rather than broken.
  */
-function resolvePolarCaps(ctx, width, height) {
+function resolvePolarCaps(ctx, width, height, holeRows) {
   const capRows = Math.floor(((90 - MAX_MERCATOR_LAT) / 180) * height);
   if (capRows < 1) return;
+
+  // How many rows each cap still needs covering. Without real polar imagery
+  // that is the whole cap; with it, only the hole those services leave over the
+  // pole itself — about half a degree.
+  const north = Math.max(0, Math.min(capRows, holeRows?.north ?? capRows));
+  const south = Math.max(0, Math.min(capRows, holeRows?.south ?? capRows));
 
   // Smoothstep keeps the ramp from showing a visible edge where it begins.
   const ease = (t) => t * t * (3 - 2 * t);
 
   const caps = [
-    { edge: capRows, dir: -1 }, // north: boundary row, walking up to y=0
-    { edge: height - 1 - capRows, dir: 1 }, // south: walking down to y=height-1
+    { edge: north, dir: -1, rows: north }, // north: first real row, walking up to y=0
+    { edge: height - 1 - south, dir: 1, rows: south }, // south: walking down
   ];
 
-  for (const { edge, dir } of caps) {
+  for (const { edge, dir, rows } of caps) {
+    if (rows < 1) continue;
+
     // Blur first, then blend: the blur removes the stripes themselves, and the
     // blend then carries what is left toward one colour at the pole.
-    blurCapRows(ctx, width, height, edge, dir, capRows);
+    blurCapRows(ctx, width, height, edge, dir, rows);
 
     const [r, g, b] = averageRow(ctx, width, edge);
-    for (let i = 1; i <= capRows; i++) {
+    for (let i = 1; i <= rows; i++) {
       const y = edge + dir * i;
       if (y < 0 || y >= height) break;
       ctx.save();
-      ctx.globalAlpha = ease(i / capRows);
+      ctx.globalAlpha = ease(i / rows);
       ctx.fillStyle = `rgb(${r}, ${g}, ${b})`;
       ctx.fillRect(0, y, width, 1);
       ctx.restore();

--- a/src/utils/globeTexture.js
+++ b/src/utils/globeTexture.js
@@ -148,37 +148,54 @@ export async function buildGlobeTexture({ tileUrlTemplate, tileZoom = 3, lang, b
   for (let y = 0; y < outH; y++) {
     const lat = 90 - ((y + 0.5) / outH) * 180;
     // Beyond ±85.05° Mercator has no data, so clamping repeats the last real
-    // row across the cap. resolvePolarCaps() below then fades those repeats out
-    // — on a sphere every column of a row converges to the pole, so a repeated
-    // row of coastline becomes a pinwheel of wedges.
+    // row across the cap. For basemaps with a polar source those rows are then
+    // replaced with real imagery; for the rest they stay as they have always
+    // been.
     const srcY = Math.max(0, Math.min(dim - 1, Math.floor(latToMercatorY(lat, dim))));
     ectx.drawImage(merc, 0, srcY, dim, 1, 0, y, outW, 1);
   }
 
-  // Real imagery first where a polar-projected source exists, then the cosmetic
-  // fallback for whatever it does not reach.
-  const capRows = Math.floor(((90 - MAX_MERCATOR_LAT) / 180) * outH);
-  const holeRows = await drawPolarImagery(ectx, outW, outH, capRows, polar, signal);
-  resolvePolarCaps(ectx, outW, outH, holeRows);
+  // Polar caps are only touched for basemaps that publish polar imagery. Every
+  // other source keeps the plain clamped rows it has always had.
+  if (polar) {
+    const capRows = Math.floor(((90 - MAX_MERCATOR_LAT) / 180) * outH);
+    const hole = await drawPolarImagery(ectx, outW, outH, capRows, polar, signal);
+    settlePolarCap(ectx, outW, outH, hole.north, -1, hole.north);
+    settlePolarCap(ectx, outW, outH, outH - 1 - hole.south, 1, hole.south);
+  }
 
   return { canvas: eq, meanLuma: measureMeanLuma(eq) };
 }
 
 /**
- * Average colour of one pixel row, as [r, g, b].
+ * Per-channel mean and standard deviation over a block of pixels.
+ *
+ * `stride` skips transparent pixels when reading a fetched strip; the texture
+ * itself is always opaque, so the alpha test simply passes there.
  */
-function averageRow(ctx, width, y) {
-  const { data } = ctx.getImageData(0, y, width, 1);
-  let r = 0;
-  let g = 0;
-  let b = 0;
+function channelStats(data) {
+  const sum = [0, 0, 0];
+  const sumSq = [0, 0, 0];
+  let n = 0;
   for (let i = 0; i < data.length; i += 4) {
-    r += data[i];
-    g += data[i + 1];
-    b += data[i + 2];
+    if (data[i + 3] < 128) continue;
+    for (let c = 0; c < 3; c++) {
+      sum[c] += data[i + c];
+      sumSq[c] += data[i + c] * data[i + c];
+    }
+    n++;
   }
-  const n = data.length / 4;
-  return [Math.round(r / n), Math.round(g / n), Math.round(b / n)];
+  if (n === 0) return null;
+  return [0, 1, 2].map((c) => {
+    const mean = sum[c] / n;
+    return { mean, sd: Math.sqrt(Math.max(0, sumSq[c] / n - mean * mean)) };
+  });
+}
+
+/** Average colour of one pixel row, as [r, g, b]. */
+function averageRow(ctx, width, y) {
+  const stats = channelStats(ctx.getImageData(0, y, width, 1).data);
+  return stats ? stats.map((c) => Math.round(c.mean)) : [0, 0, 0];
 }
 
 /**
@@ -186,11 +203,11 @@ function averageRow(ctx, width, y) {
  *
  * Web Mercator has no data past ±85.05°, but the same imagery exists in polar
  * projections. Rather than reprojecting here, the ArcGIS export endpoint is
- * asked for the strip already in EPSG:4326 (imageSR=4326) — the projection this
- * texture is in — so the result drops straight into the cap rows.
+ * asked for the strip already in EPSG:4326 — the projection this texture is in —
+ * so the result drops straight into the cap rows.
  *
- * Returns null rather than throwing: real polar imagery is an improvement on the
- * fallback, never a requirement for building a texture.
+ * Returns null rather than throwing: real polar imagery is an improvement on
+ * the fallback, never a requirement for building a texture.
  */
 async function fetchPolarStrip(serviceUrl, hemisphere, width, rows, signal) {
   if (!serviceUrl || rows < 1) return null;
@@ -198,7 +215,7 @@ async function fetchPolarStrip(serviceUrl, hemisphere, width, rows, signal) {
   const bbox = hemisphere === 'north' ? `-180,${MAX_MERCATOR_LAT},180,90` : `-180,-90,180,${-MAX_MERCATOR_LAT}`;
 
   // png32 keeps an alpha channel, which is how the no-data hole over the pole
-  // itself is told apart from genuinely dark ocean.
+  // is told apart from genuinely dark ocean.
   const url =
     `${serviceUrl}/export?bbox=${bbox}&bboxSR=4326&imageSR=4326` +
     `&size=${width},${rows}&format=png32&transparent=true&f=image`;
@@ -206,29 +223,25 @@ async function fetchPolarStrip(serviceUrl, hemisphere, width, rows, signal) {
   try {
     const res = await fetch(url, { signal });
     if (!res.ok) return null;
-    const blob = await res.blob();
-    const bitmap = await createImageBitmap(blob);
-    return bitmap;
+    return await createImageBitmap(await res.blob());
   } catch {
     return null;
   }
 }
 
 /**
- * Prepare one fetched polar strip for compositing.
+ * Prepare a fetched strip for compositing: close its gaps, match it to the
+ * basemap, and ease it in at the join.
  *
- * Two things have to happen before it touches the texture, both because the
- * strip is not fully opaque:
+ * All three have to happen here, on the strip's own pixels, rather than on the
+ * texture afterwards. The strip is transparent for about 11px either side of
+ * ±180 and over the pole itself; correcting colour after compositing also
+ * scales whatever showed through those gaps, which turned the leftover Mercator
+ * row bright green down each edge.
  *
- *  - The services leave a transparent sliver either side of ±180, about 11px of
- *    4096, and a hole over the pole itself. Drawing as-is lets the repeated
- *    Mercator row show through those gaps.
- *  - The colour match must be applied here, to the strip's own pixels. Applied
- *    to the texture afterwards it also scales whatever showed through the gaps,
- *    and the gain that lifts this dark imagery to match World Imagery turned
- *    those leftovers bright green.
- *
- * Returns the prepared canvas and how many rows at the pole carry no data.
+ * @param {object} target - channelStats() of the basemap rows below the cap
+ * @returns {{ canvas: HTMLCanvasElement, hole: number }} hole = rows at the pole
+ *          still carrying no data
  */
 function preparePolarStrip(bitmap, hemisphere, target) {
   const w = bitmap.width;
@@ -243,9 +256,9 @@ function preparePolarStrip(bitmap, hemisphere, target) {
   const d = img.data;
   const alphaAt = (x, y) => d[(y * w + x) * 4 + 3];
 
-  // Close the antimeridian sliver by interpolating between the last valid
-  // column each side. The gap spans ±180, so the two edges are neighbours once
-  // the texture wraps and the join is invisible.
+  // Close the antimeridian sliver by interpolating between the last valid column
+  // each side. The gap spans ±180, so those columns are neighbours once the
+  // texture wraps and the join is invisible.
   for (let y = 0; y < h; y++) {
     let left = 0;
     while (left < w && alphaAt(left, y) < 128) left++;
@@ -253,22 +266,31 @@ function preparePolarStrip(bitmap, hemisphere, target) {
     let right = w - 1;
     while (right > left && alphaAt(right, y) < 128) right--;
 
-    const a = right * 1 * 4 + y * w * 4;
-    const b = left * 4 + y * w * 4;
-    const gapLeft = left;
-    const gapRight = w - 1 - right;
-    const total = gapLeft + gapRight;
-    if (total === 0 || total > w / 8) continue; // nothing to do, or not an edge sliver
+    const gap = left + (w - 1 - right);
+    if (gap === 0 || gap > w / 8) continue; // nothing to do, or not an edge sliver
 
-    for (let i = 0; i < total; i++) {
-      // Walk across the wrapped gap: right edge first, then the left edge.
-      const x = i < gapRight ? right + 1 + i : i - gapRight;
-      const t = (i + 1) / (total + 1);
+    const from = (y * w + right) * 4;
+    const to = (y * w + left) * 4;
+    for (let i = 0; i < gap; i++) {
+      const x = i < w - 1 - right ? right + 1 + i : i - (w - 1 - right);
+      const t = (i + 1) / (gap + 1);
       const o = (y * w + x) * 4;
-      for (let ch = 0; ch < 3; ch++) {
-        d[o + ch] = d[a + ch] * (1 - t) + d[b + ch] * t;
-      }
+      for (let c = 0; c < 3; c++) d[o + c] = d[from + c] * (1 - t) + d[to + c] * t;
       d[o + 3] = 255;
+    }
+  }
+
+  // Match level and spread to the basemap. Matching the mean alone leaves the
+  // deep cap looking wrong, because these services differ in contrast as well
+  // as brightness; scaling about the mean fixes both. Clamped, because a wild
+  // ratio means the sources disagree too badly to force together.
+  const source = channelStats(d);
+  if (target && source) {
+    const k = [0, 1, 2].map((c) => (source[c].sd < 1 ? 1 : Math.max(0.5, Math.min(2, target[c].sd / source[c].sd))));
+    for (let i = 0; i < d.length; i += 4) {
+      for (let c = 0; c < 3; c++) {
+        d[i + c] = (d[i + c] - source[c].mean) * k[c] + target[c].mean;
+      }
     }
   }
 
@@ -277,56 +299,21 @@ function preparePolarStrip(bitmap, hemisphere, target) {
   let hole = 0;
   for (const y of order) {
     let opaque = 0;
-    for (let x = 0; x < w; x++) if (d[(y * w + x) * 4 + 3] >= 128) opaque++;
+    for (let x = 0; x < w; x++) if (alphaAt(x, y) >= 128) opaque++;
     if (opaque < w * 0.5) hole++;
     else break;
   }
 
-  // Colour match, measured over real pixels only, on the row nearest the
-  // Mercator boundary — the one that has to meet it without a step.
-  const seamRow = hemisphere === 'north' ? h - 1 : 0;
-  if (target) {
-    let n = 0;
-    const sum = [0, 0, 0];
-    for (let x = 0; x < w; x++) {
-      const o = (seamRow * w + x) * 4;
-      if (d[o + 3] < 128) continue;
-      sum[0] += d[o];
-      sum[1] += d[o + 1];
-      sum[2] += d[o + 2];
-      n++;
-    }
-    if (n > 0) {
-      const gain = sum.map((v, i) => {
-        const mean = v / n;
-        if (mean < 4) return 1; // near-black: a ratio here is meaningless
-        // Wide enough to actually reach: Arctic imagery runs about half the
-        // brightness of World Imagery at the same latitude.
-        return Math.max(0.4, Math.min(3, target[i] / mean));
-      });
-      if (!gain.every((g) => Math.abs(g - 1) < 0.02)) {
-        for (let i = 0; i < d.length; i += 4) {
-          d[i] *= gain[0];
-          d[i + 1] *= gain[1];
-          d[i + 2] *= gain[2];
-        }
-      }
-    }
-  }
-
-  // Ease the strip in across a few rows at the boundary. Matching the mean gets
-  // the level right, but any residual difference still reads as a ring on a
-  // sphere; ramping the strip's own alpha lets it emerge from the Mercator
-  // imagery instead of starting at full strength on one row.
+  // Ease the strip in across the rows nearest the boundary. Matching statistics
+  // gets the level right, but any residual difference still reads as a ring on a
+  // sphere; ramping the alpha lets it emerge from the Mercator imagery instead
+  // of starting at full strength on one row.
   const blendRows = Math.max(2, Math.round(h * 0.15));
   for (let i = 0; i < blendRows; i++) {
     const y = hemisphere === 'north' ? h - 1 - i : i;
     if (y < 0 || y >= h) break;
     const t = (i + 1) / (blendRows + 1);
-    for (let x = 0; x < w; x++) {
-      const o = (y * w + x) * 4;
-      d[o + 3] = Math.round(d[o + 3] * t);
-    }
+    for (let x = 0; x < w; x++) d[(y * w + x) * 4 + 3] *= t;
   }
 
   sctx.putImageData(img, 0, 0);
@@ -338,163 +325,109 @@ function preparePolarStrip(bitmap, hemisphere, target) {
  *
  * Returns how many rows at each pole still carry no data, so the cosmetic
  * fallback only has to cover what is left — typically the half-degree hole
- * these services leave over the pole itself.
+ * these services leave over the pole itself, or the whole cap if a fetch failed.
  */
 async function drawPolarImagery(ctx, width, height, capRows, polar, signal) {
-  const reach = { north: null, south: null };
+  const reach = { north: capRows, south: capRows };
   if (!polar || capRows < 1) return reach;
 
+  const stripWidth = Math.min(width, 4096);
   const [north, south] = await Promise.all([
-    fetchPolarStrip(polar.north, 'north', Math.min(width, 4096), capRows, signal),
-    fetchPolarStrip(polar.south, 'south', Math.min(width, 4096), capRows, signal),
+    fetchPolarStrip(polar.north, 'north', stripWidth, capRows, signal),
+    fetchPolarStrip(polar.south, 'south', stripWidth, capRows, signal),
   ]);
 
-  if (north) {
-    // Target is the last real Mercator row, just below the cap.
-    const prepared = preparePolarStrip(north, 'north', averageRow(ctx, width, capRows));
-    ctx.drawImage(prepared.canvas, 0, 0, prepared.canvas.width, prepared.canvas.height, 0, 0, width, capRows);
-    reach.north = prepared.hole;
-    north.close?.();
-  }
-  if (south) {
-    const prepared = preparePolarStrip(south, 'south', averageRow(ctx, width, height - 1 - capRows));
-    ctx.drawImage(
-      prepared.canvas,
-      0,
-      0,
-      prepared.canvas.width,
-      prepared.canvas.height,
-      0,
-      height - capRows,
-      width,
-      capRows,
-    );
-    reach.south = prepared.hole;
-    south.close?.();
+  // Match against a band of basemap rows below the cap rather than a single
+  // row, so one unusual row of cloud or ice cannot skew the whole correction.
+  const band = (y0) => channelStats(ctx.getImageData(0, y0, width, Math.max(1, Math.round(capRows / 4))).data);
+
+  for (const [bitmap, hemisphere] of [
+    [north, 'north'],
+    [south, 'south'],
+  ]) {
+    if (!bitmap) continue;
+    const target = hemisphere === 'north' ? band(capRows) : band(height - capRows - Math.round(capRows / 4));
+    const { canvas, hole } = preparePolarStrip(bitmap, hemisphere, target);
+    const destY = hemisphere === 'north' ? 0 : height - capRows;
+    ctx.drawImage(canvas, 0, 0, canvas.width, canvas.height, 0, destY, width, capRows);
+    reach[hemisphere] = hole;
+    bitmap.close?.();
   }
 
   return reach;
 }
 
 /**
- * Horizontal box blur across the rows of one polar cap.
+ * Cover whatever real imagery does not reach at one pole.
  *
- * The stripes are horizontal variation inside a single repeated row, so only a
- * horizontal blur touches them — blurring vertically does nothing when every
- * row in the cap is a copy of the same one. The radius grows from zero at the
- * boundary, so the cap still meets the real imagery without a step, to
- * CAP_BLUR_MAX_FRACTION of the width at the pole.
+ * Used for the no-data hole the polar services leave over the point, and for
+ * the whole cap when a polar fetch fails. Both cases are the same problem: rows
+ * that are copies of the last real Mercator row, which a sphere collapses into
+ * a pinwheel of wedges because every column of a row meets at the pole.
  *
- * The window wraps at the antimeridian. A canvas blur filter would not, and
- * would replace the pinwheel with a seam down the 180th meridian where the
- * texture joins.
+ * Blur and blend in one pass over one readback. The blur is horizontal only —
+ * the stripes are variation *along* a row and every row here is a copy of the
+ * same one, so a vertical blur would move no pixels — and its window wraps at
+ * the antimeridian, which a canvas filter would not.
+ *
+ * @param {number} edge - row index of the last real imagery
+ * @param {number} dir  - -1 walking north, +1 walking south
+ * @param {number} rows - how many rows still need covering
  */
-function blurCapRows(ctx, width, height, edge, dir, rows) {
-  const maxRadius = Math.max(1, Math.round(width * CAP_BLUR_MAX_FRACTION));
-
-  // The whole cap is read and written once. Doing it row by row costs one GPU
-  // readback per row — 112 of them for a retina texture, which is most of the
-  // time this function takes and is felt on slower hardware.
-  const blockTop = dir < 0 ? Math.max(0, edge - capRows) : Math.min(height - 1, edge + 1);
+function settlePolarCap(ctx, width, height, edge, dir, rows) {
+  if (rows < 1) return;
+  const blockTop = dir < 0 ? Math.max(0, edge - rows) : Math.min(height - 1, edge + 1);
   const blockRows = Math.min(rows, dir < 0 ? edge : height - 1 - edge);
   if (blockRows < 1) return;
 
+  const settled = averageRow(ctx, width, edge);
+  const maxRadius = Math.max(1, Math.round(width * CAP_BLUR_MAX_FRACTION));
+  const ease = (t) => t * t * (3 - 2 * t);
+
   const img = ctx.getImageData(0, blockTop, width, blockRows);
-  const src = img.data;
-  const out = new Uint8ClampedArray(src);
+  const d = img.data;
+  const src = new Uint8ClampedArray(d); // blur reads the original, writes to d
 
   for (let i = 1; i <= blockRows; i++) {
-    const y = edge + dir * i;
-    const row = y - blockTop;
+    const row = edge + dir * i - blockTop;
     if (row < 0 || row >= blockRows) continue;
 
-    const radius = Math.round((i / rows) * maxRadius);
-    if (radius < 1) continue;
-
     const base = row * width * 4;
+    const radius = Math.round((i / rows) * maxRadius);
+    const alpha = ease(i / rows);
     const span = radius * 2 + 1;
     const wrap = (x) => base + (((x % width) + width) % width) * 4;
 
-    // Running sum over a wrapped window, so cost per row is O(width) rather
-    // than O(width * radius).
+    // Running sum over the wrapped window: O(width) per row, not O(width·radius).
     let sr = 0;
     let sg = 0;
     let sb = 0;
-    for (let k = -radius; k <= radius; k++) {
-      const q = wrap(k);
-      sr += src[q];
-      sg += src[q + 1];
-      sb += src[q + 2];
+    if (radius >= 1) {
+      for (let k = -radius; k <= radius; k++) {
+        const q = wrap(k);
+        sr += src[q];
+        sg += src[q + 1];
+        sb += src[q + 2];
+      }
     }
 
     for (let x = 0; x < width; x++) {
       const o = base + x * 4;
-      out[o] = sr / span;
-      out[o + 1] = sg / span;
-      out[o + 2] = sb / span;
-
-      const leaving = wrap(x - radius);
-      const entering = wrap(x + radius + 1);
-      sr += src[entering] - src[leaving];
-      sg += src[entering + 1] - src[leaving + 1];
-      sb += src[entering + 2] - src[leaving + 2];
+      const blurred = radius >= 1 ? [sr / span, sg / span, sb / span] : [src[o], src[o + 1], src[o + 2]];
+      for (let c = 0; c < 3; c++) {
+        d[o + c] = blurred[c] * (1 - alpha) + settled[c] * alpha;
+      }
+      if (radius >= 1) {
+        const leaving = wrap(x - radius);
+        const entering = wrap(x + radius + 1);
+        sr += src[entering] - src[leaving];
+        sg += src[entering + 1] - src[leaving + 1];
+        sb += src[entering + 2] - src[leaving + 2];
+      }
     }
   }
 
-  img.data.set(out);
   ctx.putImageData(img, 0, blockTop);
-}
-
-/**
- * Settle the polar caps.
- *
- * Web Mercator stops at ±85.0511°, so the rows above and below that are copies
- * of the last real row. SphereGeometry collapses every column of a row onto the
- * pole, which turns those copies into a fan of wedges radiating from the point.
- *
- * Each cap is faded toward the average colour of its own last real row —
- * Arctic sea reads blue-grey, Antarctic ice reads white — with the blend
- * starting at zero on the boundary row so nothing seams at 85°, and reaching
- * full at the pole so the wedges converge on a single flat colour instead of
- * on 4096 competing ones. Detail Mercator never carried cannot be recovered;
- * this makes the caps read as plausible rather than broken.
- */
-function resolvePolarCaps(ctx, width, height, holeRows) {
-  const capRows = Math.floor(((90 - MAX_MERCATOR_LAT) / 180) * height);
-  if (capRows < 1) return;
-
-  // How many rows each cap still needs covering. Without real polar imagery
-  // that is the whole cap; with it, only the hole those services leave over the
-  // pole itself — about half a degree.
-  const north = Math.max(0, Math.min(capRows, holeRows?.north ?? capRows));
-  const south = Math.max(0, Math.min(capRows, holeRows?.south ?? capRows));
-
-  // Smoothstep keeps the ramp from showing a visible edge where it begins.
-  const ease = (t) => t * t * (3 - 2 * t);
-
-  const caps = [
-    { edge: north, dir: -1, rows: north }, // north: first real row, walking up to y=0
-    { edge: height - 1 - south, dir: 1, rows: south }, // south: walking down
-  ];
-
-  for (const { edge, dir, rows } of caps) {
-    if (rows < 1) continue;
-
-    // Blur first, then blend: the blur removes the stripes themselves, and the
-    // blend then carries what is left toward one colour at the pole.
-    blurCapRows(ctx, width, height, edge, dir, rows);
-
-    const [r, g, b] = averageRow(ctx, width, edge);
-    for (let i = 1; i <= rows; i++) {
-      const y = edge + dir * i;
-      if (y < 0 || y >= height) break;
-      ctx.save();
-      ctx.globalAlpha = ease(i / rows);
-      ctx.fillStyle = `rgb(${r}, ${g}, ${b})`;
-      ctx.fillRect(0, y, width, 1);
-      ctx.restore();
-    }
-  }
 }
 
 /**

--- a/src/utils/globeTexture.js
+++ b/src/utils/globeTexture.js
@@ -11,6 +11,12 @@
 
 const DEG = Math.PI / 180;
 const MAX_MERCATOR_LAT = 85.0511287798066;
+
+// Widest horizontal blur applied inside a polar cap, as a fraction of texture
+// width — reached at the pole, zero at the boundary. 1/64 is about 5.6° of
+// longitude at the equator, which is enough to erase the repeated row's fine
+// detail while keeping its broad light and dark areas.
+const CAP_BLUR_MAX_FRACTION = 1 / 64;
 const MAX_CONCURRENT = 6;
 
 const subdomains = ['a', 'b', 'c'];
@@ -169,6 +175,75 @@ function averageRow(ctx, width, y) {
 }
 
 /**
+ * Horizontal box blur across the rows of one polar cap.
+ *
+ * The stripes are horizontal variation inside a single repeated row, so only a
+ * horizontal blur touches them — blurring vertically does nothing when every
+ * row in the cap is a copy of the same one. The radius grows from zero at the
+ * boundary, so the cap still meets the real imagery without a step, to
+ * CAP_BLUR_MAX_FRACTION of the width at the pole.
+ *
+ * The window wraps at the antimeridian. A canvas blur filter would not, and
+ * would replace the pinwheel with a seam down the 180th meridian where the
+ * texture joins.
+ */
+function blurCapRows(ctx, width, height, edge, dir, capRows) {
+  const maxRadius = Math.max(1, Math.round(width * CAP_BLUR_MAX_FRACTION));
+
+  // The whole cap is read and written once. Doing it row by row costs one GPU
+  // readback per row — 112 of them for a retina texture, which is most of the
+  // time this function takes and is felt on slower hardware.
+  const blockTop = dir < 0 ? Math.max(0, edge - capRows) : Math.min(height - 1, edge + 1);
+  const blockRows = Math.min(capRows, dir < 0 ? edge : height - 1 - edge);
+  if (blockRows < 1) return;
+
+  const img = ctx.getImageData(0, blockTop, width, blockRows);
+  const src = img.data;
+  const out = new Uint8ClampedArray(src);
+
+  for (let i = 1; i <= blockRows; i++) {
+    const y = edge + dir * i;
+    const row = y - blockTop;
+    if (row < 0 || row >= blockRows) continue;
+
+    const radius = Math.round((i / capRows) * maxRadius);
+    if (radius < 1) continue;
+
+    const base = row * width * 4;
+    const span = radius * 2 + 1;
+    const wrap = (x) => base + (((x % width) + width) % width) * 4;
+
+    // Running sum over a wrapped window, so cost per row is O(width) rather
+    // than O(width * radius).
+    let sr = 0;
+    let sg = 0;
+    let sb = 0;
+    for (let k = -radius; k <= radius; k++) {
+      const q = wrap(k);
+      sr += src[q];
+      sg += src[q + 1];
+      sb += src[q + 2];
+    }
+
+    for (let x = 0; x < width; x++) {
+      const o = base + x * 4;
+      out[o] = sr / span;
+      out[o + 1] = sg / span;
+      out[o + 2] = sb / span;
+
+      const leaving = wrap(x - radius);
+      const entering = wrap(x + radius + 1);
+      sr += src[entering] - src[leaving];
+      sg += src[entering + 1] - src[leaving + 1];
+      sb += src[entering + 2] - src[leaving + 2];
+    }
+  }
+
+  img.data.set(out);
+  ctx.putImageData(img, 0, blockTop);
+}
+
+/**
  * Settle the polar caps.
  *
  * Web Mercator stops at ±85.0511°, so the rows above and below that are copies
@@ -195,6 +270,10 @@ function resolvePolarCaps(ctx, width, height) {
   ];
 
   for (const { edge, dir } of caps) {
+    // Blur first, then blend: the blur removes the stripes themselves, and the
+    // blend then carries what is left toward one colour at the pole.
+    blurCapRows(ctx, width, height, edge, dir, capRows);
+
     const [r, g, b] = averageRow(ctx, width, edge);
     for (let i = 1; i <= capRows; i++) {
       const y = edge + dir * i;

--- a/src/utils/globeTexture.js
+++ b/src/utils/globeTexture.js
@@ -215,98 +215,161 @@ async function fetchPolarStrip(serviceUrl, hemisphere, width, rows, signal) {
 }
 
 /**
- * Scale a cap's colours so it meets the Mercator imagery without a step.
+ * Prepare one fetched polar strip for compositing.
  *
- * The polar services render the same ocean differently from the basemap — Esri's
- * Arctic imagery is markedly darker than World Imagery at the same latitude — so
- * dropping one into the other leaves a visible ring at 85°. Matching the mean of
- * the cap's first row to the mean of the last real Mercator row removes it.
+ * Two things have to happen before it touches the texture, both because the
+ * strip is not fully opaque:
  *
- * A per-channel gain rather than an offset, so the cap keeps its own contrast;
- * clamped, because a wild ratio would mean the two sources disagree so badly
- * that forcing them together would look worse than the seam.
+ *  - The services leave a transparent sliver either side of ±180, about 11px of
+ *    4096, and a hole over the pole itself. Drawing as-is lets the repeated
+ *    Mercator row show through those gaps.
+ *  - The colour match must be applied here, to the strip's own pixels. Applied
+ *    to the texture afterwards it also scales whatever showed through the gaps,
+ *    and the gain that lifts this dark imagery to match World Imagery turned
+ *    those leftovers bright green.
+ *
+ * Returns the prepared canvas and how many rows at the pole carry no data.
  */
-function matchCapToBoundary(ctx, width, height, edgeRow, capTop, capRows) {
-  if (capRows < 1) return;
+function preparePolarStrip(bitmap, hemisphere, target) {
+  const w = bitmap.width;
+  const h = bitmap.height;
+  const scratch = document.createElement('canvas');
+  scratch.width = w;
+  scratch.height = h;
+  const sctx = scratch.getContext('2d', { willReadFrequently: true });
+  sctx.drawImage(bitmap, 0, 0);
 
-  const target = averageRow(ctx, width, edgeRow);
-  const source = averageRow(ctx, width, capTop === 0 ? capRows - 1 : capTop);
-
-  const gain = [0, 1, 2].map((i) => {
-    if (source[i] < 4) return 1; // near-black: a ratio here is meaningless
-    return Math.max(0.5, Math.min(2.5, target[i] / source[i]));
-  });
-  if (gain.every((g) => Math.abs(g - 1) < 0.02)) return;
-
-  const img = ctx.getImageData(0, capTop, width, capRows);
+  const img = sctx.getImageData(0, 0, w, h);
   const d = img.data;
-  for (let i = 0; i < d.length; i += 4) {
-    d[i] = d[i] * gain[0];
-    d[i + 1] = d[i + 1] * gain[1];
-    d[i + 2] = d[i + 2] * gain[2];
+  const alphaAt = (x, y) => d[(y * w + x) * 4 + 3];
+
+  // Close the antimeridian sliver by interpolating between the last valid
+  // column each side. The gap spans ±180, so the two edges are neighbours once
+  // the texture wraps and the join is invisible.
+  for (let y = 0; y < h; y++) {
+    let left = 0;
+    while (left < w && alphaAt(left, y) < 128) left++;
+    if (left >= w) continue; // whole row is hole; the fallback covers it
+    let right = w - 1;
+    while (right > left && alphaAt(right, y) < 128) right--;
+
+    const a = right * 1 * 4 + y * w * 4;
+    const b = left * 4 + y * w * 4;
+    const gapLeft = left;
+    const gapRight = w - 1 - right;
+    const total = gapLeft + gapRight;
+    if (total === 0 || total > w / 8) continue; // nothing to do, or not an edge sliver
+
+    for (let i = 0; i < total; i++) {
+      // Walk across the wrapped gap: right edge first, then the left edge.
+      const x = i < gapRight ? right + 1 + i : i - gapRight;
+      const t = (i + 1) / (total + 1);
+      const o = (y * w + x) * 4;
+      for (let ch = 0; ch < 3; ch++) {
+        d[o + ch] = d[a + ch] * (1 - t) + d[b + ch] * t;
+      }
+      d[o + 3] = 255;
+    }
   }
-  ctx.putImageData(img, 0, capTop);
+
+  // Rows with no data at the pole, counted from the polar end.
+  const order = hemisphere === 'north' ? [...Array(h).keys()] : [...Array(h).keys()].reverse();
+  let hole = 0;
+  for (const y of order) {
+    let opaque = 0;
+    for (let x = 0; x < w; x++) if (d[(y * w + x) * 4 + 3] >= 128) opaque++;
+    if (opaque < w * 0.5) hole++;
+    else break;
+  }
+
+  // Colour match, measured over real pixels only, on the row nearest the
+  // Mercator boundary — the one that has to meet it without a step.
+  const seamRow = hemisphere === 'north' ? h - 1 : 0;
+  if (target) {
+    let n = 0;
+    const sum = [0, 0, 0];
+    for (let x = 0; x < w; x++) {
+      const o = (seamRow * w + x) * 4;
+      if (d[o + 3] < 128) continue;
+      sum[0] += d[o];
+      sum[1] += d[o + 1];
+      sum[2] += d[o + 2];
+      n++;
+    }
+    if (n > 0) {
+      const gain = sum.map((v, i) => {
+        const mean = v / n;
+        if (mean < 4) return 1; // near-black: a ratio here is meaningless
+        // Wide enough to actually reach: Arctic imagery runs about half the
+        // brightness of World Imagery at the same latitude.
+        return Math.max(0.4, Math.min(3, target[i] / mean));
+      });
+      if (!gain.every((g) => Math.abs(g - 1) < 0.02)) {
+        for (let i = 0; i < d.length; i += 4) {
+          d[i] *= gain[0];
+          d[i + 1] *= gain[1];
+          d[i + 2] *= gain[2];
+        }
+      }
+    }
+  }
+
+  // Ease the strip in across a few rows at the boundary. Matching the mean gets
+  // the level right, but any residual difference still reads as a ring on a
+  // sphere; ramping the strip's own alpha lets it emerge from the Mercator
+  // imagery instead of starting at full strength on one row.
+  const blendRows = Math.max(2, Math.round(h * 0.15));
+  for (let i = 0; i < blendRows; i++) {
+    const y = hemisphere === 'north' ? h - 1 - i : i;
+    if (y < 0 || y >= h) break;
+    const t = (i + 1) / (blendRows + 1);
+    for (let x = 0; x < w; x++) {
+      const o = (y * w + x) * 4;
+      d[o + 3] = Math.round(d[o + 3] * t);
+    }
+  }
+
+  sctx.putImageData(img, 0, 0);
+  return { canvas: scratch, hole };
 }
 
 /**
  * Paint real polar imagery over the repeated Mercator rows.
  *
- * Returns how far poleward real data reaches, as a row index per cap, so the
- * cosmetic fallback only has to cover what is left — typically the half-degree
- * hole these services leave over the pole itself.
+ * Returns how many rows at each pole still carry no data, so the cosmetic
+ * fallback only has to cover what is left — typically the half-degree hole
+ * these services leave over the pole itself.
  */
 async function drawPolarImagery(ctx, width, height, capRows, polar, signal) {
   const reach = { north: null, south: null };
-  if (!polar) return reach;
+  if (!polar || capRows < 1) return reach;
 
   const [north, south] = await Promise.all([
     fetchPolarStrip(polar.north, 'north', Math.min(width, 4096), capRows, signal),
     fetchPolarStrip(polar.south, 'south', Math.min(width, 4096), capRows, signal),
   ]);
 
-  // Measured on a scratch canvas: drawing straight onto the texture would blend
-  // the strip's transparent hole with what is underneath and lose the alpha that
-  // says where real data stops.
-  const measure = (bitmap, hemisphere) => {
-    if (!bitmap) return null;
-    const scratch = document.createElement('canvas');
-    scratch.width = bitmap.width;
-    scratch.height = bitmap.height;
-    const sctx = scratch.getContext('2d', { willReadFrequently: true });
-    sctx.drawImage(bitmap, 0, 0);
-    const { data } = sctx.getImageData(0, 0, bitmap.width, bitmap.height);
-
-    // Row order runs north to south in both strips, so the pole is the first row
-    // for the northern cap and the last for the southern one.
-    const rowsIn =
-      hemisphere === 'north' ? [...Array(bitmap.height).keys()] : [...Array(bitmap.height).keys()].reverse();
-    let covered = 0;
-    for (const y of rowsIn) {
-      let opaque = 0;
-      for (let x = 0; x < bitmap.width; x++) {
-        if (data[(y * bitmap.width + x) * 4 + 3] >= 128) opaque++;
-      }
-      // A row counts as real once most of it carries data; the services cut a
-      // clean circular hole, so this flips once rather than flickering.
-      if (opaque < bitmap.width * 0.5) covered++;
-      else break;
-    }
-    return covered;
-  };
-
   if (north) {
-    const hole = measure(north, 'north');
-    ctx.drawImage(north, 0, 0, north.width, north.height, 0, 0, width, capRows);
-    // Boundary row is the first real Mercator row, just below the cap.
-    matchCapToBoundary(ctx, width, height, capRows, 0, capRows);
-    reach.north = hole === null ? null : hole;
+    // Target is the last real Mercator row, just below the cap.
+    const prepared = preparePolarStrip(north, 'north', averageRow(ctx, width, capRows));
+    ctx.drawImage(prepared.canvas, 0, 0, prepared.canvas.width, prepared.canvas.height, 0, 0, width, capRows);
+    reach.north = prepared.hole;
     north.close?.();
   }
   if (south) {
-    const hole = measure(south, 'south');
-    ctx.drawImage(south, 0, 0, south.width, south.height, 0, height - capRows, width, capRows);
-    matchCapToBoundary(ctx, width, height, height - 1 - capRows, height - capRows, capRows);
-    reach.south = hole === null ? null : hole;
+    const prepared = preparePolarStrip(south, 'south', averageRow(ctx, width, height - 1 - capRows));
+    ctx.drawImage(
+      prepared.canvas,
+      0,
+      0,
+      prepared.canvas.width,
+      prepared.canvas.height,
+      0,
+      height - capRows,
+      width,
+      capRows,
+    );
+    reach.south = prepared.hole;
     south.close?.();
   }
 


### PR DESCRIPTION
## What does this PR do?

The 3D globe's polar caps had no imagery. Web Mercator stops at ±85.0511° — latitude runs to infinity at the poles, so the tile grid cannot contain them — and the equirectangular remap filled the gap by repeating the last real row. `SphereGeometry` collapses every column of a row onto the pole, so those 56 identical rows rendered as thousands of wedges radiating from the point.

For the **Satellite** basemap the data does exist, just in a different projection. Esri publishes `Polar/Arctic_Imagery` and `Polar/Antarctic_Imagery` alongside `World_Imagery`, and the ArcGIS `export` endpoint will reproject on request — asking for `imageSR=4326` returns the cap already in the projection this texture uses. No reprojection maths, no second tile grid to walk: one request per pole, drawn straight into the cap rows.

**Only Satellite is affected.** Carto, Google and the other Esri basemaps publish Mercator only, so they are left exactly as they were — the polar code is behind a check for a configured polar source, and a basemap without one takes the same path it always has.

### Details worth knowing

**Coverage.** Real imagery reaches 89.47°N; the services cut a clean circular hole above that — 100% covered below, 0% above, no ragged edge. That half-degree hole is blurred and faded to the average of the last real row, which is also the fallback if a fetch fails.

**Colour.** The two services render the same ocean differently: Arctic imagery came in at mean luminance 30.8 where World Imagery is 67.9 at the same latitude, and dropping it in raw left a bright ring at 85°. Each cap is scaled about its own mean to match the basemap's level *and* spread — matching the mean alone still left the cap interior visibly wrong — measured over a band of rows so one stray row of cloud cannot skew it. The strip's alpha then ramps in over the first 15% of the cap, because on a sphere any residual difference lands on a single circle of latitude and reads as a ring.

**Edges.** The exported strips are transparent for ~11px either side of ±180. That gap is closed by interpolating between the last valid column on each side — they are neighbours once the texture wraps.

**Failure is silent.** Any fetch error, CORS problem or missing service returns null and the cosmetic fallback covers the whole cap. Real polar imagery is an improvement on the fallback, never a requirement for building a texture.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. `npm ci`, then `node server.js` and `npm run dev`. Switch the map to **3D** and the style to **Satellite**.
2. Drag down over the North Pole. The wedge pinwheel should be gone, replaced by Arctic sea ice and bathymetry that continues across 85° rather than starting there.
3. Same at the South Pole.
4. Switch through **Dark**, **Terrain**, **Countries**, **Hybrid**. Each should build and render exactly as before — none of them touch the polar code.
5. Block `services.arcgisonline.com/arcgis/rest/services/Polar/*` in devtools and reload Satellite: the globe should still build, with the caps falling back to the faded treatment.

## Checklist

- [x] App loads without console errors
- [x] Tested in **Dark**, **Light**, and **Retro** themes
- [x] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps — *n/a, untouched*
- [ ] If adding an API route: includes caching and error handling — *n/a, none added*
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts — *n/a, no new panel*
- [x] No hardcoded colors — uses CSS variables
- [x] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Verification

Measured on the built texture (4096×2048, 56 cap rows) rather than judged by eye. Per-row luminance across the north cap; the basemap below the boundary sits at 68:

```
           mean before   mean after
85.21°         68            69.7
86.79°         68            69.7
88.11°         68            66.9
89.43°         68            64.5
```

Before, every row from the boundary to the pole was byte-identical — one repeated row of coastline. After, each row carries its own imagery, and the tone tracks the basemap the whole way in.

South cap, where the basemap below reads 240.6:

```
-85.21°  240.0     -86.79°  239.8     -88.55°  241.2     -89.78°  242.2
```

Cap edge columns read ordinary ocean and ice — `(23,74,90)` north, `(238,240,252)` south — with no seam at the antimeridian.

## Notes

MODIS could get the same treatment from NASA GIBS, which publishes both EPSG:4326 and polar stereographic. Left out deliberately: its true-colour product has no data at whichever pole is in polar night — the August Antarctic tile is a 5KB black image — so it needs a seasonal story of its own.

## Screenshots (if visual change)
Before:
<img width="266" height="248" alt="image" src="https://github.com/user-attachments/assets/c9395fae-38b6-46e2-baeb-9ae33141376c" />
After:
<img width="383" height="367" alt="image" src="https://github.com/user-attachments/assets/e3bb88cc-79f5-4434-808f-a566a05bdd1c" />

