### PR TITLE
hotfix: honor legacy TLE_FETCHER_URL in fletcher routing

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -130,8 +130,12 @@ const CONFIG = {
     // (e.g. http://fletcher.railway.internal:3000) the CelesTrak / AMSAT /
     // SatNOGS fetches in routes/satellites.js are rewritten to traverse the
     // proxy service so they use its egress IP instead of OpenHamClock's.
-    // Empty string = direct upstream (default).
-    fletcherUrl: (process.env.FLETCHER_URL || '').trim().replace(/\/+$/, ''),
+    // Empty string = direct upstream (default). TLE_FETCHER_URL is the
+    // service's pre-rename env name — health.js already honors it, and a
+    // deploy whose Railway env still uses it must keep routing through the
+    // relay rather than silently going direct (CelesTrak drops requests
+    // from the production egress IP).
+    fletcherUrl: (process.env.FLETCHER_URL || process.env.TLE_FETCHER_URL || '').trim().replace(/\/+$/, ''),
     celestrak: {
       get enabled() {
         return !(process.env.CELESTRAK_ENABLED && process.env.CELESTRAK_ENABLED === 'false');


### PR DESCRIPTION
Post-release hotfix for a probable prod defect visible right now: prod health reports fletcher ok (health.js accepts FLETCHER_URL **or** TLE_FETCHER_URL) while satellite debug shows all 17 CelesTrak-only weather satellites unresolved and only fallback-covered amateur birds up — the exact signature of routing reading only FLETCHER_URL and silently going direct into CelesTrak's block of the production egress IP.

Cherry-pick of a3edf6e3 from Staging: routing now accepts the legacy env name, matching the health probe.

If weather sats resolve after this deploys, diagnosis confirmed; if prod's env already uses the new name, this is a no-op consistency fix either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)