### PR TITLE
feat(globe): draw the satellite footprint as a cone, not just a ring

### DIFF
--- a/src/components/Globe3D.jsx
+++ b/src/components/Globe3D.jsx
@@ -244,6 +244,26 @@ function footprintRingPoints(lat, lon, angularRadius, r, segments = 72) {
   return pts;
 }
 
+/**
+ * Cone from a satellite down to its footprint ring — the volume it can hear.
+ *
+ * A triangle fan from the satellite to consecutive points of the ring, so the
+ * cone's base is exactly the footprint the ring already draws rather than an
+ * approximation of it. Open at both ends: there is no cap at the satellite (it
+ * is a point) and none on the ground, where the ring itself reads as the edge.
+ */
+function footprintConeGeometry(apex, ringPts) {
+  const positions = new Float32Array(ringPts.length * 9);
+  for (let i = 0; i < ringPts.length; i++) {
+    const a = ringPts[i];
+    const b = ringPts[(i + 1) % ringPts.length];
+    positions.set([apex.x, apex.y, apex.z, a.x, a.y, a.z, b.x, b.y, b.z], i * 9);
+  }
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  return geo;
+}
+
 // Stars and the atmospheric limb only read against a dark backdrop; on the
 // Light and Retro themes they turn into grey noise around the globe.
 function backdropIsDark() {
@@ -2402,12 +2422,35 @@ export default function Globe3D({
       // Footprint ring for selected satellites — green when workable from DE.
       if (isSelected && Number.isFinite(sat.footprintRadius) && sat.footprintRadius > 0) {
         const ringPts = footprintRingPoints(sat.lat, sat.lon, sat.footprintRadius / 6371, EARTH_R * 1.003);
+        const footprintColor = sat.isVisible ? accentGreen : accentCyan;
+
+        // Cone from the satellite to that ring, so the footprint reads as a
+        // volume rather than a circle that happens to sit near a dot.
+        //
+        // DoubleSide is deliberate: seeing the far wall through the near one is
+        // what gives it depth. depthWrite stays off so it never occludes the
+        // globe, the ground track or the satellite itself — the cone is a hint,
+        // not an object, and at low opacity a depth-writing mesh would punch a
+        // hole in whatever it covers.
+        s.satGroup.add(
+          new THREE.Mesh(
+            footprintConeGeometry(satPos, ringPts),
+            new THREE.MeshBasicMaterial({
+              color: footprintColor,
+              transparent: true,
+              opacity: 0.1,
+              side: THREE.DoubleSide,
+              depthWrite: false,
+            }),
+          ),
+        );
+
         const ringGeo = new THREE.BufferGeometry().setFromPoints(ringPts);
         s.satGroup.add(
           new THREE.LineLoop(
             ringGeo,
             new THREE.LineBasicMaterial({
-              color: sat.isVisible ? accentGreen : accentCyan,
+              color: footprintColor,
               transparent: true,
               opacity: 0.8,
               depthWrite: false,


### PR DESCRIPTION
## What does this PR do?

Selecting a satellite on the 3D globe drew a ring where its footprint meets the ground. The satellite dot and that ring read as two separate things — nothing tied the circle to the satellite it belongs to.

This fills the volume between them: a semi-transparent cone from the satellite down to its footprint ring.

The cone is a triangle fan from the satellite to consecutive points of the ring `footprintRingPoints()` already computes, so its base **is** the footprint being drawn rather than a second approximation of the same circle that could drift from it. The ring stays exactly as it was and now reads as the cone's base.

Colour follows the ring — green when the satellite is workable from DE, cyan otherwise — so the two can never disagree.

### Rendering choices

Three deliberate ones, each of which looks like an oversight if you don't know why:

- **`side: DoubleSide`** — seeing the far wall through the near one is what gives the cone depth. Single-sided it reads as a flat patch.
- **`depthWrite: false`** — the cone never occludes the globe, the ground track or the satellite dot. At this opacity a depth-writing mesh would punch a hole in whatever it covered, which is worse than the flat ring it replaces.
- **`opacity: 0.1`** — the map underneath has to stay readable. It also stacks: where the near and far walls overlap the shape reads denser on its own, which is the depth cue for free.

### One thing to expect

For low-earth orbits the cone is squat. AO-73 sits about 0.09 earth radii up against a footprint thousands of km across, so the walls flare almost flat and it reads more as a filled lens than a beam. That is the geometry being honest — a higher orbit gives a visibly taller cone. Exaggerating the altitude would look better and misrepresent the coverage, so it does not.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Translation
- [ ] Map layer plugin

## How to test

1. `npm ci`, then `node server.js` and `npm run dev`.
2. Settings → Satellites: track one or two (AO-73 and AO-91 are good — reasonably large footprints).
3. Switch the map to **3D** and click a satellite dot to select it.
4. The footprint ring should now be the base of a translucent cone rising to the satellite. Drag to orbit: the cone should read as a volume from the side and as a filled disc looking straight down its axis.
5. Check it does not obscure anything — the ground track, the nadir line, the dot and the map underneath all stay visible through it.
6. Deselect: cone and ring disappear together.

## Checklist

- [x] App loads without console errors
- [x] Tested in **Dark**, **Light**, and **Retro** themes
- [x] Responsive at different screen sizes (desktop + mobile)
- [ ] If touching `server.js`: caches have TTLs and size caps — *n/a, untouched*
- [ ] If adding an API route: includes caching and error handling — *n/a, none added*
- [ ] If adding a panel: wired into Modern, Classic, and Dockable layouts — *n/a, no new panel*
- [x] No hardcoded colors — uses CSS variables
- [x] No `.bak`, `.old`, `console.log` debug lines, or test scripts included

## Verification

Inspected in the running scene rather than judged only by eye. With two satellites selected the satellite group holds, per satellite, one `Mesh` of **216 vertices** — 72 ring segments × 3 — with `side: 2` (DoubleSide), `opacity: 0.1`, and the same colour as its `LineLoop` ring.

Cost is one mesh per *selected* satellite, built from points that were being computed anyway; nothing is added for unselected ones.

## Screenshots (if visual change)

<!-- Side view of a selected satellite showing the cone over its footprint -->
<img width="941" height="601" alt="image" src="https://github.com/user-attachments/assets/8a824566-45a5-498c-a9c8-b2159e2f162d" />

