### PR TITLE
Hotfix: stop paging watchtower on single fletcher relay blips

### DIFF
--- a/fletcher/server.js
+++ b/fletcher/server.js
@@ -56,9 +56,13 @@ const stats = {
   // reads these so "fletcher alive but every relay failing" no longer
   // reports green. 403/429/5xx and network errors count as errors; 404 is a
   // routine missing-satellite answer and counts as ok.
+  // consecutiveUpstreamFails lets the probe tell one transient blip (which
+  // used to page watchtower for a guaranteed 10 minutes) from an upstream
+  // that is actually failing repeatedly.
   lastUpstreamOkAt: null,
   lastUpstreamErrorAt: null,
   lastUpstreamStatus: null,
+  consecutiveUpstreamFails: 0,
 };
 
 const log = (level, msg) => {
@@ -109,8 +113,10 @@ async function relay(upstreamName, targetUrl, req, res) {
     stats.lastUpstreamStatus = result.status;
     if (result.status === 403 || result.status === 429 || result.status >= 500) {
       stats.lastUpstreamErrorAt = now();
+      stats.consecutiveUpstreamFails++;
     } else {
       stats.lastUpstreamOkAt = now();
+      stats.consecutiveUpstreamFails = 0;
     }
 
     if (result.status >= 200 && result.status < 300) {
@@ -127,6 +133,7 @@ async function relay(upstreamName, targetUrl, req, res) {
     stats.upstreamFails++;
     stats.lastUpstreamErrorAt = now();
     stats.lastUpstreamStatus = 0;
+    stats.consecutiveUpstreamFails++;
     log('WARN', `${upstreamName} fetch failed (${targetUrl}): ${err.message}`);
 
     if (cached) {

--- a/server/health.js
+++ b/server/health.js
@@ -12,9 +12,10 @@
  * the subsystem is intentionally disabled (e.g. FLETCHER_URL unset).
  */
 
+const { classifyFletcherRelays } = require('./utils/fletcherRelayHealth');
+
 const REFRESH_MS = 30 * 1000;
 const PROBE_TIMEOUT_MS = 5 * 1000;
-const FLETCHER_RELAY_ERROR_WINDOW_MS = 10 * 60 * 1000; // relay error newer than this (and newer than the last success) => degraded
 const RBN_STALE_AFTER_MS = 10 * 60 * 1000; // no spot in 10 min => degraded
 const SATELLITES_GRACE_MS = 60 * 60 * 1000; // 1h past OMM_CACHE_DURATION before degraded
 const SATELLITES_CACHE_DURATION_MS = 24 * 60 * 60 * 1000; // mirrors OMM_CACHE_DURATION
@@ -74,15 +75,12 @@ async function checkFletcher(ctx) {
   // lastUpstreamOkAt/lastUpstreamErrorAt so we can report relay trouble.
   const result = await probeJson(`${base}/stats`, 'fletcher');
   if (result.ok) {
-    const s = result.json || {};
-    const errAt = typeof s.lastUpstreamErrorAt === 'number' ? s.lastUpstreamErrorAt : 0;
-    const okAt = typeof s.lastUpstreamOkAt === 'number' ? s.lastUpstreamOkAt : 0;
-    if (errAt > okAt && Date.now() - errAt < FLETCHER_RELAY_ERROR_WINDOW_MS) {
-      const secs = Math.round((Date.now() - errAt) / 1000);
-      const status = s.lastUpstreamStatus === 0 ? 'no response' : `HTTP ${s.lastUpstreamStatus}`;
-      return { status: 'degraded', detail: `alive but relays failing (${status}, last error ${secs}s ago)` };
-    }
-    return { status: 'ok', detail: `${result.status} from ${base}/stats` };
+    // Verdict logic lives in utils/fletcherRelayHealth so it's testable:
+    // degraded needs ≥2 consecutive relay failures — a single transient
+    // blip used to page watchtower for a guaranteed 10 minutes.
+    const verdict = classifyFletcherRelays(result.json || {}, Date.now());
+    if (verdict.status === 'degraded') return verdict;
+    return { status: 'ok', detail: `${result.status} from ${base}/stats — ${verdict.detail}` };
   }
 
   // Older fletcher builds without the outcome fields still answer /health.

--- a/server/utils/fletcherRelayHealth.js
+++ b/server/utils/fletcherRelayHealth.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Fletcher relay-health verdict (#1165 follow-up).
+ *
+ * The original probe marked fletcher degraded whenever the newest relay
+ * outcome was an error inside a 10-minute window. Fletcher is a passive
+ * relay with no background refresh, so after ONE transient upstream
+ * timeout there is often no follow-up fetch to clear the error — health
+ * sat degraded until the window expired, and watchtower paged Discord on
+ * both flips. One failed HTTP request bought two pings, every time.
+ *
+ * Now a relay error only degrades health once fletcher reports at least
+ * CONSECUTIVE_FAILS_THRESHOLD consecutive failures. A genuinely blocked
+ * upstream (the v26.6.0 release-day serial 403s) still trips immediately
+ * as retries stack up; a lone blip reports ok with the blip noted in the
+ * detail string so the information isn't lost, it just doesn't page.
+ */
+
+const RELAY_ERROR_WINDOW_MS = 10 * 60 * 1000;
+const CONSECUTIVE_FAILS_THRESHOLD = 2;
+
+/**
+ * @param {object} s parsed fletcher /stats JSON
+ * @param {number} nowMs current time
+ * @returns {{status: 'ok'|'degraded', detail: string}}
+ */
+function classifyFletcherRelays(s, nowMs) {
+  const errAt = typeof s.lastUpstreamErrorAt === 'number' ? s.lastUpstreamErrorAt : 0;
+  const okAt = typeof s.lastUpstreamOkAt === 'number' ? s.lastUpstreamOkAt : 0;
+  const errorIsCurrent = errAt > okAt && nowMs - errAt < RELAY_ERROR_WINDOW_MS;
+  if (!errorIsCurrent) return { status: 'ok', detail: 'relays ok' };
+
+  const secs = Math.round((nowMs - errAt) / 1000);
+  const statusText = s.lastUpstreamStatus === 0 ? 'no response' : `HTTP ${s.lastUpstreamStatus}`;
+  // Older fletcher builds don't report the counter. Treat missing as a
+  // single blip: during a mixed-version deploy window we'd rather
+  // under-page than reintroduce the two-pings-per-blip noise, and
+  // satellite data serves stale through relay trouble regardless.
+  const fails = typeof s.consecutiveUpstreamFails === 'number' ? s.consecutiveUpstreamFails : 1;
+  if (fails >= CONSECUTIVE_FAILS_THRESHOLD) {
+    return {
+      status: 'degraded',
+      detail: `alive but relays failing (${statusText}, ${fails} consecutive, last error ${secs}s ago)`,
+    };
+  }
+  return { status: 'ok', detail: `ok (1 transient relay error ${secs}s ago, ${statusText})` };
+}
+
+module.exports = { classifyFletcherRelays, RELAY_ERROR_WINDOW_MS, CONSECUTIVE_FAILS_THRESHOLD };

--- a/server/utils/fletcherRelayHealth.test.js
+++ b/server/utils/fletcherRelayHealth.test.js
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import relayHealth from './fletcherRelayHealth.js';
+
+const { classifyFletcherRelays, RELAY_ERROR_WINDOW_MS, CONSECUTIVE_FAILS_THRESHOLD } = relayHealth;
+
+const NOW = 1_800_000_000_000;
+
+describe('classifyFletcherRelays (#1165 follow-up — no paging on single blips)', () => {
+  it('ok when there are no outcomes at all (fresh boot)', () => {
+    expect(classifyFletcherRelays({}, NOW).status).toBe('ok');
+  });
+
+  it('ok when the last outcome was a success', () => {
+    const s = { lastUpstreamOkAt: NOW - 1000, lastUpstreamErrorAt: NOW - 5000, consecutiveUpstreamFails: 0 };
+    expect(classifyFletcherRelays(s, NOW).status).toBe('ok');
+  });
+
+  it('a single recent failure reports ok, with the blip noted in the detail', () => {
+    const s = {
+      lastUpstreamOkAt: NOW - 60_000,
+      lastUpstreamErrorAt: NOW - 30_000,
+      lastUpstreamStatus: 0,
+      consecutiveUpstreamFails: 1,
+    };
+    const v = classifyFletcherRelays(s, NOW);
+    expect(v.status).toBe('ok');
+    expect(v.detail).toContain('1 transient relay error');
+    expect(v.detail).toContain('no response');
+  });
+
+  it(`degraded at ${CONSECUTIVE_FAILS_THRESHOLD} consecutive failures`, () => {
+    const s = {
+      lastUpstreamOkAt: NOW - 60_000,
+      lastUpstreamErrorAt: NOW - 30_000,
+      lastUpstreamStatus: 403,
+      consecutiveUpstreamFails: 2,
+    };
+    const v = classifyFletcherRelays(s, NOW);
+    expect(v.status).toBe('degraded');
+    expect(v.detail).toContain('2 consecutive');
+    expect(v.detail).toContain('HTTP 403');
+  });
+
+  it('the v26.6.0 release-day shape (serial 403s) still trips immediately', () => {
+    const s = {
+      lastUpstreamOkAt: null,
+      lastUpstreamErrorAt: NOW - 10_000,
+      lastUpstreamStatus: 403,
+      consecutiveUpstreamFails: 7,
+    };
+    expect(classifyFletcherRelays(s, NOW).status).toBe('degraded');
+  });
+
+  it('recovers when the error ages out of the window even with a high count', () => {
+    const s = {
+      lastUpstreamOkAt: null,
+      lastUpstreamErrorAt: NOW - RELAY_ERROR_WINDOW_MS - 1000,
+      lastUpstreamStatus: 0,
+      consecutiveUpstreamFails: 9,
+    };
+    expect(classifyFletcherRelays(s, NOW).status).toBe('ok');
+  });
+
+  it('missing counter (older fletcher build) is treated as a single blip — no paging in a mixed-version deploy window', () => {
+    const s = { lastUpstreamOkAt: NOW - 60_000, lastUpstreamErrorAt: NOW - 30_000, lastUpstreamStatus: 0 };
+    const v = classifyFletcherRelays(s, NOW);
+    expect(v.status).toBe('ok');
+    expect(v.detail).toContain('transient');
+  });
+
+  it('distinguishes no-response (status 0) from HTTP status in the degraded detail', () => {
+    const s = {
+      lastUpstreamOkAt: 0,
+      lastUpstreamErrorAt: NOW - 5000,
+      lastUpstreamStatus: 0,
+      consecutiveUpstreamFails: 3,
+    };
+    expect(classifyFletcherRelays(s, NOW).detail).toContain('no response');
+  });
+});


### PR DESCRIPTION
Re-cut of #1172 as a cherry-pick onto main — Staging moved (footprint-cone merge) after that PR opened, and its head was the branch itself, so merging it would no longer have been hotfix-only.

Same change, verified live on staging: fletcher /stats reports `consecutiveUpstreamFails`, and the health verdict (extracted to `server/utils/fletcherRelayHealth.js`, 8 tests) goes degraded only at ≥2 consecutive relay failures. Single transient blips stop producing the ok→degraded→ok Discord ping pairs watchtower has been sending since 26.7.0 shipped; the real failure mode (serial 403s) still trips immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)