### PR TITLE
v26.7.2 — hotfix release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhamclock",
-  "version": "26.7.1",
+  "version": "26.7.2",
   "description": "Amateur Radio Dashboard - A modern web-based HamClock alternative",
   "main": "electron/main.js",
   "scripts": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -65,6 +65,7 @@ import useAudioAlerts from './hooks/app/useAudioAlerts';
 import { useSatelliteAnnouncements } from './hooks/app/useSatelliteAnnouncements';
 import useSceneRotation from './hooks/app/useSceneRotation';
 import WhatsNew from './components/WhatsNew.jsx';
+import StarTrekDayModal from './components/StarTrekDayModal.jsx';
 import CommandPalette from './components/CommandPalette.jsx';
 import { LogQsoPopupController } from './components/LogQsoPopup.jsx';
 import { initCtyLookup } from './utils/ctyLookup.js';
@@ -1031,6 +1032,8 @@ const App = () => {
         isLocalInstall={isLocalInstall}
       />
       <WhatsNew showWhatsNew={config.showWhatsNew} />
+      {/* Star Trek Day 2026 (Sept 7-9) — one-shot event notice, ?stday previews */}
+      <StarTrekDayModal />
       {/* Scene rotation indicator — unobtrusive dot while rotating, with the
           new layout's name flashed briefly on each switch. */}
       {sceneRotation.active && (

--- a/src/components/StarTrekDayModal.jsx
+++ b/src/components/StarTrekDayModal.jsx
@@ -1,0 +1,206 @@
+/**
+ * Star Trek Day 2026 — one-shot event notification.
+ *
+ * Shows once per browser during September 7-9, 2026 (local dates, same
+ * convention as the seasonal easter eggs): a blurb for Star Trek Day —
+ * September 8, 2026 is the 60th anniversary of the 1966 premiere — a nudge
+ * toward the Trek theme with an Engage button that applies it on the spot,
+ * and the Special Event Station N3S operating schedule. Either button
+ * (Engage or OK) dismisses it permanently via localStorage.
+ *
+ * Preview: `?stday` in the URL forces it open regardless of date or
+ * dismissal (kept out of the manual, like `?egg=`). The preview never
+ * writes the dismissed flag, so checking the popup early doesn't eat the
+ * real September showing.
+ */
+import { useState } from 'react';
+import { useTheme } from '../theme/useTheme';
+
+const LS_KEY = 'ohc_startrekday_2026_dismissed';
+const LCARS_ORANGE = '#ff9c00';
+const LCARS_LAVENDER = '#9999cc';
+
+/** Local-date window: September 7-9, 2026. Exported for tests. */
+export function inStarTrekDayWindow(date = new Date()) {
+  return date.getFullYear() === 2026 && date.getMonth() === 8 && date.getDate() >= 7 && date.getDate() <= 9;
+}
+
+/** Whether the modal should show. Exported for tests. */
+export function shouldShowStarTrekDay({ date = new Date(), dismissed = false, forced = false } = {}) {
+  if (forced) return true;
+  return !dismissed && inStarTrekDayWindow(date);
+}
+
+const isForced = () => {
+  try {
+    return new URLSearchParams(window.location.search).has('stday');
+  } catch {
+    return false;
+  }
+};
+
+export default function StarTrekDayModal() {
+  const { setTheme } = useTheme();
+  const [forced] = useState(isForced);
+  const [open, setOpen] = useState(() => {
+    let dismissed = false;
+    try {
+      dismissed = localStorage.getItem(LS_KEY) === '1';
+    } catch {}
+    return shouldShowStarTrekDay({ dismissed, forced: isForced() });
+  });
+
+  if (!open) return null;
+
+  const dismiss = () => {
+    // A forced preview never writes the flag — checking the popup early
+    // shouldn't eat the real September showing.
+    if (!forced) {
+      try {
+        localStorage.setItem(LS_KEY, '1');
+      } catch {}
+    }
+    setOpen(false);
+  };
+
+  const engage = () => {
+    setTheme('trek');
+    dismiss();
+  };
+
+  const pill = (text, color) => (
+    <span
+      style={{
+        display: 'inline-block',
+        background: color,
+        color: '#000',
+        borderRadius: '999px',
+        padding: '1px 10px',
+        fontWeight: 700,
+        fontSize: '11px',
+        letterSpacing: '0.5px',
+      }}
+    >
+      {text}
+    </span>
+  );
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Star Trek Day"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 10000,
+        background: 'rgba(0, 0, 0, 0.72)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '20px',
+      }}
+    >
+      <div
+        style={{
+          maxWidth: '560px',
+          width: '100%',
+          maxHeight: '90vh',
+          overflowY: 'auto',
+          background: '#000',
+          border: `2px solid ${LCARS_ORANGE}`,
+          borderLeft: `16px solid ${LCARS_ORANGE}`,
+          borderRadius: '24px 8px 8px 24px',
+          padding: '18px 22px',
+          color: '#ffcc99',
+          fontFamily: "'Antonio', 'Arial Narrow', 'Helvetica Neue', sans-serif",
+        }}
+      >
+        <div
+          style={{
+            background: LCARS_ORANGE,
+            color: '#000',
+            borderRadius: '999px',
+            padding: '4px 16px',
+            fontWeight: 700,
+            fontSize: '16px',
+            letterSpacing: '1px',
+            textTransform: 'uppercase',
+            marginBottom: '14px',
+          }}
+        >
+          🖖 Happy Star Trek Day
+        </div>
+
+        <p style={{ fontSize: '14px', lineHeight: 1.5, margin: '0 0 12px' }}>
+          On September 8, 1966, Star Trek aired for the very first time — which makes this Star Trek Day the{' '}
+          <b style={{ color: LCARS_ORANGE }}>60th anniversary</b>. In celebration, OpenHamClock has a full LCARS
+          bridge-console theme. Engage it below, or find it any time in Settings → Display.
+        </p>
+
+        <div
+          style={{
+            border: `1px solid ${LCARS_LAVENDER}`,
+            borderRadius: '10px',
+            padding: '10px 14px',
+            marginBottom: '12px',
+            fontSize: '13px',
+            lineHeight: 1.55,
+          }}
+        >
+          <div style={{ marginBottom: '6px' }}>{pill('SPECIAL EVENT STATION N3S', LCARS_LAVENDER)}</div>
+          <b style={{ color: '#fff' }}>N3S</b> is on the air <b>September 7–9</b>, daily from{' '}
+          <b>9 AM–9 PM Eastern (1300–0100 UTC)</b>, with operators scattered across all three days on <b>all modes</b>.
+          <br />
+          <br />
+          Catch project lead <b style={{ color: LCARS_ORANGE }}>K0CJH</b> and contributor{' '}
+          <b style={{ color: LCARS_ORANGE }}>N3DD</b> running <b>1,500 watts</b> across the USA from New Jersey:
+          <br />• Monday 1–5 PM Eastern (1700–2100 UTC)
+          <br />• Tuesday 5–9 PM Eastern (2100–0100 UTC)
+          <br />
+          <br />
+          See the <b>N3S page on QRZ</b> for details and a peek at the QSL card design.
+        </div>
+
+        <div style={{ display: 'flex', gap: '10px', justifyContent: 'flex-end' }}>
+          <button
+            type="button"
+            onClick={engage}
+            style={{
+              background: LCARS_ORANGE,
+              color: '#000',
+              border: 'none',
+              borderRadius: '999px',
+              padding: '6px 18px',
+              fontWeight: 700,
+              fontSize: '13px',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              textTransform: 'uppercase',
+            }}
+          >
+            Engage Trek Theme
+          </button>
+          <button
+            type="button"
+            onClick={dismiss}
+            style={{
+              background: 'transparent',
+              color: LCARS_LAVENDER,
+              border: `1px solid ${LCARS_LAVENDER}`,
+              borderRadius: '999px',
+              padding: '6px 18px',
+              fontWeight: 700,
+              fontSize: '13px',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              textTransform: 'uppercase',
+            }}
+          >
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/StarTrekDayModal.test.jsx
+++ b/src/components/StarTrekDayModal.test.jsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { inStarTrekDayWindow, shouldShowStarTrekDay } from './StarTrekDayModal.jsx';
+
+describe('Star Trek Day 2026 window', () => {
+  it('opens Sept 7-9 2026 only', () => {
+    expect(inStarTrekDayWindow(new Date(2026, 8, 6))).toBe(false);
+    expect(inStarTrekDayWindow(new Date(2026, 8, 7))).toBe(true);
+    expect(inStarTrekDayWindow(new Date(2026, 8, 8))).toBe(true);
+    expect(inStarTrekDayWindow(new Date(2026, 8, 9))).toBe(true);
+    expect(inStarTrekDayWindow(new Date(2026, 8, 10))).toBe(false);
+  });
+
+  it('never fires in other years', () => {
+    expect(inStarTrekDayWindow(new Date(2027, 8, 8))).toBe(false);
+    expect(inStarTrekDayWindow(new Date(2025, 8, 8))).toBe(false);
+  });
+
+  it('dismissal wins inside the window', () => {
+    expect(shouldShowStarTrekDay({ date: new Date(2026, 8, 8), dismissed: false })).toBe(true);
+    expect(shouldShowStarTrekDay({ date: new Date(2026, 8, 8), dismissed: true })).toBe(false);
+  });
+
+  it('?stday preview forces it regardless of date and dismissal', () => {
+    expect(shouldShowStarTrekDay({ date: new Date(2026, 8, 3), dismissed: true, forced: true })).toBe(true);
+  });
+});

--- a/src/components/WhatsNew.jsx
+++ b/src/components/WhatsNew.jsx
@@ -44,6 +44,11 @@ const CHANGELOG = [
         title: 'FIX: EmComm Respects the DE/DX Marker Toggle',
         desc: 'The DE/DX map layer toggle worked everywhere except EmComm mode, where the layout hardcoded the markers on. It now tracks the same setting as every other layout.',
       },
+      {
+        icon: '🖖',
+        title: 'FIX: Trek Theme Header Buttons Readable Again',
+        desc: 'Buttons and badges in panel headers kept the light colours they wear on dark panels, which vanished against the bright LCARS pill bars. Plain header text now goes black like a proper LCARS bar, and buttons, selects, and inputs sit in black wells — the cutouts real LCARS consoles have — so their own state colours stay visible.',
+      },
     ],
   },
   {

--- a/src/components/WhatsNew.jsx
+++ b/src/components/WhatsNew.jsx
@@ -29,6 +29,24 @@ const ANNOUNCEMENT = {
 
 const CHANGELOG = [
   {
+    version: '26.7.2',
+    date: '2026-09-03',
+    heading:
+      'Another quick hotfix — two EmComm mode bugs from the same sharp pair of eyes (thanks @mbrun-plm), both cases of the EmComm layout ignoring settings the Dockable layout respects.',
+    features: [
+      {
+        icon: '📻',
+        title: 'FIX: EmComm APRS Source Filter Now Filters the Map',
+        desc: 'The RF Only / Internet Only / All Sources select in the EmComm Stations panel filtered the station list but not the map — the map quietly received the unfiltered feed, so "RF Only" still plotted every internet station. The select now drives both, on top of any watchlist or group filter you have active.',
+      },
+      {
+        icon: '📍',
+        title: 'FIX: EmComm Respects the DE/DX Marker Toggle',
+        desc: 'The DE/DX map layer toggle worked everywhere except EmComm mode, where the layout hardcoded the markers on. It now tracks the same setting as every other layout.',
+      },
+    ],
+  },
+  {
     version: '26.7.1',
     date: '2026-09-02',
     heading:

--- a/src/layouts/EmcommLayout.jsx
+++ b/src/layouts/EmcommLayout.jsx
@@ -162,6 +162,7 @@ export default function EmcommLayout(props) {
     dxFilters,
     mapBandFilter,
     setMapBandFilter,
+    mapLayers,
     aprsData,
     emcommData,
     setShowSettings,
@@ -308,6 +309,18 @@ export default function EmcommLayout(props) {
 
   const { alerts = [], shelters = [], disasters = [], loading } = emcommData || {};
   const allAprsStations = aprsData?.stations || [];
+
+  // Stations for the MAP: the hook's filteredStations (watchlist/group rules
+  // applied) with this layout's own source select applied on top. The select
+  // previously filtered only the EmComm Stations panel list — the map got the
+  // unfiltered hook output, so "RF Only" still plotted internet stations
+  // (#1175).
+  const mapAprsStations = useMemo(() => {
+    const base = aprsData?.filteredStations || [];
+    if (aprsSource === 'rf') return base.filter((s) => s.source === 'local-tnc');
+    if (aprsSource === 'internet') return base.filter((s) => s.source !== 'local-tnc');
+    return base;
+  }, [aprsData?.filteredStations, aprsSource]);
 
   // Apply APRS source filter
   const aprsStations = useMemo(() => {
@@ -863,7 +876,7 @@ export default function EmcommLayout(props) {
             onMapBandFilterChange={setMapBandFilter}
             satellites={[]}
             pskReporterSpots={[]}
-            showDeDxMarkers={true}
+            showDeDxMarkers={mapLayers?.showDeDxMarkers ?? true}
             showDXPaths={false}
             showDXLabels={false}
             onToggleDXLabels={toggleDXLabels}
@@ -878,7 +891,7 @@ export default function EmcommLayout(props) {
             showWSJTX={false}
             showDXNews={false}
             showAPRS={true}
-            aprsStations={aprsData?.filteredStations}
+            aprsStations={mapAprsStations}
             aprsWatchlistCalls={aprsData?.allWatchlistCalls}
             hoveredSpot={hoveredSpot}
             hideOverlays={true}

--- a/src/layouts/EmcommLayout.jsx
+++ b/src/layouts/EmcommLayout.jsx
@@ -162,7 +162,6 @@ export default function EmcommLayout(props) {
     dxFilters,
     mapBandFilter,
     setMapBandFilter,
-    mapLayers,
     aprsData,
     emcommData,
     setShowSettings,

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1699,6 +1699,26 @@ pre,
   background: #cc99cc !important;
 }
 
+/* Header pill contents. Spans and badges pin light colours inline
+   (var(--text-muted), accent greens) that were designed for dark panels
+   and vanish against the bright pill — LCARS bars carry black text, so
+   force it on everything that isn't a form control. Controls instead get
+   a dark well behind them (the black cutouts real LCARS bars have), which
+   keeps their own light text and active-state colours readable and
+   working. .no-theme-header (contest quick-log strip) opts out of all of
+   this along with the pill itself. */
+[data-theme='trek']
+  .panel:not(.no-theme-header)
+  > div:first-child
+  *:not(button):not(select):not(input):not(button *):not(select *) {
+  color: #000 !important;
+}
+[data-theme='trek'] .panel:not(.no-theme-header) > div:first-child button,
+[data-theme='trek'] .panel:not(.no-theme-header) > div:first-child select,
+[data-theme='trek'] .panel:not(.no-theme-header) > div:first-child input {
+  background: rgba(0, 0, 0, 0.75) !important;
+}
+
 /* Pill buttons, LCARS-style */
 [data-theme='trek'] button {
   border-radius: 999px !important;


### PR DESCRIPTION
Second hotfix this week — EmComm fixes verified by the reporter and Chris on staging, Trek polish, and the Star Trek Day event window (time-sensitive: must be on prod before Sept 7).

- 📻 **#1175** — EmComm APRS source select now filters the map, not just the station list (verified on staging, issue closed)
- 📍 **#1176** — EmComm respects the DE/DX marker toggle (verified on staging, issue closed)
- 🖖 Trek theme: header buttons/badges readable — plain header text goes black, controls get LCARS black wells
- 🖖 **Star Trek Day modal** (Sept 7–9, one-shot per browser): 60th-anniversary blurb, Engage-Trek-theme button, N3S special event station schedule; `?stday` previews
- 🔧 build-break fix from the c3df3117 duplicate-destructure incident

WhatsNew 26.7.2 entry (three fixes) + version bump included. Suite 1515 green, staging deployed and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)