### PR TITLE
fix(scripts): use POSIX ERE in vendor-download.sh for Alpine/BusyBox compatibility

### DIFF
--- a/scripts/vendor-download.sh
+++ b/scripts/vendor-download.sh
@@ -46,7 +46,7 @@ COUNTER=0
 cp /tmp/gfonts-raw.css "$VENDOR_DIR/fonts/fonts.css"
 
 # Extract all woff2 URLs, download them, rewrite CSS
-grep -oP 'https://fonts\.gstatic\.com/[^\)]+' /tmp/gfonts-raw.css | sort -u | while read url; do
+grep -oE 'https://fonts\.gstatic\.com/[^)]+' /tmp/gfonts-raw.css | sort -u | while read url; do
   COUNTER=$((COUNTER + 1))
   FILENAME="font-${COUNTER}.woff2"
   curl -sL "$url" -o "$VENDOR_DIR/fonts/$FILENAME"


### PR DESCRIPTION
### Summary
Fixes font asset extraction in `scripts/vendor-download.sh` when running in Alpine Linux (Docker container builds) and BusyBox environments.

### Problem
In `scripts/vendor-download.sh`, line 49 used `grep -oP`:
```bash
grep -oP 'https://fonts\.gstatic\.com/[^\)]+' /tmp/gfonts-raw.css
```
Alpine's default BusyBox `grep` does not support the `-P` (PCRE) flag and fails with:
```
grep: unrecognized option: P
0 font files downloaded
```
Because the Dockerfile uses `bash scripts/vendor-download.sh || true`, the build continues silently without downloading the `.woff2` font files, leaving the self-hosted container reliant on remote Google Fonts CDN.

### Solution
Switch from `-oP` to `-oE` (POSIX Extended Regular Expression):
```bash
grep -oE 'https://fonts\.gstatic\.com/[^)]+' /tmp/gfonts-raw.css
```
This works universally across Alpine (BusyBox), Debian/Ubuntu (GNU grep), and macOS/BSD without requiring extra packages.

### Verification
- Tested in Alpine container with BusyBox `grep` — successfully extracted and downloaded all font files.
- Tested on standard Linux environment with GNU `grep`.