### PR TITLE
v26.7.3 — hotfix release

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -40,17 +40,17 @@ map layer, not a logbook.
 Accepts a single QSO object, a bare array, or `{ "qsos": [...] }`.
 Batches are capped at **100 QSOs per request**.
 
-| Field       | Type             | Required | Notes                                                        |
-| ----------- | ---------------- | -------- | ------------------------------------------------------------ |
-| `call`      | string           | yes      | Callsign of the worked station (portable `/` suffixes OK)    |
-| `grid`      | string           | \*       | Maidenhead locator, 2/4/6/8 chars (e.g. `FN42`)              |
-| `lat`,`lon` | number           | \*       | Decimal degrees; takes precedence over `grid` when both sent |
-| `freq`      | number           | no       | Frequency in **MHz** (`freq_khz` also accepted)              |
-| `band`      | string           | no       | e.g. `20m`; derived from `freq` when omitted                 |
-| `mode`      | string           | no       | e.g. `SSB`, `CW`, `FT8`                                      |
-| `timestamp` | string \| number | no       | ISO 8601 or epoch **ms**; defaults to server "now"           |
-| `label`     | string           | no       | Free text shown in the marker popup (max 120 chars)          |
-| `color`     | string           | no       | CSS color for this QSO's marker/path (`#rrggbb` or named)    |
+| Field       | Type             | Required | Notes                                                                                         |
+| ----------- | ---------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `call`      | string           | yes      | Callsign of the worked station (portable `/` suffixes OK); drawn as a label beside the marker |
+| `grid`      | string           | \*       | Maidenhead locator, 2/4/6/8 chars (e.g. `FN42`)                                               |
+| `lat`,`lon` | number           | \*       | Decimal degrees; takes precedence over `grid` when both sent                                  |
+| `freq`      | number           | no       | Frequency in **MHz** (`freq_khz` also accepted)                                               |
+| `band`      | string           | no       | e.g. `20m`; derived from `freq` when omitted                                                  |
+| `mode`      | string           | no       | e.g. `SSB`, `CW`, `FT8`                                                                       |
+| `timestamp` | string \| number | no       | ISO 8601 or epoch **ms**; defaults to server "now"                                            |
+| `label`     | string           | no       | Free text shown in the marker popup (max 120 chars)                                           |
+| `color`     | string           | no       | CSS color for this QSO's marker/path (`#rrggbb` or named)                                     |
 
 \* At least one of `grid` or `lat`+`lon` is required — a QSO that can't be
 placed on the map is rejected. Unknown fields are silently dropped.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openhamclock",
-  "version": "26.6.0",
+  "version": "26.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openhamclock",
-      "version": "26.6.0",
+      "version": "26.7.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openhamclock",
-  "version": "26.7.2",
+  "version": "26.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openhamclock",
-      "version": "26.7.2",
+      "version": "26.7.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhamclock",
-  "version": "26.7.2",
+  "version": "26.7.3",
   "description": "Amateur Radio Dashboard - A modern web-based HamClock alternative",
   "main": "electron/main.js",
   "scripts": {

--- a/scripts/vendor-download.sh
+++ b/scripts/vendor-download.sh
@@ -46,7 +46,7 @@ COUNTER=0
 cp /tmp/gfonts-raw.css "$VENDOR_DIR/fonts/fonts.css"
 
 # Extract all woff2 URLs, download them, rewrite CSS
-grep -oP 'https://fonts\.gstatic\.com/[^\)]+' /tmp/gfonts-raw.css | sort -u | while read url; do
+grep -oE 'https://fonts\.gstatic\.com/[^)]+' /tmp/gfonts-raw.css | sort -u | while read url; do
   COUNTER=$((COUNTER + 1))
   FILENAME="font-${COUNTER}.woff2"
   curl -sL "$url" -o "$VENDOR_DIR/fonts/$FILENAME"

--- a/src/DockableApp.jsx
+++ b/src/DockableApp.jsx
@@ -82,6 +82,7 @@ import { DockableLayoutProvider } from './contexts';
 import { useRig } from './contexts/RigContext.jsx';
 import { calculateBearing, calculateDistance, formatDistance } from './utils/geo.js';
 import { findDXPathForSpot } from './utils/dxClusterSpotMatcher';
+import { requestMapFocus } from './utils/mapFocus.js';
 import { DXGridInput } from './components/DXGridInput.jsx';
 import { DXCallsignInput } from './components/DXCallsignInput.jsx';
 import { DXFavorites } from './components/DXFavorites.jsx';
@@ -421,13 +422,18 @@ export const DockableApp = ({
       // 2. Set DX Location if location data is available
       // For DX Cluster spots, we need to find the path data which contains coordinates
       // For POTA/SOTA, the spot object itself has lat/lon
+      // 3. Bring the target into view: the map pans only when the target is
+      // off-screen and drops a pulse ring on it either way (#1182). Runs even
+      // with DX locked — the marker stays put, but the eye still gets a cue.
       if (spot.lat != null && spot.lon != null) {
         handleDXChange({ lat: spot.lat, lon: spot.lon, callsign: spot.call ?? null });
+        requestMapFocus({ lat: spot.lat, lon: spot.lon });
       } else if (spot.call) {
         // Try to find in DX Cluster paths
         const path = findDXPathForSpot(dxClusterData.paths || [], spot);
         if (path && path.dxLat != null && path.dxLon != null) {
           handleDXChange({ lat: path.dxLat, lon: path.dxLon, callsign: spot.call ?? null });
+          requestMapFocus({ lat: path.dxLat, lon: path.dxLon });
         }
       }
     },
@@ -1213,6 +1219,7 @@ export const DockableApp = ({
               showOnMap={mapLayersEff.showAPRS}
               onToggleMap={toggleAPRSEff}
               onHoverSpot={setHoveredSpot}
+              onSpotClick={handleSpotClick}
               deLocation={config.location}
               units={config.allUnits?.dist}
             />

--- a/src/components/APRSPanel.jsx
+++ b/src/components/APRSPanel.jsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import CallsignLink from './CallsignLink.jsx';
 import { useCallsignPopup } from './CallsignPopupManager.jsx';
 import { calculateDistance, formatDistance } from '../utils/geo.js';
+import { stationAgeMinutes, formatStationAge } from '../utils/aprsStationAge.js';
 
 const APRSPanel = ({ aprsData, showOnMap, onToggleMap, onHoverSpot, deLocation, units = 'metric' }) => {
   const {
@@ -64,13 +65,7 @@ const APRSPanel = ({ aprsData, showOnMap, onToggleMap, onHoverSpot, deLocation, 
     }
   }, [addCallInput, addCallTarget, addCallToGroup]);
 
-  const formatAge = (minutes) =>
-    minutes == null ? '?' : minutes < 1 ? 'now' : minutes < 60 ? `${minutes}m` : `${Math.floor(minutes / 60)}h`;
-  const stationAgeMinutes = (station) => {
-    if (station.age != null) return station.age;
-    if (station.timestamp != null) return Math.floor((Date.now() - station.timestamp) / 60000);
-    return null;
-  };
+  const formatAge = formatStationAge;
 
   if (!aprsEnabled) {
     return (

--- a/src/components/APRSPanel.jsx
+++ b/src/components/APRSPanel.jsx
@@ -10,7 +10,7 @@ import { useCallsignPopup } from './CallsignPopupManager.jsx';
 import { calculateDistance, formatDistance } from '../utils/geo.js';
 import { stationAgeMinutes, formatStationAge } from '../utils/aprsStationAge.js';
 
-const APRSPanel = ({ aprsData, showOnMap, onToggleMap, onHoverSpot, deLocation, units = 'metric' }) => {
+const APRSPanel = ({ aprsData, showOnMap, onToggleMap, onHoverSpot, onSpotClick, deLocation, units = 'metric' }) => {
   const {
     filteredStations = [],
     stations = [],
@@ -508,7 +508,13 @@ const APRSPanel = ({ aprsData, showOnMap, onToggleMap, onHoverSpot, deLocation, 
                   onHoverSpot?.(null);
                   setTooltip(null);
                 }}
-                onClick={() => {}}
+                onClick={() => {
+                  // Set DX + bring the station into view on the map (#1182)
+                  if (station.lat != null && station.lon != null) {
+                    onSpotClick?.({ call: station.call, ssid: station.ssid, lat: station.lat, lon: station.lon });
+                  }
+                }}
+                title={station.lat != null && station.lon != null ? 'Show on map' : undefined}
                 style={{
                   display: 'grid',
                   gridTemplateColumns: '1fr auto',

--- a/src/components/PluginLayer.jsx
+++ b/src/components/PluginLayer.jsx
@@ -37,6 +37,7 @@ const PluginLayerInner = ({
   satellites,
   allUnits,
   config,
+  showLabels,
 }) => {
   const layerFunc = plugin.useLayer || plugin.hook;
   const safeMap = isMapAlive(map) ? map : null;
@@ -56,6 +57,7 @@ const PluginLayerInner = ({
       satellites,
       allUnits,
       config,
+      showLabels,
     });
   }
   return null;

--- a/src/components/WhatsNew.jsx
+++ b/src/components/WhatsNew.jsx
@@ -29,6 +29,39 @@ const ANNOUNCEMENT = {
 
 const CHANGELOG = [
   {
+    version: '26.7.3',
+    date: '2026-09-10',
+    heading:
+      'Third hotfix of the cycle, and the first with a new feature in it. Two more EmComm reports from Michael (@mbrun-plm), plus a request of his that turned into something every layout gets; a QSO-layer ask from Alan McDonald on Facebook; and a Docker fix from @9M2PJU.',
+    features: [
+      {
+        icon: '🎯',
+        title: 'Click a Panel Row to Find It on the Map',
+        desc: 'Any station, shelter, gateway, or spot listed in a panel can now pull the map to it. In EmComm mode the EmComm Stations, Nearby Winlink Gateways, and Net Roster rows are clickable (roster entries once an APRS position has been heard), pan the map to the target, and drop a short expanding-ring pulse on it so your eye lands on the right dot in a busy view. In the Dockable layout every spot click you already use — DX Cluster, POTA/SOTA/WWFF, PSK Reporter, MeshCom — now pulses the target and pans to it when it is off-screen; if it is already in view the map stays put. APRS panel rows, which looked clickable but did nothing, now behave like every other panel. Flat map only for now; the Azimuthal and 3D globe projections ignore the request. Requested by @mbrun-plm.',
+      },
+      {
+        icon: '🏷️',
+        title: 'Callsign Labels on the Logged-QSO Layers',
+        desc: 'A dot at the end of a QSO path said nothing about who you worked, while the DX spots beside it carried callsign pills. Both logged-QSO layers — Logged QSOs (API) and Logged QSOs (N3FJP) — now draw the same style pill beside each contact, in the layer\'s colour (a per-QSO colour sent through the REST API carries into its pill), and N3FJP live-entry previews get a trailing "?" so a half-typed call reads as tentative. The pills follow the map\'s existing Show/Hide Calls button, so one control governs spot and QSO labels alike. Asked for by Alan McDonald on Facebook.',
+      },
+      {
+        icon: '⏱️',
+        title: 'FIX: EmComm Station Age No Longer Reads "NaNh ago"',
+        desc: 'The EmComm Stations list read a precomputed age that only stations from the server feed carry; beacons arriving over RF from the rig-bridge TNC have just a timestamp, so the maths produced NaN. A shared helper now derives minutes-since-heard from the timestamp and only falls back to the server value when there is no timestamp. The Dockable APRS panel uses it too, so its ages now tick live between polls instead of freezing at fetch time. Reported by @mbrun-plm (#1180).',
+      },
+      {
+        icon: '📋',
+        title: 'FIX: EmComm Event Log Comes Back After Clear',
+        desc: "Clearing the Event Log left it empty until a page refresh. The log records activity by diffing each feed against what it had already seen, and Clear wiped the stored events but not those snapshots — so only a brand-new station or alert could ever log again. Clear now resets the baselines and re-runs the recording pass immediately: the current stations, alerts, roster, shelter and field reports, and this session's received messages re-log right away, the same result a refresh gave you, minus the reload, so the map keeps its hours of RF-heard beacons. Reported by @mbrun-plm (#1181).",
+      },
+      {
+        icon: '🐳',
+        title: 'FIX: Self-Hosted Fonts on Alpine Docker Builds',
+        desc: 'The vendor-download script extracted Google Fonts URLs with a Perl-regex grep flag that Alpine\'s BusyBox grep does not have, so container builds silently downloaded zero font files and the "self-hosted" image quietly fell back to Google\'s CDN. It now uses a POSIX extended regex that works on Alpine, Debian, and macOS alike. Thanks @9M2PJU (#1179).',
+      },
+    ],
+  },
+  {
     version: '26.7.2',
     date: '2026-09-03',
     heading:

--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -29,6 +29,7 @@ import { GLOBE_OVERLAY_LAYER_IDS } from '../utils/globeOverlays.js';
 import { countryColor, fetchCountriesGeojson } from '../utils/countriesBasemap.js';
 import PluginLayer from './PluginLayer.jsx';
 import AzimuthalMap from './AzimuthalMap.jsx';
+import { MAP_FOCUS_EVENT, MAP_FOCUS_PULSE_MS, nearestWrappedLon, isInView } from '../utils/mapFocus.js';
 // three.js is ~600 kB — load it only when the operator actually opens 3D mode.
 // React 18 permanently caches a rejected lazy() import, so a single failed
 // chunk load (stale HTML right after a redeploy is the classic case) would
@@ -1158,6 +1159,69 @@ export const WorldMap = ({
     map.on('click', handleMapClick);
     return () => map.off('click', handleMapClick);
   }, [leafletReady]);
+
+  // "Bring this station into view" requests from panel rows (#1182). Pans only
+  // when the target is off-screen (or the request is forced), then drops a
+  // self-removing pulse ring so the eye finds the target in a busy view.
+  // The Leaflet map is hidden under the azimuthal / 3D projections, so those
+  // requests are ignored until the projection has its own focus handling.
+  const focusPulseRef = useRef(null);
+  useEffect(() => {
+    if (isLeafletHidden) return;
+    const handleFocus = (e) => {
+      const map = mapInstanceRef.current;
+      const d = e.detail;
+      if (!map || !d || !Number.isFinite(d.lat) || !Number.isFinite(d.lon)) return;
+      const lon = nearestWrappedLon(map.getCenter().lng, d.lon);
+      const target = [d.lat, lon];
+      if (d.force || !isInView(map.getBounds(), d.lat, d.lon)) {
+        if (Number.isFinite(d.zoom)) map.setView(target, d.zoom, { animate: true });
+        else map.panTo(target, { animate: true });
+      }
+      const prev = focusPulseRef.current;
+      if (prev) {
+        clearTimeout(prev.timer);
+        try {
+          map.removeLayer(prev.marker);
+        } catch {
+          /* already gone */
+        }
+      }
+      const marker = L.marker(target, {
+        icon: L.divIcon({
+          className: 'map-focus-pulse',
+          html: '<span></span><span></span><span></span>',
+          iconSize: [0, 0],
+        }),
+        interactive: false,
+        keyboard: false,
+        zIndexOffset: 25000,
+      }).addTo(map);
+      const timer = setTimeout(() => {
+        try {
+          map.removeLayer(marker);
+        } catch {
+          /* map torn down */
+        }
+        if (focusPulseRef.current?.marker === marker) focusPulseRef.current = null;
+      }, MAP_FOCUS_PULSE_MS);
+      focusPulseRef.current = { marker, timer };
+    };
+    window.addEventListener(MAP_FOCUS_EVENT, handleFocus);
+    return () => {
+      window.removeEventListener(MAP_FOCUS_EVENT, handleFocus);
+      const prev = focusPulseRef.current;
+      if (prev) {
+        clearTimeout(prev.timer);
+        try {
+          mapInstanceRef.current?.removeLayer(prev.marker);
+        } catch {
+          /* map torn down */
+        }
+        focusPulseRef.current = null;
+      }
+    };
+  }, [leafletReady, isLeafletHidden]);
 
   // Update the value for how many scroll pixels count as a zoom level
   useEffect(() => {

--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -2667,6 +2667,7 @@ export const WorldMap = ({
               onDXChange={onDXChange}
               mapBandFilter={mapBandFilter}
               config={finalConfig}
+              showLabels={showDXLabels}
               map={isAzimuthal ? azimuthalMapRef.current : mapInstanceRef.current}
               satellites={satellites}
               allUnits={allUnits}

--- a/src/layouts/EmcommLayout.jsx
+++ b/src/layouts/EmcommLayout.jsx
@@ -11,6 +11,7 @@ import { esc } from '../utils/escapeHtml.js';
 import { apiFetch } from '../utils/apiFetch.js';
 import { mergeShelters } from '../utils/emcommShelters.js';
 import { winlinkModeLabel, winlinkModeColor } from '../utils/winlinkModes.js';
+import { stationAgeMinutes, formatStationAge } from '../utils/aprsStationAge.js';
 import {
   recordEvent,
   getEvents,
@@ -190,8 +191,12 @@ export default function EmcommLayout(props) {
   const [eventLog, setEventLog] = useState(() => getEvents());
   // Previous-snapshot key sets for event-log diffing (null = no snapshot yet)
   const evtPrevRef = useRef({ roster: null, alerts: null, shelters: null, stations: null, fieldReports: null });
+  // Bumped when the operator clears the log so the recording effects below
+  // re-run against a reset baseline and re-seed the current picture (#1181)
+  const [logEpoch, setLogEpoch] = useState(0);
   // High-water mark for received-APRS-message polling (only log traffic from this session on)
-  const msgSinceRef = useRef(Date.now());
+  const sessionStartRef = useRef(Date.now());
+  const msgSinceRef = useRef(sessionStartRef.current);
   const mapInstanceRef = useRef(null);
   const overlayLayersRef = useRef([]);
 
@@ -304,7 +309,7 @@ export default function EmcommLayout(props) {
     fetchMessages();
     const timer = setInterval(fetchMessages, 30000);
     return () => clearInterval(timer);
-  }, []);
+  }, [logEpoch]);
 
   const { alerts = [], shelters = [], disasters = [], loading } = emcommData || {};
   const allAprsStations = aprsData?.stations || [];
@@ -354,7 +359,7 @@ export default function EmcommLayout(props) {
       recordEvent('net_checkout', { callsign: call, summary: 'Checked out of net' });
     }
     evtPrevRef.current.roster = keys;
-  }, [netRoster]);
+  }, [netRoster, logEpoch]);
 
   // NWS alerts: new alert IDs
   useEffect(() => {
@@ -367,7 +372,7 @@ export default function EmcommLayout(props) {
       });
     }
     evtPrevRef.current.alerts = keys;
-  }, [alerts]);
+  }, [alerts, logEpoch]);
 
   // APRS shelter reports: new reports (keyed by sender + report timestamp)
   useEffect(() => {
@@ -386,7 +391,7 @@ export default function EmcommLayout(props) {
       });
     }
     evtPrevRef.current.shelters = keys;
-  }, [aprsShelterReports]);
+  }, [aprsShelterReports, logEpoch]);
 
   // EmComm APRS stations: first-heard (once per station per log lifetime)
   useEffect(() => {
@@ -399,7 +404,7 @@ export default function EmcommLayout(props) {
       });
     }
     evtPrevRef.current.stations = keys;
-  }, [emcommStations]);
+  }, [emcommStations, logEpoch]);
 
   // Field reports: new report IDs (row hashes from the CSV ingest)
   useEffect(() => {
@@ -414,7 +419,7 @@ export default function EmcommLayout(props) {
       });
     }
     evtPrevRef.current.fieldReports = keys;
-  }, [fieldReports]);
+  }, [fieldReports, logEpoch]);
 
   // Calculate distance from DE for shelters
   const sheltersWithDistance = useMemo(() => {
@@ -766,9 +771,23 @@ export default function EmcommLayout(props) {
   }, [config.callsign, config.location]);
 
   const clearEventLog = useCallback(() => {
-    if (window.confirm('Clear the entire EmComm event log? This cannot be undone.')) {
-      clearEvents();
-    }
+    if (!window.confirm('Clear the entire EmComm event log? This cannot be undone.')) return;
+    clearEvents();
+    // Clearing wiped the stored events but the diff snapshots above still
+    // remembered everything already on the board, so nothing re-logged until
+    // a brand-new station/alert appeared — the log looked dead until a page
+    // refresh (#1181). Reset the baselines to *empty* (not null) so the next
+    // effect pass treats the current picture as freshly heard, exactly like a
+    // reload does, without throwing away the map's RF history.
+    evtPrevRef.current = {
+      roster: new Set(),
+      alerts: new Set(),
+      shelters: new Set(),
+      stations: new Set(),
+      fieldReports: new Set(),
+    };
+    msgSinceRef.current = sessionStartRef.current;
+    setLogEpoch((n) => n + 1);
   }, []);
 
   // Time until expiry helper
@@ -1108,7 +1127,9 @@ export default function EmcommLayout(props) {
               <EmptyState text="No emergency APRS stations heard" />
             ) : (
               emcommStationsWithDistance.map((s) => {
-                const ageStr = s.age < 1 ? 'now' : s.age < 60 ? `${s.age}m ago` : `${Math.floor(s.age / 60)}h ago`;
+                // RF stations from the rig-bridge stream carry only a timestamp, no
+                // precomputed age — reading s.age directly rendered "NaNh ago" (#1180)
+                const ageStr = formatStationAge(stationAgeMinutes(s), { suffix: ' ago' });
                 const hasTokens = s.tokens && s.tokens.length > 0;
                 return (
                   <div

--- a/src/layouts/EmcommLayout.jsx
+++ b/src/layouts/EmcommLayout.jsx
@@ -12,6 +12,7 @@ import { apiFetch } from '../utils/apiFetch.js';
 import { mergeShelters } from '../utils/emcommShelters.js';
 import { winlinkModeLabel, winlinkModeColor } from '../utils/winlinkModes.js';
 import { stationAgeMinutes, formatStationAge } from '../utils/aprsStationAge.js';
+import { requestMapFocus } from '../utils/mapFocus.js';
 import {
   recordEvent,
   getEvents,
@@ -713,11 +714,12 @@ export default function EmcommLayout(props) {
   }, [config.location, alerts, mergedShelters, emcommStationsWithDistance, winlinkGateways, fieldReports]);
 
   // Click shelter to pan map
-  const panToShelter = useCallback((shelter) => {
-    const map = mapInstanceRef.current;
-    if (map && shelter.lat && shelter.lon) {
-      map.setView([shelter.lat, shelter.lon], 10, { animate: true });
-    }
+  // Bring a panel row's target (shelter, station, gateway, roster op, field
+  // report) into view: always pans, zooms to 10, pulses the target (#1182).
+  // Rows without a position (roster ops never heard on APRS) are a no-op.
+  const panToTarget = useCallback((item) => {
+    if (item?.lat == null || item?.lon == null) return;
+    requestMapFocus({ lat: item.lat, lon: item.lon, zoom: 10, force: true });
   }, []);
 
   // Send an APRS message to the current target (shared by Enter key + button)
@@ -1032,7 +1034,7 @@ export default function EmcommLayout(props) {
                       borderRadius: '3px',
                       borderLeft: isAprs ? '2px solid #22c55e' : '2px solid transparent',
                     }}
-                    onClick={() => panToShelter(s)}
+                    onClick={() => panToTarget(s)}
                     onMouseEnter={(e) => (e.currentTarget.style.background = '#1a1a1a')}
                     onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
                   >
@@ -1134,6 +1136,8 @@ export default function EmcommLayout(props) {
                 return (
                   <div
                     key={s.call}
+                    onClick={() => panToTarget(s)}
+                    title="Show on map"
                     style={{
                       padding: hasTokens ? '6px 8px' : '4px 8px',
                       fontSize: '11px',
@@ -1141,7 +1145,10 @@ export default function EmcommLayout(props) {
                       borderLeft: hasTokens ? '2px solid #22d3ee' : 'none',
                       background: hasTokens ? '#0d1117' : 'transparent',
                       borderRadius: hasTokens ? '4px' : '0',
+                      cursor: 'pointer',
                     }}
+                    onMouseEnter={(e) => (e.currentTarget.style.background = '#1a1f2e')}
+                    onMouseLeave={(e) => (e.currentTarget.style.background = hasTokens ? '#0d1117' : 'transparent')}
                   >
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                       <div>
@@ -1201,6 +1208,8 @@ export default function EmcommLayout(props) {
                 return (
                   <div
                     key={gw.callsign}
+                    onClick={() => panToTarget(gw)}
+                    title="Show on map"
                     style={{
                       padding: '5px 8px',
                       fontSize: '11px',
@@ -1208,7 +1217,10 @@ export default function EmcommLayout(props) {
                       borderLeft: gw.hasEmcomm ? '2px solid #ef4444' : '2px solid #3b82f6',
                       background: '#0d1117',
                       borderRadius: '4px',
+                      cursor: 'pointer',
                     }}
+                    onMouseEnter={(e) => (e.currentTarget.style.background = '#1a1f2e')}
+                    onMouseLeave={(e) => (e.currentTarget.style.background = '#0d1117')}
                   >
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                       <div>
@@ -1276,7 +1288,7 @@ export default function EmcommLayout(props) {
                     borderRadius: '4px',
                     cursor: r.lat != null && r.lon != null ? 'pointer' : 'default',
                   }}
-                  onClick={() => panToShelter(r)}
+                  onClick={() => panToTarget(r)}
                 >
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                     <div style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
@@ -1309,9 +1321,12 @@ export default function EmcommLayout(props) {
             ) : (
               netRoster.map((op) => {
                 const ageStr = op.age < 1 ? 'now' : op.age < 60 ? `${op.age}m` : `${Math.floor(op.age / 60)}h`;
+                const hasPos = op.lat != null && op.lon != null;
                 return (
                   <div
                     key={op.call}
+                    onClick={hasPos ? () => panToTarget(op) : undefined}
+                    title={hasPos ? 'Show on map' : 'No APRS position heard for this station'}
                     style={{
                       padding: '5px 8px',
                       fontSize: '11px',
@@ -1319,7 +1334,10 @@ export default function EmcommLayout(props) {
                       background: '#0d1117',
                       borderRadius: '4px',
                       marginBottom: '3px',
+                      cursor: hasPos ? 'pointer' : 'default',
                     }}
+                    onMouseEnter={hasPos ? (e) => (e.currentTarget.style.background = '#1a1f2e') : undefined}
+                    onMouseLeave={hasPos ? (e) => (e.currentTarget.style.background = '#0d1117') : undefined}
                   >
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                       <div>
@@ -1329,7 +1347,10 @@ export default function EmcommLayout(props) {
                       <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
                         <span style={{ color: '#888', fontSize: '10px' }}>{ageStr}</span>
                         <button
-                          onClick={() => setMessageTarget(op.call)}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setMessageTarget(op.call);
+                          }}
                           style={{
                             background: 'none',
                             border: '1px solid #333',

--- a/src/plugins/layers/callLabel.js
+++ b/src/plugins/layers/callLabel.js
@@ -1,0 +1,27 @@
+/**
+ * callLabel — the callsign pill drawn next to a plotted station.
+ *
+ * Same visual language as the DX Cluster spot labels in WorldMap (mono
+ * font, coloured pill, dark border), so a QSO layer's contacts read like the
+ * spot pills a user already knows — just in the layer's own colour. Anchored
+ * to the upper-right of the dot so it never covers the marker itself.
+ */
+import { esc } from '../../utils/escapeHtml.js';
+
+/**
+ * Build a non-interactive Leaflet marker carrying a callsign pill.
+ * @param {object} L        Leaflet global
+ * @param {[number, number]} latlng
+ * @param {string} text     callsign (escaped here)
+ * @param {string} color    pill background (already sanitised by the caller)
+ * @param {{ opacity?: number, zIndexOffset?: number, textColor?: string }} [opts]
+ */
+export function makeCallLabel(L, latlng, text, color, { opacity = 1, zIndexOffset = 500, textColor = '#000' } = {}) {
+  const html =
+    `<span style="display:inline-block;background:${color};color:${textColor};padding:2px 5px;` +
+    `border-radius:3px;font-family:var(--font-mono);font-size:11px;font-weight:700;white-space:nowrap;` +
+    `border:1px solid rgba(0,0,0,0.5);box-shadow:0 1px 2px rgba(0,0,0,0.3);line-height:1.1;` +
+    `opacity:${Math.max(0, Math.min(1, opacity))};">${esc(text)}</span>`;
+  const icon = L.divIcon({ className: '', html, iconSize: [0, 0], iconAnchor: [-8, 8] });
+  return L.marker(latlng, { icon, interactive: false, keyboard: false, zIndexOffset });
+}

--- a/src/plugins/layers/callLabel.test.js
+++ b/src/plugins/layers/callLabel.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makeCallLabel } from './callLabel.js';
+
+// Minimal Leaflet stand-in: records what the helper asked for.
+function fakeL() {
+  const calls = { divIcon: [], marker: [] };
+  return {
+    calls,
+    divIcon: vi.fn((o) => (calls.divIcon.push(o), { __icon: o })),
+    marker: vi.fn((latlng, o) => (calls.marker.push({ latlng, o }), { latlng, options: o })),
+  };
+}
+
+describe('makeCallLabel', () => {
+  it('builds a non-interactive marker with an escaped callsign pill in the layer colour', () => {
+    const L = fakeL();
+    const m = makeCallLabel(L, [10, 20], 'VK4ACZ', '#00ccff', { opacity: 0.9 });
+    expect(m.latlng).toEqual([10, 20]);
+    expect(m.options.interactive).toBe(false);
+    const icon = L.calls.divIcon[0];
+    expect(icon.html).toContain('VK4ACZ');
+    expect(icon.html).toContain('background:#00ccff');
+    expect(icon.html).toContain('opacity:0.9');
+    // anchored off the dot so it never covers the marker
+    expect(icon.iconAnchor).toEqual([-8, 8]);
+  });
+
+  it('escapes markup in the callsign text', () => {
+    const L = fakeL();
+    makeCallLabel(L, [0, 0], '<img src=x onerror=alert(1)>', '#fff');
+    const html = L.calls.divIcon[0].html;
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;img');
+  });
+
+  it('clamps opacity into 0..1', () => {
+    const L = fakeL();
+    makeCallLabel(L, [0, 0], 'X', '#fff', { opacity: 4 });
+    expect(L.calls.divIcon[0].html).toContain('opacity:1;');
+  });
+});

--- a/src/plugins/layers/useN3FJPLoggedQSOs.js
+++ b/src/plugins/layers/useN3FJPLoggedQSOs.js
@@ -3,6 +3,7 @@ import { esc } from '../../utils/escapeHtml.js';
 import { addMinimizeToggle } from './addMinimizeToggle.js';
 import { makeDraggable } from './makeDraggable.js';
 import { getGreatCirclePoints, replicatePath, maidenheadToLatLon } from '../../utils/geo.js';
+import { makeCallLabel } from './callLabel.js';
 
 export const metadata = {
   id: 'n3fjp_logged_qsos',
@@ -26,7 +27,7 @@ const STORAGE_PREVIEW_COLOR_KEY = 'n3fjp_preview_line_color';
 // Sanitize CSS color values from localStorage to prevent innerHTML injection
 const sanitizeColor = (c, fallback = '#3388ff') => (/^(#[0-9a-f]{3,8}|[a-z]{3,20})$/i.test(c) ? c : fallback);
 
-export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
+export function useLayer({ enabled = false, opacity = 0.9, map = null, showLabels = true }) {
   const [layersRef, setLayersRef] = useState([]);
   const [qsos, setQsos] = useState([]);
   const [retentionMinutes, setRetentionMinutes] = useState(15);
@@ -346,6 +347,12 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
 
       newLayers.push(dxMarker);
 
+      // Callsign pill beside the dot, following the map's global Calls toggle.
+      // Previews get a "?" suffix so a half-typed call reads as tentative.
+      if (showLabels) {
+        newLayers.push(makeCallLabel(L, [lat, lon], isPreview ? `${dxCall}?` : dxCall, color, { opacity }).addTo(map));
+      }
+
       // If this was the popup that was open before redraw, re-open it now
       if (!suppressReopenRef.current && openDxCall && dxCall === openDxCall) {
         setTimeout(() => {
@@ -384,7 +391,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
         } catch {}
       });
     };
-  }, [enabled, qsos, map, opacity, retentionMinutes, displayMinutes, lineColor, previewLineColor]);
+  }, [enabled, qsos, map, opacity, retentionMinutes, displayMinutes, lineColor, previewLineColor, showLabels]);
 
   return {
     qsoCount: qsos.length,

--- a/src/plugins/layers/useQsoApiLayer.js
+++ b/src/plugins/layers/useQsoApiLayer.js
@@ -7,11 +7,13 @@
 import { useEffect, useState } from 'react';
 import { esc } from '../../utils/escapeHtml.js';
 import { getGreatCirclePoints, replicatePath, maidenheadToLatLon } from '../../utils/geo.js';
+import { makeCallLabel } from './callLabel.js';
 
 export const metadata = {
   id: 'qso-api',
   name: 'Logged QSOs (API)',
-  description: 'QSOs pushed by any external logger through the open REST API (POST /api/qso-layer).',
+  description:
+    "QSOs pushed by any external logger through the open REST API (POST /api/qso-layer). Callsign labels follow the map's Calls toggle.",
   icon: '📖',
   category: 'amateur',
   localOnly: true,
@@ -48,7 +50,7 @@ function readStationPosition() {
   return null;
 }
 
-export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
+export function useLayer({ enabled = false, opacity = 0.9, map = null, showLabels = true }) {
   const [qsos, setQsos] = useState([]);
   const [retentionMinutes, setRetentionMinutes] = useState(1440);
 
@@ -117,6 +119,12 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
       );
       layers.push(marker);
 
+      // Callsign pill beside the dot (a dot alone says nothing about who was
+      // worked). Honours the map's global Calls toggle like DX spot labels do.
+      if (showLabels) {
+        layers.push(makeCallLabel(L, [q.lat, q.lon], call, color, { opacity }).addTo(map));
+      }
+
       // Great-circle path from DE to the worked station
       if (station) {
         const arcPoints = getGreatCirclePoints(station.lat, station.lon, q.lat, q.lon, 64);
@@ -148,7 +156,7 @@ export function useLayer({ enabled = false, opacity = 0.9, map = null }) {
         }
       });
     };
-  }, [enabled, qsos, map, opacity, retentionMinutes]);
+  }, [enabled, qsos, map, opacity, retentionMinutes, showLabels]);
 
   return {
     qsoCount: qsos.length,

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -494,6 +494,42 @@ body::before {
   height: 32px;
 }
 
+/* Click-to-locate pulse (#1182): three rings expand from the target a panel
+   row asked the map to show, then the marker removes itself. */
+.map-focus-pulse {
+  pointer-events: none;
+}
+.map-focus-pulse span {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 44px;
+  height: 44px;
+  margin: -22px 0 0 -22px;
+  border-radius: 50%;
+  border: 2px solid var(--accent-cyan);
+  box-shadow: 0 0 8px var(--accent-cyan);
+  opacity: 0;
+  transform: scale(0.2);
+  animation: map-focus-ring 1.3s ease-out 2;
+}
+.map-focus-pulse span:nth-child(2) {
+  animation-delay: 0.3s;
+}
+.map-focus-pulse span:nth-child(3) {
+  animation-delay: 0.6s;
+}
+@keyframes map-focus-ring {
+  0% {
+    opacity: 0.95;
+    transform: scale(0.2);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.6);
+  }
+}
+
 .sun-marker-icon,
 .moon-marker-icon {
   background: none !important;

--- a/src/utils/aprsStationAge.js
+++ b/src/utils/aprsStationAge.js
@@ -1,0 +1,39 @@
+/**
+ * aprsStationAge — one place to turn an APRS station record into a
+ * human-readable "heard N minutes ago".
+ *
+ * Stations reach the UI from two sources with different shapes:
+ *  - /api/aprs/stations (APRS-IS + server-side TNC cache) carries both a
+ *    packet `timestamp` and a precomputed `age` (minutes, frozen at fetch time)
+ *  - the rig-bridge SSE stream (direct local TNC) carries only `timestamp`
+ *
+ * Deriving from `timestamp` whenever it is present keeps the value live
+ * between polls and works for both shapes; `age` is the fallback (#1180).
+ */
+
+/**
+ * Minutes since the station was last heard, or null when unknown.
+ * @param {object} station
+ * @param {number} [now] epoch ms (injectable for tests)
+ */
+export function stationAgeMinutes(station, now = Date.now()) {
+  if (!station) return null;
+  const ts = Number(station.timestamp);
+  if (Number.isFinite(ts) && ts > 0) return Math.max(0, Math.floor((now - ts) / 60000));
+  const age = Number(station.age);
+  if (Number.isFinite(age)) return Math.max(0, Math.floor(age));
+  return null;
+}
+
+/**
+ * Format an age in minutes: "now" / "12m" / "3h". Unknown → "?".
+ * @param {number|null} minutes
+ * @param {{ suffix?: string }} [opts] suffix appended to the m/h forms only
+ *   (e.g. ' ago' → "12m ago"; "now" never takes the suffix)
+ */
+export function formatStationAge(minutes, { suffix = '' } = {}) {
+  if (minutes == null || !Number.isFinite(minutes)) return '?';
+  if (minutes < 1) return 'now';
+  const base = minutes < 60 ? `${minutes}m` : `${Math.floor(minutes / 60)}h`;
+  return `${base}${suffix}`;
+}

--- a/src/utils/aprsStationAge.test.js
+++ b/src/utils/aprsStationAge.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { stationAgeMinutes, formatStationAge } from './aprsStationAge.js';
+
+const NOW = 1_800_000_000_000;
+
+describe('stationAgeMinutes', () => {
+  it('derives age from timestamp when present (rig-bridge RF stations have no age field)', () => {
+    expect(stationAgeMinutes({ timestamp: NOW - 5 * 60000 }, NOW)).toBe(5);
+    expect(stationAgeMinutes({ timestamp: NOW - 90 * 60000 }, NOW)).toBe(90);
+    expect(stationAgeMinutes({ timestamp: NOW - 30000 }, NOW)).toBe(0);
+  });
+
+  it('prefers a live timestamp over a frozen server age', () => {
+    expect(stationAgeMinutes({ timestamp: NOW - 10 * 60000, age: 2 }, NOW)).toBe(10);
+  });
+
+  it('falls back to the server-computed age when there is no timestamp', () => {
+    expect(stationAgeMinutes({ age: 7 }, NOW)).toBe(7);
+    expect(stationAgeMinutes({ age: '7' }, NOW)).toBe(7);
+  });
+
+  it('never goes negative on clock skew', () => {
+    expect(stationAgeMinutes({ timestamp: NOW + 60000 }, NOW)).toBe(0);
+    expect(stationAgeMinutes({ age: -3 }, NOW)).toBe(0);
+  });
+
+  it('returns null when neither field is usable', () => {
+    expect(stationAgeMinutes({}, NOW)).toBeNull();
+    expect(stationAgeMinutes({ timestamp: 'bogus', age: undefined }, NOW)).toBeNull();
+    expect(stationAgeMinutes(null, NOW)).toBeNull();
+  });
+});
+
+describe('formatStationAge', () => {
+  it('formats now / minutes / hours', () => {
+    expect(formatStationAge(0)).toBe('now');
+    expect(formatStationAge(12)).toBe('12m');
+    expect(formatStationAge(59)).toBe('59m');
+    expect(formatStationAge(60)).toBe('1h');
+    expect(formatStationAge(150)).toBe('2h');
+  });
+
+  it('applies the suffix to m/h forms but not to "now"', () => {
+    expect(formatStationAge(0, { suffix: ' ago' })).toBe('now');
+    expect(formatStationAge(12, { suffix: ' ago' })).toBe('12m ago');
+    expect(formatStationAge(120, { suffix: ' ago' })).toBe('2h ago');
+  });
+
+  it('never renders NaN for unknown ages (#1180)', () => {
+    expect(formatStationAge(null, { suffix: ' ago' })).toBe('?');
+    expect(formatStationAge(undefined)).toBe('?');
+    expect(formatStationAge(NaN)).toBe('?');
+  });
+});

--- a/src/utils/emcommEventLog.test.js
+++ b/src/utils/emcommEventLog.test.js
@@ -161,6 +161,13 @@ describe('diffAdded', () => {
     expect(keys.has('b')).toBe(true);
   });
 
+  it('treats an empty (non-null) baseline as "everything is new" — the re-seed after Clear (#1181)', () => {
+    const { added, removed, keys } = diffAdded(new Set(), [{ id: 'a' }, { id: 'b' }], (x) => x.id);
+    expect(added.map((x) => x.id)).toEqual(['a', 'b']);
+    expect(removed).toEqual([]);
+    expect([...keys]).toEqual(['a', 'b']);
+  });
+
   it('ignores items whose key is null', () => {
     const { added, keys } = diffAdded(new Set(), [{ id: null }, { id: 'x' }], (x) => x.id);
     expect(added).toEqual([{ id: 'x' }]);

--- a/src/utils/mapFocus.js
+++ b/src/utils/mapFocus.js
@@ -1,0 +1,68 @@
+/**
+ * mapFocus — "bring this station into view" request bus (#1182).
+ *
+ * Any panel can ask the map to show a coordinate without holding a map
+ * reference: it dispatches a window event and whichever WorldMap instance is
+ * mounted answers by panning (only when the target is off-screen, unless
+ * forced) and dropping a short pulse ring on the target so the eye finds it
+ * in a busy view.
+ */
+
+export const MAP_FOCUS_EVENT = 'ohc-map-focus';
+
+/** Lifetime of the pulse marker, ms. Matches the CSS animation (2 × 1.3s). */
+export const MAP_FOCUS_PULSE_MS = 2600;
+
+/**
+ * Ask the map to bring a coordinate into view.
+ * @param {object} req
+ * @param {number} req.lat
+ * @param {number} req.lon
+ * @param {number} [req.zoom]  zoom level to jump to when panning (default: keep current)
+ * @param {boolean} [req.force] pan even if the target is already on screen
+ * @returns {boolean} false when the request was dropped (bad coords / no window)
+ */
+export function requestMapFocus({ lat, lon, zoom, force = false } = {}) {
+  if (typeof window === 'undefined') return false;
+  // Number(null) is 0 — a roster entry never heard on APRS must not send the
+  // map to 0°,0°. Reject empty values before coercing numeric strings.
+  if (lat == null || lon == null || lat === '' || lon === '') return false;
+  const la = Number(lat);
+  const lo = Number(lon);
+  if (!Number.isFinite(la) || !Number.isFinite(lo)) return false;
+  const detail = { lat: la, lon: lo, force: !!force };
+  if (Number.isFinite(zoom)) detail.zoom = zoom;
+  window.dispatchEvent(new CustomEvent(MAP_FOCUS_EVENT, { detail }));
+  return true;
+}
+
+/**
+ * Longitude of `lon` in the world copy nearest to `centerLon`. Leaflet maps
+ * here wrap horizontally, so a station at 170°E is best reached at −190° when
+ * the view is centred on Alaska — panning "the short way" instead of dragging
+ * the whole world past.
+ */
+export function nearestWrappedLon(centerLon, lon) {
+  let best = lon;
+  let bestDist = Math.abs(lon - centerLon);
+  for (const cand of [lon - 360, lon + 360]) {
+    const d = Math.abs(cand - centerLon);
+    if (d < bestDist) {
+      best = cand;
+      bestDist = d;
+    }
+  }
+  return best;
+}
+
+/**
+ * Is the coordinate visible inside `bounds` in any world copy?
+ * @param {{ contains: Function }} bounds  Leaflet LatLngBounds (or anything with contains([lat, lon]))
+ */
+export function isInView(bounds, lat, lon) {
+  if (!bounds || typeof bounds.contains !== 'function') return false;
+  for (const lo of [lon, lon - 360, lon + 360]) {
+    if (bounds.contains([lat, lo])) return true;
+  }
+  return false;
+}

--- a/src/utils/mapFocus.test.js
+++ b/src/utils/mapFocus.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { requestMapFocus, nearestWrappedLon, isInView, MAP_FOCUS_EVENT } from './mapFocus.js';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('requestMapFocus', () => {
+  it('dispatches a window event carrying normalised coordinates', () => {
+    const spy = vi.spyOn(window, 'dispatchEvent');
+    expect(requestMapFocus({ lat: '41.5', lon: -81.2, zoom: 10, force: true })).toBe(true);
+    const ev = spy.mock.calls[0][0];
+    expect(ev.type).toBe(MAP_FOCUS_EVENT);
+    expect(ev.detail).toEqual({ lat: 41.5, lon: -81.2, zoom: 10, force: true });
+  });
+
+  it('omits zoom when not given and defaults force to false', () => {
+    const spy = vi.spyOn(window, 'dispatchEvent');
+    requestMapFocus({ lat: 1, lon: 2 });
+    expect(spy.mock.calls[0][0].detail).toEqual({ lat: 1, lon: 2, force: false });
+  });
+
+  it('drops requests without usable coordinates (roster entries never heard on APRS)', () => {
+    const spy = vi.spyOn(window, 'dispatchEvent');
+    expect(requestMapFocus({ lat: null, lon: null })).toBe(false);
+    expect(requestMapFocus({})).toBe(false);
+    expect(requestMapFocus({ lat: 'x', lon: 5 })).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('nearestWrappedLon', () => {
+  it('keeps the longitude when it is already the closest copy', () => {
+    expect(nearestWrappedLon(-80, -85)).toBe(-85);
+  });
+  it('picks the wrapped copy across the antimeridian', () => {
+    expect(nearestWrappedLon(-150, 170)).toBe(-190);
+    expect(nearestWrappedLon(150, -170)).toBe(190);
+  });
+});
+
+describe('isInView', () => {
+  const bounds = (w, e) => ({ contains: ([, lo]) => lo >= w && lo <= e });
+  it('is true when the point is inside the bounds', () => {
+    expect(isInView(bounds(-100, -60), 40, -80)).toBe(true);
+  });
+  it('is true when a wrapped world copy of the point is inside', () => {
+    expect(isInView(bounds(-200, -160), 60, 170)).toBe(true);
+  });
+  it('is false when no copy is visible, or without bounds', () => {
+    expect(isInView(bounds(-100, -60), 40, 10)).toBe(false);
+    expect(isInView(null, 40, 10)).toBe(false);
+  });
+});


### PR DESCRIPTION
Third hotfix of the cycle — two more EmComm fixes from KE8PLM plus a feature request of his that every layout benefits from, a QSO-layer request from Facebook, and a Docker font fix from 9M2PJU.

- 🎯 **#1182** — click any panel row (EmComm Stations / Winlink / Net Roster, and every Dockable spot panel incl. APRS) to bring the station into view; pans only when off-screen, drops a pulse ring on the target (issue closed)
- 🏷️ **Callsign labels on Logged QSOs (API) and (N3FJP)** — same pill style as DX spots, layer/per-QSO colour, follows the map's Show/Hide Calls toggle (Alan McDonald, Facebook)
- ⏱️ **#1180** — EmComm Stations "NaNh ago" for RF-heard stations; shared `aprsStationAge` helper also makes Dockable APRS ages tick live (issue closed)
- 📋 **#1181** — EmComm Event Log stayed empty after Clear until a refresh; Clear now re-seeds the current picture without a reload (issue closed)
- 🐳 **#1179** — `vendor-download.sh` `grep -oP` → `-oE` so Alpine/BusyBox Docker builds actually download the self-hosted fonts (9M2PJU, merged)

WhatsNew 26.7.3 entry (five items) + version bump included. Suite 1535 green, build clean, focus/label behaviour verified headless in both layouts.

Merge with **Create a merge commit** (true merge, per the release model), then tag `v26.7.3` on main and publish the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJnt1EH6i8U5FzL74z5aVY