### PR TITLE
v26.7.4 — hotfix release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openhamclock",
-  "version": "26.7.3",
+  "version": "26.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openhamclock",
-      "version": "26.7.3",
+      "version": "26.7.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhamclock",
-  "version": "26.7.3",
+  "version": "26.7.4",
   "description": "Amateur Radio Dashboard - A modern web-based HamClock alternative",
   "main": "electron/main.js",
   "scripts": {

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -700,7 +700,11 @@ export const SettingsPanel = ({
       sceneRotation,
       // units,
       allUnits: { dist: distUnits, temp: tempUnits, press: pressUnits },
-      propagation: { mode: propMode, power: parseFloat(propPower) || 100 },
+      // Spread the existing propagation block: this panel only edits mode and
+      // power, and replacing the object wholesale silently dropped the antenna
+      // chosen in the Propagation panel — it came back as the default on the
+      // next load (N3DD report).
+      propagation: { ...config.propagation, mode: propMode, power: parseFloat(propPower) || 100 },
       licenseClass,
       wsjtxRelayMulticast: { enabled: wsjtxMulticastEnabled, address: wsjtxMulticastAddress },
       rigControl: {

--- a/src/components/WhatsNew.jsx
+++ b/src/components/WhatsNew.jsx
@@ -29,6 +29,18 @@ const ANNOUNCEMENT = {
 
 const CHANGELOG = [
   {
+    version: '26.7.4',
+    date: '2026-09-12',
+    heading: 'One-fix hotfix: the VOACAP antenna you pick now stays picked. Thanks to N3DD for the report.',
+    features: [
+      {
+        icon: '📡',
+        title: 'FIX: VOACAP Antenna Choice No Longer Reverts to Isotropic',
+        desc: "Choose an antenna in the Propagation panel, save anything in Settings later, refresh — and the antenna was back to Isotropic. The Settings save rebuilt the propagation block from only the two fields it edits (mode and power) and silently dropped the antenna, so the next load filled the gap with the default. It now keeps the existing block and overrides just mode and power. As a belt-and-braces measure for self-hosted installs with settings sync, any change still waiting in the 2-second sync debounce is now pushed on page unload, so a refresh straight after a change can no longer let the server's older copy win. If you already lost your antenna this way you will see Isotropic once more after updating; pick it again and it sticks. Reported by N3DD.",
+      },
+    ],
+  },
+  {
     version: '26.7.3',
     date: '2026-09-10',
     heading:

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -301,6 +301,9 @@ const collectSyncSettings = () => {
  * localStorage (N3DD: antenna type reverting on refresh).
  * @returns {boolean} true when a beacon was queued
  */
+/** True while a debounced server sync is armed and not yet sent. */
+export const hasPendingSettingsSync = () => _syncTimeout != null;
+
 export const flushSettingsSync = () => {
   if (!_syncTimeout) return false;
   clearTimeout(_syncTimeout);
@@ -516,6 +519,7 @@ export default {
   fetchServerSettings,
   syncAllSettingsToServer,
   flushSettingsSync,
+  hasPendingSettingsSync,
   loadConfig,
   saveConfig,
   isConfigIncomplete,

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -273,27 +273,56 @@ export const fetchServerSettings = async () => {
  * No-op if settings sync is not enabled (interceptor not installed).
  */
 let _syncTimeout = null;
+
+/** Gather every synced localStorage key into one settings object. */
+const collectSyncSettings = () => {
+  const settings = {};
+  for (const key of SYNC_KEYS) {
+    const val = localStorage.getItem(key);
+    if (val !== null) settings[key] = val;
+  }
+  // Also capture any openhamclock_*/ohc_* keys not in the static list
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && (key.startsWith('openhamclock_') || key.startsWith('ohc_')) && !settings[key]) {
+      // Skip profiles (too large, browser-specific)
+      if (key === 'openhamclock_profiles' || key === 'openhamclock_activeProfile') continue;
+      settings[key] = localStorage.getItem(key);
+    }
+  }
+  return settings;
+};
+
+/**
+ * If a debounced sync is still pending when the page goes away, push it now
+ * with sendBeacon (survives unload). Without this, changing a setting and
+ * refreshing within the 2 s debounce lost the change: the server copy was
+ * stale, and on reload "server wins" wrote the old value back over
+ * localStorage (N3DD: antenna type reverting on refresh).
+ * @returns {boolean} true when a beacon was queued
+ */
+export const flushSettingsSync = () => {
+  if (!_syncTimeout) return false;
+  clearTimeout(_syncTimeout);
+  _syncTimeout = null;
+  try {
+    if (typeof navigator === 'undefined' || typeof navigator.sendBeacon !== 'function') return false;
+    const body = new Blob([JSON.stringify(collectSyncSettings())], { type: 'application/json' });
+    return navigator.sendBeacon('/api/settings', body);
+  } catch {
+    return false;
+  }
+};
+
 export const syncAllSettingsToServer = () => {
   if (!_interceptorInstalled) return; // Sync not enabled — no-op
 
   // Debounce: wait 2s after last change before pushing
   if (_syncTimeout) clearTimeout(_syncTimeout);
   _syncTimeout = setTimeout(async () => {
+    _syncTimeout = null;
     try {
-      const settings = {};
-      for (const key of SYNC_KEYS) {
-        const val = localStorage.getItem(key);
-        if (val !== null) settings[key] = val;
-      }
-      // Also capture any openhamclock_*/ohc_* keys not in the static list
-      for (let i = 0; i < localStorage.length; i++) {
-        const key = localStorage.key(i);
-        if (key && (key.startsWith('openhamclock_') || key.startsWith('ohc_')) && !settings[key]) {
-          // Skip profiles (too large, browser-specific)
-          if (key === 'openhamclock_profiles' || key === 'openhamclock_activeProfile') continue;
-          settings[key] = localStorage.getItem(key);
-        }
-      }
+      const settings = collectSyncSettings();
 
       const response = await fetch('/api/settings', {
         method: 'POST',
@@ -329,6 +358,11 @@ export const installSettingsSyncInterceptor = () => {
       syncAllSettingsToServer();
     }
   };
+
+  // A refresh inside the debounce window must not lose the last change
+  if (typeof window !== 'undefined') {
+    window.addEventListener('pagehide', flushSettingsSync);
+  }
 };
 
 /**
@@ -481,6 +515,7 @@ export default {
   fetchServerConfig,
   fetchServerSettings,
   syncAllSettingsToServer,
+  flushSettingsSync,
   loadConfig,
   saveConfig,
   isConfigIncomplete,

--- a/src/utils/configSync.test.js
+++ b/src/utils/configSync.test.js
@@ -4,7 +4,14 @@
  *  - loadConfig must keep the antenna saved in localStorage
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { loadConfig, saveConfig, installSettingsSyncInterceptor, flushSettingsSync } from './config.js';
+import {
+  loadConfig,
+  saveConfig,
+  installSettingsSyncInterceptor,
+  flushSettingsSync,
+  hasPendingSettingsSync,
+  syncAllSettingsToServer,
+} from './config.js';
 
 describe('flushSettingsSync', () => {
   beforeEach(() => {
@@ -22,11 +29,17 @@ describe('flushSettingsSync', () => {
 
   it('pushes a pending debounced sync with sendBeacon so a quick refresh cannot lose it', async () => {
     const beacon = vi.fn(() => true);
-    Object.defineProperty(navigator, 'sendBeacon', { value: beacon, configurable: true });
+    vi.stubGlobal('navigator', { sendBeacon: beacon });
+    expect(typeof navigator.sendBeacon).toBe('function');
     installSettingsSyncInterceptor();
 
-    // A settings write arms the 2 s debounce
+    // A settings write arms the 2 s debounce (the interceptor routes
+    // localStorage.setItem here; call it directly so the test does not depend
+    // on jsdom's Storage accepting a patched setItem or on module-state
+    // isolation between test files).
     localStorage.setItem('openhamclock_config', JSON.stringify({ propagation: { antenna: 'dipole' } }));
+    syncAllSettingsToServer();
+    expect(hasPendingSettingsSync()).toBe(true);
 
     expect(flushSettingsSync()).toBe(true);
     expect(beacon).toHaveBeenCalledTimes(1);
@@ -47,7 +60,8 @@ describe('flushSettingsSync', () => {
 
   it('is a no-op when nothing is pending', () => {
     const beacon = vi.fn(() => true);
-    Object.defineProperty(navigator, 'sendBeacon', { value: beacon, configurable: true });
+    vi.stubGlobal('navigator', { sendBeacon: beacon });
+    expect(hasPendingSettingsSync()).toBe(false);
     expect(flushSettingsSync()).toBe(false);
     expect(beacon).not.toHaveBeenCalled();
   });

--- a/src/utils/configSync.test.js
+++ b/src/utils/configSync.test.js
@@ -1,0 +1,68 @@
+/**
+ * Settings persistence regressions (N3DD: VOACAP antenna reverting on refresh).
+ *  - a change made inside the 2 s server-sync debounce must survive a refresh
+ *  - loadConfig must keep the antenna saved in localStorage
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { loadConfig, saveConfig, installSettingsSyncInterceptor, flushSettingsSync } from './config.js';
+
+describe('flushSettingsSync', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ keys: 1 }) })),
+    );
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('pushes a pending debounced sync with sendBeacon so a quick refresh cannot lose it', async () => {
+    const beacon = vi.fn(() => true);
+    Object.defineProperty(navigator, 'sendBeacon', { value: beacon, configurable: true });
+    installSettingsSyncInterceptor();
+
+    // A settings write arms the 2 s debounce
+    localStorage.setItem('openhamclock_config', JSON.stringify({ propagation: { antenna: 'dipole' } }));
+
+    expect(flushSettingsSync()).toBe(true);
+    expect(beacon).toHaveBeenCalledTimes(1);
+    const [url, body] = beacon.mock.calls[0];
+    expect(url).toBe('/api/settings');
+    expect(body).toBeInstanceOf(Blob);
+    expect(body.type).toBe('application/json');
+    // jsdom's Blob cannot be read back under fake timers; a non-empty JSON
+    // body is enough — collectSyncSettings() is what fills it.
+    expect(body.size).toBeGreaterThan(20);
+
+    // The debounced fetch was cancelled — nothing fires later
+    vi.advanceTimersByTime(3000);
+    expect(fetch).not.toHaveBeenCalled();
+    // Nothing pending any more
+    expect(flushSettingsSync()).toBe(false);
+  });
+
+  it('is a no-op when nothing is pending', () => {
+    const beacon = vi.fn(() => true);
+    Object.defineProperty(navigator, 'sendBeacon', { value: beacon, configurable: true });
+    expect(flushSettingsSync()).toBe(false);
+    expect(beacon).not.toHaveBeenCalled();
+  });
+});
+
+describe('loadConfig antenna persistence', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('keeps the antenna saved in localStorage', () => {
+    saveConfig({ ...loadConfig(), propagation: { mode: 'CW', power: 50, antenna: 'vert-qw' } });
+    expect(loadConfig().propagation).toMatchObject({ mode: 'CW', power: 50, antenna: 'vert-qw' });
+  });
+
+  it('falls back to the default antenna only when the saved block has none', () => {
+    localStorage.setItem('openhamclock_config', JSON.stringify({ propagation: { mode: 'SSB', power: 100 } }));
+    expect(loadConfig().propagation.antenna).toBe('isotropic');
+  });
+});

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -12,6 +12,7 @@ export {
   fetchServerConfig,
   fetchServerSettings,
   syncAllSettingsToServer,
+  flushSettingsSync,
   installSettingsSyncInterceptor,
   isConfigIncomplete,
   MAP_STYLES,


### PR DESCRIPTION
One-fix hotfix for the VOACAP antenna setting reverting to Isotropic, reported by N3DD.

- 📡 **VOACAP antenna choice persists** — SettingsPanel's save rebuilt `propagation` from only {mode, power} and dropped `antenna`; it now spreads the existing block. Belt-and-braces for self-host settings sync: a change still inside the 2 s debounce is flushed on `pagehide` via `sendBeacon`, so a refresh right after a change can't let the server's older copy win.
- 🧪 Test hardening for the flush test that failed on CI's Node 22 jsdom (test-only; the behaviour was fine).

WhatsNew 26.7.4 entry + version bump included. Suite 1539 green, build clean.

Merge with **Create a merge commit**, then tag `v26.7.4` on main and publish the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJnt1EH6i8U5FzL74z5aVY